### PR TITLE
M14: automate the instruments() list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -259,6 +259,12 @@ Structure", for a worked introduction to both.
   length-greater-than-one vector without complaint; such input now raises a
   clear error.
 
+* `instruments()` now derives its listing from the bundled instrument data
+  rather than a hardcoded table, so it always reflects the instruments
+  actually shipped. As part of this, the listed name for the IIP-SC now
+  reads "Inventory of Interpersonal Problems Short Circumplex" (matching its
+  stored metadata).
+
 # circumplex 1.2.0
 
 * The SSM plotting functions (`ssm_plot_circle()`, `ssm_plot_curve()`,

--- a/R/instrument_oop.R
+++ b/R/instrument_oop.R
@@ -194,24 +194,29 @@ norms <- function(x) {
 #' instruments()
 instruments <- function() {
 
-  # TODO: Find a way to automate this - maybe data$results minus example data?
+  # Enumerate the packaged instruments from the data itself so this listing
+  # can never drift from the shipped datasets. Each instrument is a
+  # circumplex_instrument object carrying its abbreviation and full name in
+  # $Details; example datasets (e.g. aw2009, jz2017, raw) are filtered out by
+  # class.
+  nms <- utils::data(package = "circumplex")$results[, "Item"]
+  insts <- sort(Filter(function(nm) {
+    e <- new.env()
+    utils::data(list = nm, package = "circumplex", envir = e)
+    inherits(get(nm, envir = e), "circumplex_instrument")
+  }, nms))
 
-  cat(
-    "The circumplex package currently includes 15 instruments:\n",
-    "1. CAIS: Child and Adolescent Interpersonal Survey (cais)\n",
-    "2. CSIE: Circumplex Scales of Interpersonal Efficacy (csie)\n",
-    "3. CSIG: Circumplex Scales of Intergroup Goals (csig)\n",
-    "4. CSIP: Circumplex Scales of Interpersonal Problems (csip)\n",
-    "5. CSIV: Circumplex Scales of Interpersonal Values (csiv)\n",
-    "6. IEI: Interpersonal Emotion Inventory (iei)\n",
-    "7. IGI-CR: Interpersonal Goals Inventory for Children, Revised Version (igicr)\n",
-    "8. IIP-32: Inventory of Interpersonal Problems, Brief Version (iip32)\n",
-    "9. IIP-64: Inventory of Interpersonal Problems (iip64)\n",
-    "10. IIP-SC: Inventory of Interpersonal Problems, Short Circumplex (iipsc)\n",
-    "11. IIS-32: Inventory of Interpersonal Strengths, Brief Version (iis32)\n",
-    "12. IIS-64: Inventory of Interpersonal Strengths (iis64)\n",
-    "13. IIT-C: Inventory of Influence Tactics Circumplex (iitc)\n",
-    "14. IPIP-IPC: IPIP Interpersonal Circumplex (ipipipc)\n",
-    "15. ISC: Interpersonal Sensitivities Circumplex (isc)\n"
+  header <- sprintf(
+    "The circumplex package currently includes %d instruments:\n",
+    length(insts)
   )
+  lines <- vapply(seq_along(insts), function(i) {
+    nm <- insts[[i]]
+    e <- new.env()
+    utils::data(list = nm, package = "circumplex", envir = e)
+    d <- get(nm, envir = e)$Details
+    sprintf("%d. %s: %s (%s)\n", i, d$Abbrev, d$Name, nm)
+  }, character(1))
+
+  cat(c(header, lines))
 }

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | — | high | milestones/M7-v2-release-prep.md |
-| M14 | Automate the instruments() list | in-progress | — | normal | milestones/M14-instruments-list-automation.md |
+| M14 | Automate the instruments() list | review | — | normal | milestones/M14-instruments-list-automation.md |
 | M13 | Angle-class S3 follow-ups (RR01) | done | — | normal | milestones/archive/M13-angle-class-s3-followups.md |
 | M12 | Result-label DRY + statistical-core coverage tracking | done | — | normal | milestones/archive/M12-label-dry-coverage.md |
 | M11 | Boundary-coverage hardening + test-suite tidiness | done | — | normal | milestones/archive/M11-boundary-coverage-hardening.md |

--- a/cairn/milestones/M14-instruments-list-automation.md
+++ b/cairn/milestones/M14-instruments-list-automation.md
@@ -36,16 +36,16 @@ Derive `instruments()`' printed list and count from the package's
 
 ## Acceptance criteria
 
-- [ ] `instruments()` contains no hardcoded instrument names or count: the
+- [x] `instruments()` contains no hardcoded instrument names or count: the
       list and the "N instruments" count are computed at call time from the
       package's `circumplex_instrument` datasets (evidence: source inspection;
       the `TODO` is gone).
-- [ ] A test asserts the printed output is data-derived — the count line
+- [x] A test asserts the printed output is data-derived — the count line
       equals the number of `circumplex_instrument` datasets, and every such
       dataset's `$Details$Abbrev` and `$Details$Name` appears in the output —
       so adding or removing an instrument would change `instruments()` without
       a code edit (evidence: test passes; demonstrably keys off the data).
-- [ ] `devtools::check()` clean (0 errors / 0 warnings / 0 notes).
+- [x] `devtools::check()` clean (0 errors / 0 warnings / 0 notes).
 
 ## Coverage
 
@@ -103,3 +103,35 @@ Derive `instruments()`' printed list and count from the package's
   prevents; not treated as a breaking change. Snapshot updated to match.
 
 ## Review
+
+**Acceptance evidence (fresh, 2026-07-12):**
+- AC1 → source inspection: `instruments()` body has no instrument literals,
+  count, or `TODO` (grep of the function is empty); list + count computed from
+  `utils::data()`. Confirmed by both the diff-bug and prior-PR reviewers.
+- AC2 → `test_file("test-instrument_oop.R")` green; the drift-guard test
+  independently re-enumerates the `circumplex_instrument` datasets and asserts
+  the count line and each Abbrev/Name — verified red against the old hardcoded
+  body during implement (teeth).
+- AC3 → fresh `devtools::check()` = Status OK, 0 errors / 0 warnings / 0 notes
+  (3m33s).
+
+**Consistency gate:** `cairn_validate` all-pass (incl. coverage complete);
+`document()` no diff; `pkgdown::check_pkgdown()` clean (`instruments` already
+indexed); NEWS.md entry added; no DESIGN principle change (cairn_impact
+skipped); no new top-level files.
+
+**Independent review — 3 lenses, all clean, zero findings:**
+- [O] diff-bug (Opus): no defects; AC1/AC2 met; enumeration sound (correct
+  class filter, deterministic sort, no global-env pollution). Dropped as
+  non-defects: pre-existing undeclared `utils::` use (already elsewhere; check
+  clean), and a minor double dataset-load in an interactive printer (efficiency,
+  not correctness).
+- [S] blame-history (Sonnet): no findings; the hardcoded list carried an
+  8-year-old "automate this" TODO (never deliberate), and the IIP-SC comma
+  lived only in the hand-typed string — the data's `$Details$Name` was always
+  comma-free. Consistent with M14-D1.
+- [S] prior-PR-comments (Sonnet): no prior-PR evidence bears against the diff;
+  corroborated that a prior "14 vs 15" hardcoded-drift bug (legacy, 2026-07-02)
+  is the exact class M14 structurally eliminates.
+
+No findings scored; nothing below-threshold to log.

--- a/cairn/milestones/M14-instruments-list-automation.md
+++ b/cairn/milestones/M14-instruments-list-automation.md
@@ -7,7 +7,7 @@
 - **Priority:** normal
 - **Depends on:** —
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** m14-instruments-list-automation
 
 ## Goal
 
@@ -55,7 +55,7 @@ Derive `instruments()`' printed list and count from the package's
 
 ## Tasks
 
-- [ ] **T1** — Test-first: add a testthat test that enumerates the
+- [x] **T1** — Test-first: add a testthat test that enumerates the
       `circumplex_instrument` datasets (via `utils::data(package = "circumplex")`,
       filtered by class) and asserts `instruments()` output contains the
       derived count line and each instrument's Abbrev/Name. Written against the
@@ -77,6 +77,9 @@ Derive `instruments()`' printed list and count from the package's
   opportunistic fold-ins at the user's direction (question gate). Derivation
   feasibility confirmed: all 15 entries reproduce from `$Details$Abbrev/$Name`;
   the only text delta is the IIP-SC comma (the drift this fixes).
+- 2026-07-12: branch cut. T1 — data-derived drift-guard test added
+  (`test-instrument_oop.R`); confirmed red against the hardcoded body
+  ("missing Name for iipsc", the comma delta).
 
 ## Decisions
 

--- a/cairn/milestones/M14-instruments-list-automation.md
+++ b/cairn/milestones/M14-instruments-list-automation.md
@@ -7,7 +7,7 @@
 - **Priority:** normal
 - **Depends on:** —
 - **Principles touched:** —
-- **Branch/PR:** m14-instruments-list-automation
+- **Branch/PR:** m14-instruments-list-automation / #38
 
 ## Goal
 
@@ -87,6 +87,10 @@ Derive `instruments()`' printed list and count from the package's
 - 2026-07-12: T3 — full `devtools::test()` green (0 failures / 1869 pass);
   `devtools::check()` clean (0 errors / 0 warnings / 0 notes, 3m34s). No
   roxygen change → no `document()` needed. Status → review.
+- 2026-07-12: review in progress — draft PR #38 opened. Consistency gate
+  green: `cairn_validate` all-pass (coverage complete), `document()` no diff,
+  `pkgdown::check_pkgdown()` clean, NEWS.md entry added, no principle change.
+  Fresh `check()` + 3-lens independent review running (checkpoint).
 
 ## Decisions
 

--- a/cairn/milestones/M14-instruments-list-automation.md
+++ b/cairn/milestones/M14-instruments-list-automation.md
@@ -62,7 +62,7 @@ Derive `instruments()`' printed list and count from the package's
       intended data-derived output (note the IIP-SC string resolves to the
       data's `$Details$Name`, without the current comma). Fails against the
       present hardcoded body where the two diverge.
-- [ ] **T2** — Rewrite `instruments()` (`R/instrument_oop.R:195`) to enumerate,
+- [x] **T2** — Rewrite `instruments()` (`R/instrument_oop.R:195`) to enumerate,
       sort by dataset name, format `"N. ABBREV: Name (obj)\n"`, and compute the
       count from the data; delete the hardcoded block and the `TODO`. Keep it a
       `cat()` printer returning invisibly as today.
@@ -80,7 +80,19 @@ Derive `instruments()`' printed list and count from the package's
 - 2026-07-12: branch cut. T1 — data-derived drift-guard test added
   (`test-instrument_oop.R`); confirmed red against the hardcoded body
   ("missing Name for iipsc", the comma delta).
+- 2026-07-12: T2 — `instruments()` now enumerates via `utils::data()`,
+  filters by class, formats from `$Details$Abbrev/$Name`, count from data;
+  TODO removed. Output byte-identical to the old format except the IIP-SC
+  line (see M14-D1). Snapshot regenerated; structural test green.
 
 ## Decisions
+
+- **M14-D1** (2026-07-12): the data is the source of truth for the printed
+  strings. This changes one line vs. the old hardcoded list — IIP-SC's name
+  resolves to its `$Details$Name` "Inventory of Interpersonal Problems Short
+  Circumplex" (no comma), where the hardcoded literal had "Problems, Short".
+  This is a cosmetic console-text change to an informational printer (no
+  return-value/API contract), and is exactly the drift the automation
+  prevents; not treated as a breaking change. Snapshot updated to match.
 
 ## Review

--- a/cairn/milestones/M14-instruments-list-automation.md
+++ b/cairn/milestones/M14-instruments-list-automation.md
@@ -3,7 +3,7 @@
      Per-section owners are tagged below. -->
 # M14: Automate the instruments() list
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Principles touched:** —
@@ -66,7 +66,7 @@ Derive `instruments()`' printed list and count from the package's
       sort by dataset name, format `"N. ABBREV: Name (obj)\n"`, and compute the
       count from the data; delete the hardcoded block and the `TODO`. Keep it a
       `cat()` printer returning invisibly as today.
-- [ ] **T3** — `devtools::document()` if roxygen changed; `devtools::test()`
+- [x] **T3** — `devtools::document()` if roxygen changed; `devtools::test()`
       then `devtools::check()` clean; update any snapshot.
 
 ## Work log
@@ -84,6 +84,9 @@ Derive `instruments()`' printed list and count from the package's
   filters by class, formats from `$Details$Abbrev/$Name`, count from data;
   TODO removed. Output byte-identical to the old format except the IIP-SC
   line (see M14-D1). Snapshot regenerated; structural test green.
+- 2026-07-12: T3 — full `devtools::test()` green (0 failures / 1869 pass);
+  `devtools::check()` clean (0 errors / 0 warnings / 0 notes, 3m34s). No
+  roxygen change → no `document()` needed. Status → review.
 
 ## Decisions
 

--- a/tests/testthat/_snaps/instrument_oop.md
+++ b/tests/testthat/_snaps/instrument_oop.md
@@ -419,7 +419,7 @@
      7. IGI-CR: Interpersonal Goals Inventory for Children, Revised Version (igicr)
      8. IIP-32: Inventory of Interpersonal Problems, Brief Version (iip32)
      9. IIP-64: Inventory of Interpersonal Problems (iip64)
-     10. IIP-SC: Inventory of Interpersonal Problems, Short Circumplex (iipsc)
+     10. IIP-SC: Inventory of Interpersonal Problems Short Circumplex (iipsc)
      11. IIS-32: Inventory of Interpersonal Strengths, Brief Version (iis32)
      12. IIS-64: Inventory of Interpersonal Strengths (iis64)
      13. IIT-C: Inventory of Influence Tactics Circumplex (iitc)

--- a/tests/testthat/test-instrument_oop.R
+++ b/tests/testthat/test-instrument_oop.R
@@ -37,3 +37,31 @@ test_that("scales() rejects a non-flag items argument (is_flag guard)", {
 test_that("The instruments function produces the expected output", {
   expect_snapshot_output(instruments())
 })
+
+test_that("instruments() output is derived from the instrument datasets, not hardcoded", {
+  # Independently enumerate the packaged circumplex_instrument datasets.
+  nms <- utils::data(package = "circumplex")$results[, "Item"]
+  insts <- Filter(function(nm) {
+    e <- new.env()
+    utils::data(list = nm, package = "circumplex", envir = e)
+    inherits(get(nm, envir = e), "circumplex_instrument")
+  }, nms)
+
+  out <- paste(capture.output(instruments()), collapse = "\n")
+
+  # The count line reflects the actual number of instrument datasets, so
+  # adding or removing an instrument changes the output with no code edit.
+  expect_match(out, sprintf("includes %d instruments", length(insts)))
+
+  # Every instrument's abbreviation and full name (from its own $Details)
+  # appears in the listing -- the list is data-derived, not a literal.
+  for (nm in insts) {
+    e <- new.env()
+    utils::data(list = nm, package = "circumplex", envir = e)
+    d <- get(nm, envir = e)$Details
+    expect_true(grepl(d$Abbrev, out, fixed = TRUE),
+      info = paste("missing Abbrev for", nm))
+    expect_true(grepl(d$Name, out, fixed = TRUE),
+      info = paste("missing Name for", nm))
+  }
+})


### PR DESCRIPTION
Derive `instruments()`' printed listing and count from the packaged
`circumplex_instrument` datasets so the list can never drift from the data.

- `instruments()` now enumerates datasets via `utils::data()`, filters by
  class, and formats each line from the object's own `\$Details\$Abbrev`/`\$Name`;
  the count is computed from the data. Hardcoded 15-item block and its TODO removed.
- New data-derived drift-guard test (`test-instrument_oop.R`): the count line
  and every Abbrev/Name key off the datasets. Confirmed red against the old body first.
- Output is byte-identical to the old format except the IIP-SC line, whose name
  now matches its data ("Inventory of Interpersonal Problems Short Circumplex",
  no comma). Snapshot regenerated. Decision M14-D1.

Evidence: full suite 0 failures / 1869 pass; `devtools::check()` clean (0/0/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)