### PR TITLE
define STRICT_R_HEADERS, include float.h, adjust dbl eps constant

### DIFF
--- a/src/circular.cpp
+++ b/src/circular.cpp
@@ -1,3 +1,5 @@
+#define STRICT_R_HEADERS
+#include <float.h>
 #include <Rcpp.h>
 
 using namespace Rcpp;
@@ -15,7 +17,7 @@ double angle_mean(NumericVector x) {
   }
   double R = (sqrt(pow(S, 2) + pow(C, 2)) / n);
   // A vector length of zero has no angular mean
-  if (R > DOUBLE_EPS) {
+  if (R > DBL_EPSILON) {
     out = std::atan2(S, C);
   } else {
     out = NA_REAL;
@@ -45,7 +47,7 @@ double angle_median(NumericVector x) {
   // Find candidates for the median (with the minimum average deviation)
   for(int i(0); i < n; i++) {
     dev_val = angle_dev(x, x[i]);
-    if(((dev_val - minimum) / n) < -DOUBLE_EPS) {
+    if(((dev_val - minimum) / n) < -DBL_EPSILON) {
       minimum = dev_val;
       candidates[0] = x[i];
     } else if (fabs(dev_val - minimum) <= 1e-8) {


### PR DESCRIPTION
Hi Jeffrey, Hi circumplex team,

Your CRAN package circumplex uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at
  https://github.com/RcppCore/Rcpp/issues/1158
and the links therein for more context on this.

Here, I prefixed one #include <Rcpp.h> with STRICT_R_HEADERS.  One additional change that is needed is the #include <float.h> (the compiler may suggst the C++ header #include <cfloat>, that is equivalent). We now can use DBL_EPSILON in two places.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by
  https://github.com/RcppCore/Rcpp/issues/1158
to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.