### PR TITLE
M12: Result-label DRY + statistical-core coverage tracking

### DIFF
--- a/R/ssm_analysis.R
+++ b/R/ssm_analysis.R
@@ -289,6 +289,39 @@ ssm_analyze <- function(data, scales, angles = octants(),
   }
 }
 
+# Build the Label/Group/Measure identifier columns ----------------------------
+
+# Construct the Label/Group/Measure columns shared by the observed-score and
+# CI tables of both analysis paths. Extracted (M12) from four byte-identical
+# inline blocks (two per path, pre- and post-CI); the output must stay
+# identical across every branch, so the branch logic lives here unchanged.
+# `measures_labels`/`n_measures` are unused on the mean path (pass NULL).
+build_result_labels <- function(score_type, group_levels, measures_labels,
+                                 n_groups, n_measures, contrast, grouping) {
+  if (score_type == "Mean") {
+    Group <- group_levels
+    Measure <- rep(NA_character_, times = n_groups)
+    if (contrast && !is.null(grouping)) {
+      Group <- c(Group, paste0(Group[[2]], " - ", Group[[1]]))
+      Measure <- c(Measure, Measure[[1]])
+    }
+    Label <- Group
+  } else {
+    Group <- rep(group_levels, each = n_measures)
+    Measure <- rep(measures_labels, times = n_groups)
+    if (contrast && is.null(grouping)) {
+      Group <- c(Group, Group[[1]])
+      Measure <- c(Measure, paste0(Measure[[2]], " - ", Measure[[1]]))
+    } else if (contrast && !is.null(grouping)) {
+      Group <- c(Group, paste0(Group[[2]], " - ", Group[[1]]))
+      Measure <- c(Measure, Measure[[1]])
+    }
+    Label <- if (is.null(grouping)) Measure else paste0(Measure, ": ", Group)
+  }
+  data.frame(Label = Label, Group = Group, Measure = Measure,
+             stringsAsFactors = FALSE)
+}
+
 # Perform analyses using the mean-based Structural Summary Method --------------
 
 ssm_analyze_means <- function(data, scales, angles, grouping, contrast,
@@ -330,14 +363,10 @@ ssm_analyze_means <- function(data, scales, angles, grouping, contrast,
     scores <- rbind(scores, scores[2, ] - scores[1, ])
   }
   scores <- as.data.frame(scores)
-  Group <- group_levels
-  Measure <- rep(NA_character_, times = n_groups)
-  if (contrast && !is.null(grouping)) {
-    Group <- c(Group, paste0(Group[[2]], " - ", Group[[1]]))
-    Measure <- c(Measure, Measure[[1]])
-  }
-  Label <- Group
-  scores <- cbind(Label, Group, Measure, scores)
+  labels <- build_result_labels(
+    "Mean", group_levels, NULL, n_groups, NULL, contrast, grouping
+  )
+  scores <- cbind(labels, scores)
 
   # Create function that will perform bootstrapping
   bs_function <- function(.data, index, scales, angles, contrast, listwise, ...) {
@@ -367,14 +396,10 @@ ssm_analyze_means <- function(data, scales, angles, grouping, contrast,
   )
 
   params <- bs_output
-  Group <- group_levels
-  Measure <- rep(NA_character_, times = n_groups)
-  if (contrast && !is.null(grouping)) {
-    Group <- c(Group, paste0(Group[[2]], " - ", Group[[1]]))
-    Measure <- c(Measure, Measure[[1]])
-  }
-  Label <- Group
-  results <- cbind(Label, Group, Measure, params)
+  labels <- build_result_labels(
+    "Mean", group_levels, NULL, n_groups, NULL, contrast, grouping
+  )
+  results <- cbind(labels, params)
   
   # Collect analysis details (suff_stats is a pure list addition for the
   # CI-accuracy diagnostic; see ssm_compute_suff_stats() and spec sec. 8.3)
@@ -455,21 +480,11 @@ ssm_analyze_corrs <- function(data, scales, angles, measures, grouping,
     scores <- rbind(scores, scores[2, ] - scores[1, ])
   }
   scores <- as.data.frame(scores)
-  Group <- rep(group_levels, each = n_measures)
-  Measure <- rep(measures_labels, times = n_groups)
-  if (contrast && is.null(grouping)) {
-    Group <- c(Group, Group[[1]])
-    Measure <- c(Measure, paste0(Measure[[2]], " - ", Measure[[1]]))
-  } else if (contrast && !is.null(grouping)) {
-    Group <- c(Group, paste0(Group[[2]], " - ", Group[[1]]))
-    Measure <- c(Measure, Measure[[1]])
-  }
-  if (is.null(grouping)) {
-    Label <- Measure
-  } else {
-    Label <- paste0(Measure, ": ", Group)
-  }
-  scores <- cbind(Label, Group, Measure, scores)
+  labels <- build_result_labels(
+    "Correlation", group_levels, measures_labels, n_groups, n_measures,
+    contrast, grouping
+  )
+  scores <- cbind(labels, scores)
 
 
   # Create function that will perform bootstrapping
@@ -501,21 +516,11 @@ ssm_analyze_corrs <- function(data, scales, angles, measures, grouping,
     obs_scores = obs_scores
   )
   
-  Group <- rep(group_levels, each = n_measures)
-  Measure <- rep(measures_labels, times = n_groups)
-  if (contrast && is.null(grouping)) {
-    Group <- c(Group, Group[[1]])
-    Measure <- c(Measure, paste0(Measure[[2]], " - ", Measure[[1]]))
-  } else if (contrast && !is.null(grouping)) {
-    Group <- c(Group, paste0(Group[[2]], " - ", Group[[1]]))
-    Measure <- c(Measure, Measure[[1]])
-  }
-  if (is.null(grouping)) {
-    Label <- Measure
-  } else {
-    Label <- paste0(Measure, ": ", Group)
-  }
-  results <- cbind(Label, Group, Measure, bs_output)
+  labels <- build_result_labels(
+    "Correlation", group_levels, measures_labels, n_groups, n_measures,
+    contrast, grouping
+  )
+  results <- cbind(labels, bs_output)
 
 
   # Collect analysis details (suff_stats is a pure list addition for the

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | — | high | milestones/M7-v2-release-prep.md |
-| M12 | Result-label DRY + statistical-core coverage tracking | in-progress | — | normal | milestones/M12-label-dry-coverage.md |
+| M12 | Result-label DRY + statistical-core coverage tracking | review | — | normal | milestones/M12-label-dry-coverage.md |
 | M11 | Boundary-coverage hardening + test-suite tidiness | done | — | normal | milestones/archive/M11-boundary-coverage-hardening.md |
 | M8 | SEM-layer DRY single-sourcing | done | — | normal | milestones/archive/M8-sem-dry-single-sourcing.md |
 | M9 | sem_estimate() vectorization + oracle single-sourcing | done | — | normal | milestones/archive/M9-sem-estimate-vectorize.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | — | high | milestones/M7-v2-release-prep.md |
-| M12 | Result-label DRY + statistical-core coverage tracking | planned | — | normal | milestones/M12-label-dry-coverage.md |
+| M12 | Result-label DRY + statistical-core coverage tracking | in-progress | — | normal | milestones/M12-label-dry-coverage.md |
 | M11 | Boundary-coverage hardening + test-suite tidiness | done | — | normal | milestones/archive/M11-boundary-coverage-hardening.md |
 | M8 | SEM-layer DRY single-sourcing | done | — | normal | milestones/archive/M8-sem-dry-single-sourcing.md |
 | M9 | sem_estimate() vectorization + oracle single-sourcing | done | — | normal | milestones/archive/M9-sem-estimate-vectorize.md |

--- a/cairn/milestones/M12-label-dry-coverage.md
+++ b/cairn/milestones/M12-label-dry-coverage.md
@@ -3,7 +3,7 @@
      Per-section owners are tagged below. -->
 # M12: Result-label DRY + statistical-core coverage tracking
 
-- **Status:** in-progress   <!-- owner: transitioning skill · mirror-update; cairn/ROADMAP.md is the authority -->
+- **Status:** review   <!-- owner: transitioning skill · mirror-update; cairn/ROADMAP.md is the authority -->
 - **Priority:** normal   <!-- owner: plan · create/amend-via-gate; high | normal | low -->
 - **Depends on:** —   <!-- owner: plan · create/amend-via-gate; M<xx>, M<yy> or — -->
 - **Branch/PR:** m12-label-dry-coverage   <!-- owner: implement (branch) / review (PR URL) · create -->
@@ -72,12 +72,14 @@ master before the v2.0.0 freeze.
       Verify T1 + existing snapshot/print tests green.
 - [x] **T3** — Add the statistical-core component/flag to `codecov.yml`; confirm
       each path glob resolves to a real `R/` file and the config validates.
-- [ ] **T4** — Full `devtools::check()` (clean-env, not `load_all()`); confirm
+- [x] **T4** — Full `devtools::check()` (clean-env, not `load_all()`); confirm
       0/0/0.
 
 ## Work log
 <!-- owner: any skill · append-only; one line per entry; absolute dates -->
 
+- 2026-07-12: T4 — `devtools::check(args="--no-manual")` clean: 0 errors / 0
+  warnings / 0 notes (3m40s; testthat 109s OK). All tasks done → status review.
 - 2026-07-12: T3 — added a `statistical_core` codecov component (7 R estimation
   sources + `src/circular.cpp` + `src/parameters.cpp`; excludes OOP/plot/tidy/
   generated layers). YAML parses; all 9 paths resolve on disk. The "workflow

--- a/cairn/milestones/M12-label-dry-coverage.md
+++ b/cairn/milestones/M12-label-dry-coverage.md
@@ -70,7 +70,7 @@ master before the v2.0.0 freeze.
       score paths, parametrized by `score_type`/`grouping`/`contrast`; replace
       the four inline blocks at `R/ssm_analysis.R:333`, `:370`, `:458`, `:504`.
       Verify T1 + existing snapshot/print tests green.
-- [ ] **T3** — Add the statistical-core component/flag to `codecov.yml`; confirm
+- [x] **T3** — Add the statistical-core component/flag to `codecov.yml`; confirm
       each path glob resolves to a real `R/` file and the config validates.
 - [ ] **T4** — Full `devtools::check()` (clean-env, not `load_all()`); confirm
       0/0/0.
@@ -78,6 +78,10 @@ master before the v2.0.0 freeze.
 ## Work log
 <!-- owner: any skill · append-only; one line per entry; absolute dates -->
 
+- 2026-07-12: T3 — added a `statistical_core` codecov component (7 R estimation
+  sources + `src/circular.cpp` + `src/parameters.cpp`; excludes OOP/plot/tidy/
+  generated layers). YAML parses; all 9 paths resolve on disk. The "workflow
+  still succeeds" half of AC2 confirms on CI after push (test-coverage.yaml).
 - 2026-07-12: T1+T2 — extracted `build_result_labels()` in `R/ssm_analysis.R`,
   replaced all four inline Label/Group/Measure blocks; added a direct helper
   unit test covering all branches (incl. corr no-contrast+grouping and corr

--- a/cairn/milestones/M12-label-dry-coverage.md
+++ b/cairn/milestones/M12-label-dry-coverage.md
@@ -61,12 +61,12 @@ master before the v2.0.0 freeze.
 ## Tasks
 <!-- owner: plan (create) / implement (check-off, minor edits) -->
 
-- [ ] **T1** — Test-first: add a targeted test pinning the current
+- [x] **T1** — Test-first: add a targeted test pinning the current
       `Label`/`Group`/`Measure` output across the branch matrix (mean+contrast
       with grouping; corr with grouping; corr no-grouping with contrast; corr
       no-grouping no-contrast), asserted against present behavior before any
       refactor.
-- [ ] **T2** — Extract one helper (e.g. `build_result_labels()`) covering both
+- [x] **T2** — Extract one helper (e.g. `build_result_labels()`) covering both
       score paths, parametrized by `score_type`/`grouping`/`contrast`; replace
       the four inline blocks at `R/ssm_analysis.R:333`, `:370`, `:458`, `:504`.
       Verify T1 + existing snapshot/print tests green.
@@ -78,6 +78,12 @@ master before the v2.0.0 freeze.
 ## Work log
 <!-- owner: any skill · append-only; one line per entry; absolute dates -->
 
+- 2026-07-12: T1+T2 — extracted `build_result_labels()` in `R/ssm_analysis.R`,
+  replaced all four inline Label/Group/Measure blocks; added a direct helper
+  unit test covering all branches (incl. corr no-contrast+grouping and corr
+  multi-measure no-contrast, which weren't asserted end-to-end). Full
+  `devtools::test()` byte-identical green (1823 pass, 0 fail); verified result/
+  score row names + column types unchanged. The 3 suite WARNs are pre-existing.
 - 2026-07-12: created by /milestone-plan. Promoted from the "Continuous /
   infrastructure refactors" candidate row (items: Group/Measure/Label dedup +
   statistical-core coverage tracking). Decided to **land pre-freeze** (v2.0.0

--- a/cairn/milestones/M12-label-dry-coverage.md
+++ b/cairn/milestones/M12-label-dry-coverage.md
@@ -6,7 +6,7 @@
 - **Status:** review   <!-- owner: transitioning skill · mirror-update; cairn/ROADMAP.md is the authority -->
 - **Priority:** normal   <!-- owner: plan · create/amend-via-gate; high | normal | low -->
 - **Depends on:** —   <!-- owner: plan · create/amend-via-gate; M<xx>, M<yy> or — -->
-- **Branch/PR:** m12-label-dry-coverage   <!-- owner: implement (branch) / review (PR URL) · create -->
+- **Branch/PR:** m12-label-dry-coverage · https://github.com/jmgirard/circumplex/pull/36   <!-- owner: implement (branch) / review (PR URL) · create -->
 
 ## Goal
 
@@ -37,7 +37,7 @@ master before the v2.0.0 freeze.
 ## Acceptance criteria
 <!-- owner: plan · create/amend-via-gate; review reads, never reinterprets -->
 
-- [ ] **AC1** — The four inline Group/Measure/Label blocks in
+- [x] **AC1** — The four inline Group/Measure/Label blocks in
       `R/ssm_analysis.R` are replaced by calls to one helper, and
       `ssm_analyze()` `results`/`scores` are byte-identical to pre-refactor.
       Evidence: existing `ssm_analyze` snapshot/print tests stay green **under
@@ -45,11 +45,11 @@ master before the v2.0.0 freeze.
       scope-leak masking), plus a new targeted test asserting the helper's
       `Label`/`Group`/`Measure` across the branch matrix (mean+contrast+group;
       corr+group; corr+no-group+contrast; corr+no-group+no-contrast).
-- [ ] **AC2** — `codecov.yml` defines a statistical-core component/flag whose
+- [x] **AC2** — `codecov.yml` defines a statistical-core component/flag whose
       path globs all resolve to existing `R/` files (no dead globs), and the
       config is valid. Evidence: every listed path matches ≥1 real file, and
       the `test-coverage.yaml` workflow still succeeds (config parses).
-- [ ] **AC3** — `devtools::check()` clean (0 errors / 0 warnings / 0 notes).
+- [x] **AC3** — `devtools::check()` clean (0 errors / 0 warnings / 0 notes).
 
 ## Coverage
 <!-- owner: plan · create/amend-via-gate -->
@@ -106,4 +106,26 @@ master before the v2.0.0 freeze.
 <!-- owner: implement / review · append-only -->
 
 ## Review
-<!-- owner: review · exclusive -->
+
+_Reviewed 2026-07-12 (PR #36). Fresh evidence per criterion:_
+
+- **AC1 (label DRY, byte-identical)** — ✓ The four inline blocks are gone;
+  `build_result_labels()` is called at all four sites in `R/ssm_analysis.R`.
+  Fresh `devtools::test()`: **1823 pass / 0 fail**; the new helper unit test
+  asserts every branch (mean single/multi/contrast; corr single, multi-measure
+  no-contrast, measure-contrast, grouping no-contrast, group-contrast).
+  Output byte-identical — result/score row names + column types verified
+  unchanged.
+- **AC2 (statistical-core coverage component)** — ✓ `codecov.yml` parses
+  (R `yaml::read_yaml`); the `statistical_core` component lists 9 paths, all
+  resolving on disk (7 R estimation sources + `src/circular.cpp` +
+  `src/parameters.cpp`). `pkgdown::check_pkgdown()`: no problems. The
+  "workflow still succeeds" half confirms on the PR's test-coverage CI run.
+- **AC3 (check clean)** — ✓ Fresh `devtools::check(--no-manual)`: **0 errors /
+  0 warnings / 0 notes**.
+
+_Consistency gate:_ `cairn_validate.py` exit 0; Coverage map complete
+(AC1→T1,T2; AC2→T3; AC3→T4, all tasks present); `devtools::document()` no diff;
+`codecov.yml` already in `.Rbuildignore`; no new top-level files; **no NEWS.md
+entry** — the milestone has no user-visible changes (byte-identical refactor +
+CI-config only). README.Rmd/README.md untouched by this milestone.

--- a/cairn/milestones/M12-label-dry-coverage.md
+++ b/cairn/milestones/M12-label-dry-coverage.md
@@ -3,10 +3,10 @@
      Per-section owners are tagged below. -->
 # M12: Result-label DRY + statistical-core coverage tracking
 
-- **Status:** planned   <!-- owner: transitioning skill · mirror-update; cairn/ROADMAP.md is the authority -->
+- **Status:** in-progress   <!-- owner: transitioning skill · mirror-update; cairn/ROADMAP.md is the authority -->
 - **Priority:** normal   <!-- owner: plan · create/amend-via-gate; high | normal | low -->
 - **Depends on:** —   <!-- owner: plan · create/amend-via-gate; M<xx>, M<yy> or — -->
-- **Branch/PR:** —   <!-- owner: implement (branch) / review (PR URL) · create -->
+- **Branch/PR:** m12-label-dry-coverage   <!-- owner: implement (branch) / review (PR URL) · create -->
 
 ## Goal
 

--- a/cairn/milestones/M12-label-dry-coverage.md
+++ b/cairn/milestones/M12-label-dry-coverage.md
@@ -129,3 +129,19 @@ _Consistency gate:_ `cairn_validate.py` exit 0; Coverage map complete
 `codecov.yml` already in `.Rbuildignore`; no new top-level files; **no NEWS.md
 entry** — the milestone has no user-visible changes (byte-identical refactor +
 CI-config only). README.Rmd/README.md untouched by this milestone.
+
+_Independent two-lens review (both fresh-context):_
+- **[O] diff-bug (Opus):** 0 findings. Transcribed the four original blocks from
+  `master` and confirmed the helper is byte-identical across all 8 branches
+  (incl. the mean-path `c(Measure, Measure[[1]])` NA append and the
+  `is.null(grouping)` contrast-branch ordering); verified the `cbind(df, df)`
+  swap is `identical()` to the old `cbind(vec…, df)` — names, character types,
+  row names — under default and non-default row names; new test is a genuine
+  pin, not a tautology.
+- **[S] blame-history (Sonnet):** 0 findings. Four blocks trace to `8c08945`
+  (2024-10-25, "Make scores and results columns uniform") which deliberately
+  made them identical; no later commit diverged them; no fixed bug resurrected;
+  no D-entry contradicted. Empirically re-confirmed `identical()` incl. row names.
+
+Both reviewers surfaced zero findings → nothing to score or triage; scorer step
+moot. No excluded (sub-80) findings.

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,6 +13,25 @@ coverage:
         threshold: 1%
         informational: true
 
+# Track the statistical core (SSM/CPM estimators and their CI machinery)
+# separately from the whole package, so a coverage regression in the math is
+# visible on its own. Paths are the estimation sources only — not the OOP,
+# plotting, tidying, or generated (RcppExports) layers.
+component_management:
+  individual_components:
+    - component_id: statistical_core
+      name: statistical-core
+      paths:
+        - R/ssm_analysis.R
+        - R/ssm_bootstrap.R
+        - R/ssm_montecarlo.R
+        - R/ssm_ci_accuracy.R
+        - R/ssm_sem.R
+        - R/ssm_sem_syntax.R
+        - R/cpm_fit.R
+        - src/circular.cpp
+        - src/parameters.cpp
+
 codecov: 
  token: b885341a-69e3-47b3-906c-665b458579c6
  

--- a/tests/testthat/test-ssm_analysis.R
+++ b/tests/testthat/test-ssm_analysis.R
@@ -836,3 +836,76 @@ test_that("measures_labels length is validated", {
   expect_equal(res_null$results$Label, c("NARPD", "ASPD"))
 })
 
+test_that("build_result_labels() covers every mean/correlation branch (M12)", {
+  lab <- function(...) build_result_labels(...)
+
+  # --- Mean path (no measures) ---------------------------------------------
+  # Single group: Measure is NA, Label mirrors Group.
+  expect_equal(
+    lab("Mean", "All", NULL, 1L, NULL, FALSE, NULL),
+    data.frame(Label = "All", Group = "All", Measure = NA_character_,
+               stringsAsFactors = FALSE)
+  )
+  # Multiple groups, no contrast.
+  expect_equal(
+    lab("Mean", c("Female", "Male"), NULL, 2L, NULL, FALSE, "gender"),
+    data.frame(Label = c("Female", "Male"), Group = c("Female", "Male"),
+               Measure = c(NA_character_, NA_character_),
+               stringsAsFactors = FALSE)
+  )
+  # Multiple groups, contrast appends the "second - first" row.
+  expect_equal(
+    lab("Mean", c("Female", "Male"), NULL, 2L, NULL, TRUE, "gender"),
+    data.frame(
+      Label = c("Female", "Male", "Male - Female"),
+      Group = c("Female", "Male", "Male - Female"),
+      Measure = c(NA_character_, NA_character_, NA_character_),
+      stringsAsFactors = FALSE
+    )
+  )
+
+  # --- Correlation path (measures present) ---------------------------------
+  # Single group, single measure: Label is the measure.
+  expect_equal(
+    lab("Correlation", "All", "PARPD", 1L, 1L, FALSE, NULL),
+    data.frame(Label = "PARPD", Group = "All", Measure = "PARPD",
+               stringsAsFactors = FALSE)
+  )
+  # Multiple measures, no grouping, no contrast (not asserted end-to-end).
+  expect_equal(
+    lab("Correlation", "All", c("ASPD", "NARPD"), 1L, 2L, FALSE, NULL),
+    data.frame(Label = c("ASPD", "NARPD"), Group = c("All", "All"),
+               Measure = c("ASPD", "NARPD"), stringsAsFactors = FALSE)
+  )
+  # Measure contrast (no grouping): "second - first" measure appended.
+  expect_equal(
+    lab("Correlation", "All", c("ASPD", "NARPD"), 1L, 2L, TRUE, NULL),
+    data.frame(
+      Label = c("ASPD", "NARPD", "NARPD - ASPD"),
+      Group = c("All", "All", "All"),
+      Measure = c("ASPD", "NARPD", "NARPD - ASPD"),
+      stringsAsFactors = FALSE
+    )
+  )
+  # Grouping, no contrast (not asserted end-to-end): Label is "measure: group".
+  expect_equal(
+    lab("Correlation", c("Female", "Male"), "NARPD", 2L, 1L, FALSE, "gender"),
+    data.frame(
+      Label = c("NARPD: Female", "NARPD: Male"),
+      Group = c("Female", "Male"),
+      Measure = c("NARPD", "NARPD"),
+      stringsAsFactors = FALSE
+    )
+  )
+  # Group contrast: "second - first" group appended, Label is "measure: group".
+  expect_equal(
+    lab("Correlation", c("Female", "Male"), "NARPD", 2L, 1L, TRUE, "gender"),
+    data.frame(
+      Label = c("NARPD: Female", "NARPD: Male", "NARPD: Male - Female"),
+      Group = c("Female", "Male", "Male - Female"),
+      Measure = c("NARPD", "NARPD", "NARPD"),
+      stringsAsFactors = FALSE
+    )
+  )
+})
+


### PR DESCRIPTION
## Summary

Single-source the `Label`/`Group`/`Measure` construction in `ssm_analyze*()` and add a statistical-core codecov component. **Byte-identical output** — no user-facing behavior change.

- Extract `build_result_labels()` from four copy-pasted inline blocks (mean/corr × pre/post-CI) in `R/ssm_analysis.R`.
- Add a direct helper unit test covering every branch, including two combos not asserted end-to-end (corr no-contrast+grouping; corr multi-measure no-contrast).
- Add a `statistical_core` codecov component (7 R estimation sources + `circular.cpp` + `parameters.cpp`).

## Evidence

- `devtools::test()`: 1823 pass, 0 fail (byte-identical; row names + column types verified unchanged).
- `devtools::check(--no-manual)`: 0 errors / 0 warnings / 0 notes.
- `codecov.yml` parses; all 9 component paths resolve.

Milestone: `cairn/milestones/M12-label-dry-coverage.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)