### PR TITLE
M15: contrast displacement reported unconditionally in ssm_ci_accuracy()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,7 +81,11 @@ Structure", for a worked introduction to both.
   amplitude intervals are theoretically weakest — along with one-sided miss
   rates, interval widths, the certification rate of the printed
   "amplitude CI excludes zero" guardrail, and displacement coverage
-  conditional on certification. Coverage at the as-estimated condition is
+  conditional on certification. For a contrast row — a signed difference that
+  `print.circumplex_ssm()` never certification-gates — the displacement
+  verdict and printed coverage are reported unconditionally, matching that
+  profiles-only stance (its conditional coverage is retained in the object as
+  a descriptive). Coverage at the as-estimated condition is
   classified against Bradley's (1978) liberal robustness band using 95%
   Wilson score intervals, and `print()`/`summary()` translate the
   classifications into a plain-language verdict, including a caution line

--- a/R/ssm_ci_accuracy.R
+++ b/R/ssm_ci_accuracy.R
@@ -32,8 +32,14 @@
 #' `round(a_lci, digits) > 0` (the rule the printed [ssm_analyze()] output
 #' applies); the
 #' implied certification threshold, `0.5 * 10^-digits` in amplitude units, is
-#' echoed in the output because it is scale-dependent. For a contrast row,
-#' "certified" means both profile rows were certified.
+#' echoed in the output because it is scale-dependent. A contrast row is a
+#' signed difference, not a prototypicality measure, so
+#' `print.circumplex_ssm()` never certification-gates it; its displacement
+#' verdict and printed coverage are therefore reported unconditionally
+#' (matching that profiles-only stance). Its certification-conditional
+#' coverage -- where "certified" means both profile rows were certified -- is
+#' still computed and retained in the returned object as a descriptive that no
+#' display consumes.
 #'
 #' The `amplitude_factors` ladder manufactures populations whose closed-form
 #' amplitude is scaled toward zero (the regime where percentile amplitude
@@ -92,7 +98,9 @@
 #'   Profile x Parameter x Condition: coverage, its Monte Carlo SE, the
 #'   one-sided miss rates, median CI width, and for displacement the
 #'   certification-conditional coverage with the number of certified
-#'   replicates behind it; `Structural` flags the amplitude rows whose zero
+#'   replicates behind it -- for a contrast row this conditional column is
+#'   retained as a joint-certification descriptive that no display consumes;
+#'   `Structural` flags the amplitude rows whose zero
 #'   coverage is a theorem rather than a measurement), `guardrail` (per
 #'   Profile x Condition: certification rate with its 95% Wilson score
 #'   interval, the user-expectation benchmark `(1 - interval) / 2`, the
@@ -104,7 +112,10 @@
 #'   branch-pathology rate -- the rate at which a displacement point estimate
 #'   falls geometrically outside its own interval), `verdict`
 #'   (Wilson-vs-Bradley classification of elevation, amplitude, and
-#'   conditional displacement coverage at the as-estimated condition, plus an
+#'   displacement coverage at the as-estimated condition -- a profile's
+#'   displacement is classified certification-conditionally (`Parameter`
+#'   `"d_conditional"`), a contrast's unconditionally (`Parameter` `"d"`) --
+#'   plus an
 #'   overall worst-of row per profile; note the printed verdict headline
 #'   additionally elevates to CAUTION whenever the guardrail `Caution` fired,
 #'   so it can read worse than the overall coverage class),
@@ -546,9 +557,10 @@ ssm_ci_accuracy <- function(ssm_object, reps = 1000,
         # Profile rows: the shipped guardrail rule, identical to the one
         # print.circumplex_ssm() applies. The contrast row is NOT gated by print
         # (a contrast's amplitude is a difference, not a prototypicality
-        # measure), so cert[1] && cert[2] here is only the diagnostic's own
-        # conditioning device for the contrast's certified-displacement coverage
-        # -- not a rule the package displays. Its guardrail Caution is NA'd below.
+        # measure; M15-D1), so cert[1] && cert[2] here conditions no displayed
+        # number -- it only populates the retained `Coverage_conditional` /
+        # `Cert_rate` object columns (documented joint-certification
+        # descriptives). Its guardrail Caution is NA'd below.
         cert <- ssm_certified(lean$lci[, a_col], digits)
         if (contrast) cert[n_rows] <- cert[1] && cert[2]
         fitpass <- !is.na(t0_all[, fit_col]) & t0_all[, fit_col] >= 0.70
@@ -692,8 +704,9 @@ ssm_ci_accuracy <- function(ssm_object, reps = 1000,
     # programmatic consumer share one decision (NA off that rung). The contrast
     # row is NA'd even at c = 0: print.circumplex_ssm() applies no certification
     # gate to a contrast, so a false-certification verdict does not apply to it
-    # (its Cert_rate is only the conditioning rate for certified-displacement
-    # coverage, and is still reported).
+    # (M15-D1). Its Cert_rate is retained as the documented joint-certification
+    # rate -- the denominator provenance for the retained Coverage_conditional
+    # column -- not a conditioning device for any displayed number.
     caution_col <- if (conds[k] == 0) {
       cau <- ssm_ci_guardrail_caution(cert_w[, 1], (1 - interval) / 2)
       if (contrast) cau[n_rows] <- NA
@@ -723,7 +736,8 @@ ssm_ci_accuracy <- function(ssm_object, reps = 1000,
 
   # ---- verdict at c = 1 (spec sec. 5.1): Wilson-95 vs Bradley liberal ----
   verdict <- ssm_ci_verdict(coverage, dcond_at_1, row_labels[seq_len(n_rows)],
-                            interval)
+                            interval,
+                            contrast_lab = if (contrast) row_labels[n_rows])
 
   # ---- population record (spec sec. 7) ----
   population <- lapply(seq_len(n_rows), function(r) {
@@ -1020,10 +1034,14 @@ ssm_ci_bradley_class <- function(k, n, nominal) {
 }
 
 # Assemble the verdict table at the as-estimated condition (spec sec. 5.1):
-# elevation and amplitude unconditional, displacement conditional on
-# certification; x and y are reported in `coverage` but do not drive the
-# verdict; the overall row is the worst classification of the three.
-ssm_ci_verdict <- function(coverage, dcond_at_1, labels, interval) {
+# elevation and amplitude unconditional; a profile's displacement is
+# conditional on certification, but the contrast's displacement is
+# UNCONDITIONAL (M15-D1: print.circumplex_ssm() never certification-gates a
+# contrast, so the verdict classifies the coverage the package actually shows
+# -- Parameter "d", not "d_conditional"). x and y are reported in `coverage`
+# but do not drive the verdict; the overall row is the worst of the three.
+ssm_ci_verdict <- function(coverage, dcond_at_1, labels, interval,
+                           contrast_lab = NULL) {
   rank <- c(adequate = 1, borderline = 2, inadequate = 3)
   rows <- list()
   for (r in seq_along(labels)) {
@@ -1035,12 +1053,20 @@ ssm_ci_verdict <- function(coverage, dcond_at_1, labels, interval) {
       k <- if (is.na(cc$Coverage)) NA_real_ else round(cc$Coverage * cc$N_reps)
       cells[[pm]] <- list(param = pm, cov = cc$Coverage, k = k, n = cc$N_reps)
     }
-    dv <- dcond_at_1[r, ]
-    nd <- sum(!is.na(dv))
-    kd <- if (nd > 0) sum(dv, na.rm = TRUE) else NA_real_
-    cells[["d"]] <- list(param = "d_conditional",
-                         cov = if (nd > 0) kd / nd else NA_real_,
-                         k = kd, n = nd)
+    if (!is.null(contrast_lab) && identical(lab, contrast_lab)) {
+      # Contrast: classify on the unconditional displacement coverage row.
+      cd <- coverage[coverage$Profile == lab & coverage$Parameter == "d" &
+                       coverage$Condition == 1, ]
+      kd <- if (is.na(cd$Coverage)) NA_real_ else round(cd$Coverage * cd$N_reps)
+      cells[["d"]] <- list(param = "d", cov = cd$Coverage, k = kd, n = cd$N_reps)
+    } else {
+      dv <- dcond_at_1[r, ]
+      nd <- sum(!is.na(dv))
+      kd <- if (nd > 0) sum(dv, na.rm = TRUE) else NA_real_
+      cells[["d"]] <- list(param = "d_conditional",
+                           cov = if (nd > 0) kd / nd else NA_real_,
+                           k = kd, n = nd)
+    }
     classes <- lapply(cells, function(cl) {
       ssm_ci_bradley_class(cl$k, cl$n, interval)
     })

--- a/R/ssm_ci_oop.R
+++ b/R/ssm_ci_oop.R
@@ -79,14 +79,18 @@ ssm_ci_verdict_blocks <- function(x) {
       sep = ""
     )
 
+    # A profile's displacement verdict is certification-conditional
+    # ("d_conditional"); the contrast's is unconditional ("d") -- M15-D1.
+    dkey <- if (is_con) "d" else "d_conditional"
     cls <- list()
-    for (pm in c("e", "a", "d_conditional")) {
+    for (pm in c("e", "a", dkey)) {
       row <- vp[vp$Parameter == pm, ]
       cls[[pm]] <- row
+      is_dcond <- pm == "d_conditional"
       leader <- switch(pm, e = "Elevation", a = "Amplitude",
-                       d_conditional = "Displacement")
+                       d = "Displacement", d_conditional = "Displacement")
       if (nrow(row) == 0 || is.na(row$Class)) {
-        txt <- if (pm == "d_conditional") {
+        txt <- if (is_dcond) {
           "never certified at the as-estimated condition (not assessable)"
         } else {
           "not assessable"
@@ -103,15 +107,16 @@ ssm_ci_verdict_blocks <- function(x) {
       }
       ssm_ci_cat_line(leader, paste0(
         "coverage ", ssm_ci_pct(row$Coverage),
-        if (pm == "d_conditional") " when certified", " -- ", shown, qual
+        if (is_dcond) " when certified", " -- ", shown, qual
       ))
     }
 
     # Guardrail false-certification line: profiles only. print.circumplex_ssm()
     # gates a profile's displacement on "amplitude CI excludes zero" but applies
     # no such gate to a contrast, so the diagnostic reports no false-cert verdict
-    # for the contrast row (its certified-displacement coverage line above still
-    # uses the joint-certification conditioning).
+    # for the contrast row -- and, since M15-D1, no certification-conditional
+    # displacement line either (the contrast's displacement line above is
+    # unconditional). The retained contrast Cert_rate is object-only provenance.
     gr0 <- gr[gr$Profile == lab & gr$Condition == 0, ]
     guard_fired <- FALSE
     guard_rate <- NA_real_
@@ -138,7 +143,7 @@ ssm_ci_verdict_blocks <- function(x) {
     }
 
     ssm_ci_cat_para(
-      ssm_ci_verdict_text(cls, guard_fired, guard_rate), indent = 2
+      ssm_ci_verdict_text(cls, guard_fired, guard_rate, dkey = dkey), indent = 2
     )
   }
   invisible(x)
@@ -166,7 +171,16 @@ ssm_ci_miss_phrase <- function(cov, lab) {
 # three classifications and the guardrail caution. The headline is CAUTION
 # whenever any coverage verdict is inadequate OR the false-certification
 # caution fired (sec. 5.1: the caution triggers the CAUTION wording).
-ssm_ci_verdict_text <- function(cls, guard_fired, guard_rate) {
+# `dkey` selects the displacement verdict key: "d_conditional" for a profile
+# (certification-conditional) or "d" for the contrast (unconditional; M15-D1).
+# `certified` drives the "when certified" / "certified displacement" wording,
+# which is omitted for the contrast.
+ssm_ci_verdict_text <- function(cls, guard_fired, guard_rate,
+                                dkey = "d_conditional") {
+  certified <- dkey == "d_conditional"
+  d_label <- if (certified) "certified displacement" else "displacement"
+  labmap <- c(e = "elevation", a = "amplitude")
+  labmap[[dkey]] <- d_label
   class_of <- function(pm) {
     row <- cls[[pm]]
     if (is.null(row) || nrow(row) == 0) NA_character_ else row$Class
@@ -175,7 +189,7 @@ ssm_ci_verdict_text <- function(cls, guard_fired, guard_rate) {
     row <- cls[[pm]]
     if (is.null(row) || nrow(row) == 0) NA_character_ else row$Direction
   }
-  cl <- vapply(c("e", "a", "d_conditional"), class_of, character(1))
+  cl <- vapply(c("e", "a", dkey), class_of, character(1))
   if (all(is.na(cl)) && !guard_fired) {
     return("Verdict: not assessable at this number of replications.")
   }
@@ -197,11 +211,11 @@ ssm_ci_verdict_text <- function(cls, guard_fired, guard_rate) {
       "amplitude CIs cover more often than nominal (they are conservative)"
     })
   }
-  if (identical(cl[["d_conditional"]], "inadequate")) {
-    bad <- c(bad, if (identical(dir_of("d_conditional"), "under")) {
-      "displacement CIs mis-cover even when certified"
+  if (identical(cl[[dkey]], "inadequate")) {
+    bad <- c(bad, if (identical(dir_of(dkey), "under")) {
+      paste0("displacement CIs mis-cover", if (certified) " even when certified")
     } else {
-      "displacement CIs over-cover when certified"
+      paste0("displacement CIs over-cover", if (certified) " when certified")
     })
   }
   if (guard_fired) {
@@ -231,22 +245,20 @@ ssm_ci_verdict_text <- function(cls, guard_fired, guard_rate) {
   sentences <- character(0)
   if (length(bad) > 0) {
     sentences <- paste0(join_and(bad), ".")
-    if (identical(cl[["d_conditional"]], "adequate")) {
-      sentences <- c(sentences,
-                     "Displacement CIs are trustworthy when certified.")
+    if (identical(cl[[dkey]], "adequate")) {
+      sentences <- c(sentences, paste0(
+        "Displacement CIs are trustworthy",
+        if (certified) " when certified", "."
+      ))
     }
   } else if (!any(cl == "borderline", na.rm = TRUE)) {
-    ok <- c(e = "elevation", a = "amplitude",
-            d_conditional = "certified displacement")[
-              names(cl)[which(cl == "adequate")]]
+    ok <- labmap[names(cl)[which(cl == "adequate")]]
     sentences <- paste0(
       "coverage is consistent with the nominal level for ", join_and(ok),
       " at this sample size."
     )
   }
-  bord <- c(e = "elevation", a = "amplitude",
-            d_conditional = "certified displacement")[
-              names(cl)[which(cl == "borderline")]]
+  bord <- labmap[names(cl)[which(cl == "borderline")]]
   if (length(bord) > 0) {
     sentences <- c(sentences, paste0(
       join_and(bord), " coverage ", if (length(bord) > 1) "rates are"
@@ -511,6 +523,13 @@ plot.circumplex_ci_accuracy <- function(x, ...) {
     N_reps = dcond$N_conditional, Structural = FALSE,
     stringsAsFactors = FALSE
   )
+  # The "Displacement (certified)" panel is a presentation surface, so it
+  # follows print's profiles-only certification stance (M15-D1): the contrast's
+  # displacement is unconditional and appears only in the "Displacement" panel.
+  if (isTRUE(x$details$contrast)) {
+    con_lab <- names(x$details$row_n)[length(x$details$row_n)]
+    dcond <- dcond[dcond$Profile != con_lab, , drop = FALSE]
+  }
   df <- rbind(base, dcond)
   df <- df[!is.na(df$Coverage) & df$N_reps > 0, , drop = FALSE]
   wl <- t(vapply(seq_len(nrow(df)), function(i) {

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | — | high | milestones/M7-v2-release-prep.md |
-| M15 | Contrast certification-conditional reporting consistency (ci_accuracy ↔ print) | planned | — | normal | milestones/M15-contrast-cert-consistency.md |
+| M15 | Contrast certification-conditional reporting consistency (ci_accuracy ↔ print) | in-progress | — | normal | milestones/M15-contrast-cert-consistency.md |
 | M14 | Automate the instruments() list | done | — | normal | milestones/archive/M14-instruments-list-automation.md |
 | M13 | Angle-class S3 follow-ups (RR01) | done | — | normal | milestones/archive/M13-angle-class-s3-followups.md |
 | M12 | Result-label DRY + statistical-core coverage tracking | done | — | normal | milestones/archive/M12-label-dry-coverage.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | — | high | milestones/M7-v2-release-prep.md |
-| M15 | Contrast certification-conditional reporting consistency (ci_accuracy ↔ print) | in-progress | — | normal | milestones/M15-contrast-cert-consistency.md |
+| M15 | Contrast certification-conditional reporting consistency (ci_accuracy ↔ print) | review | — | normal | milestones/M15-contrast-cert-consistency.md |
 | M14 | Automate the instruments() list | done | — | normal | milestones/archive/M14-instruments-list-automation.md |
 | M13 | Angle-class S3 follow-ups (RR01) | done | — | normal | milestones/archive/M13-angle-class-s3-followups.md |
 | M12 | Result-label DRY + statistical-core coverage tracking | done | — | normal | milestones/archive/M12-label-dry-coverage.md |

--- a/cairn/milestones/M15-contrast-cert-consistency.md
+++ b/cairn/milestones/M15-contrast-cert-consistency.md
@@ -3,7 +3,7 @@
      Per-section owners are tagged below. -->
 # M15: Contrast certification-conditional reporting consistency (ci_accuracy ↔ print)
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Principles touched:** —
@@ -22,31 +22,22 @@ The object contract is settled by RR02 (see M15-D1): **measured quantities
 stay in the returned object; only interpretive/presentation surfaces follow
 `print.circumplex_ssm()`'s profiles-only certification stance.**
 
+Per M15-D1, the contrast's interpretive/presentation surfaces (verdict,
+print/summary, plot) go unconditional; its measurement columns stay. Concrete
+sites in Tasks below.
+
 **In:**
-- **Verdict (interpretation).** Recompute the contrast's displacement Class on
-  the **unconditional** coverage (k = round(Coverage × N_reps), n = N_reps at
-  Condition 1) in `ssm_ci_verdict()` (`R/ssm_ci_accuracy.R` ~L1026), and
-  relabel that verdict row's `Parameter` `"d_conditional"` → `"d"`; profiles
-  keep `"d_conditional"`.
-- **Print/summary (presentation).** In `ssm_ci_verdict_blocks()`
-  (`R/ssm_ci_oop.R:83`) key the contrast displacement line to `"d"` (drops the
-  " when certified" suffix); in `ssm_ci_verdict_text()`
-  (`R/ssm_ci_oop.R:169-262`) use plain "displacement" wording for the contrast
-  (never "certified displacement"/"trustworthy when certified"); make the
-  "never certified (not assessable)" fallback (`R/ssm_ci_oop.R:89-93`)
-  unreachable for the contrast.
-- **Plot (presentation, fourth surface — RR02 Beyond-the-brief #1).** Exclude
-  the contrast series from the "Displacement (certified)" panel in
-  `plot.circumplex_ci_accuracy()` (`R/ssm_ci_oop.R:501-527`).
-- **Object (measurement) — retained, not dropped.** Keep the contrast's
+- **Verdict + print/summary + plot** made unconditional for the contrast
+  (Parameter `"d"`, no "when certified"/"certified displacement" wording;
+  excluded from the "Displacement (certified)" plot panel — the fourth
+  surface RR02 surfaced). Profiles unchanged.
+- **Object measurements retained** (not dropped): contrast
   `coverage$Coverage_conditional`/`N_conditional` and `guardrail$Cert_rate`
-  (`Caution` stays NA) as documented joint-certification descriptives; rewrite
-  the three now-stale comments (`R/ssm_ci_accuracy.R:546-551`,
-  `R/ssm_ci_accuracy.R:690-696`, `R/ssm_ci_oop.R:110-114`).
-- Supersede the "Milestone-close review #3" split (`test-ci_accuracy.R:221-250`);
-  re-pin the `ci_accuracy` snapshot (contrast-only churn; profiles
-  byte-identical); update the roxygen `@return` and add one clause to the
-  existing `NEWS.md` development bullet.
+  (`Caution` NA) kept as documented joint-certification descriptives; three
+  now-stale comments rewritten.
+- Supersede "Milestone-close review #3" (`test-ci_accuracy.R:221-250`); re-pin
+  the `ci_accuracy` snapshot (profiles byte-identical); update roxygen
+  `@return` + the `NEWS.md` development bullet.
 
 **Out:**
 - Any change to `print.circumplex_ssm()` — already correct; Direction A leaves
@@ -87,22 +78,22 @@ stay in the returned object; only interpretive/presentation surfaces follow
 
 - [x] **T1** — RB02 drafted + RR02 ingested: object contract settled (M15-D1);
       unconditional-only supersedes Milestone-close review #3. Done 2026-07-12.
-- [ ] **T2** — Regression tests first (red before the change): supersede
+- [x] **T2** — Regression tests first (red before the change): supersede
       `test-ci_accuracy.R:221-250` — pin contrast verdict `Parameter == "d"`
       with `N_reps == reps`, profiles keep `"d_conditional"`, contrast printed
       displacement line has no "when certified", contrast `Coverage_conditional`
       still populated; keep the surviving assertions (contrast `Caution` all-NA,
       finite `Cert_rate`, wording bars).
-- [ ] **T3** — Verdict + wording: recompute the contrast displacement Class on
+- [x] **T3** — Verdict + wording: recompute the contrast displacement Class on
       unconditional coverage and relabel `Parameter` → `"d"`
       (`ssm_ci_verdict()`); key the contrast to `"d"` in `ssm_ci_verdict_blocks()`
       and use plain "displacement" wording in `ssm_ci_verdict_text()`; make the
       not-assessable fallback unreachable for the contrast. Profiles unchanged.
-- [ ] **T4** — Object comments + retention: rewrite the three stale comments
+- [x] **T4** — Object comments + retention: rewrite the three stale comments
       (`R/ssm_ci_accuracy.R:546-551`, `:690-696`; `R/ssm_ci_oop.R:110-114`) to
       say the joint-cert rate is provenance for the retained object columns, not
       a conditioning device for any displayed line; add object-contract tests.
-- [ ] **T5** — Plot fix (exclude contrast from the `d_cert` panel,
+- [x] **T5** — Plot fix (exclude contrast from the `d_cert` panel,
       `R/ssm_ci_oop.R:501-527`); re-pin the `ci_accuracy` snapshot; roxygen
       `@return` + `NEWS.md` clause; `devtools::document()`; `devtools::check()`
       clean.
@@ -124,6 +115,12 @@ stay in the returned object; only interpretive/presentation surfaces follow
   option). RB02/RR02 archived. T1 done.
 - 2026-07-12: in-progress on m15-contrast-cert-consistency (cut from synced
   master); no open implementation gate (design fully settled by M15-D1).
+- 2026-07-12: T2–T5 done → review. Contrast verdict now classified on
+  unconditional coverage (Parameter "d"); print/summary/plot follow print's
+  profiles-only stance; conditional measurement columns + Cert_rate retained;
+  3 stale comments rewritten; roxygen + NEWS updated. Full suite FAIL 0 /
+  PASS 1881; `check()` 0/0/0. Added a contrast print snapshot + a data-level
+  plot-exclusion test (existing snapshot/plot fixtures were profile-only).
 
 ## Decisions
 

--- a/cairn/milestones/M15-contrast-cert-consistency.md
+++ b/cairn/milestones/M15-contrast-cert-consistency.md
@@ -3,11 +3,11 @@
      Per-section owners are tagged below. -->
 # M15: Contrast certification-conditional reporting consistency (ci_accuracy ↔ print)
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** m15-contrast-cert-consistency
 
 ## Goal
 
@@ -122,6 +122,8 @@ stay in the returned object; only interpretive/presentation surfaces follow
   (M15-D1); scope amended — verdict recompute+relabel, plot fourth surface
   added (AC3/T5), measurement fields retained (RR02 rejects the drop/NA
   option). RB02/RR02 archived. T1 done.
+- 2026-07-12: in-progress on m15-contrast-cert-consistency (cut from synced
+  master); no open implementation gate (design fully settled by M15-D1).
 
 ## Decisions
 

--- a/cairn/milestones/M15-contrast-cert-consistency.md
+++ b/cairn/milestones/M15-contrast-cert-consistency.md
@@ -7,7 +7,7 @@
 - **Priority:** normal
 - **Depends on:** —
 - **Principles touched:** —
-- **Branch/PR:** m15-contrast-cert-consistency
+- **Branch/PR:** m15-contrast-cert-consistency · https://github.com/jmgirard/circumplex/pull/39
 
 ## Goal
 
@@ -70,7 +70,7 @@ sites in Tasks below.
 
 - AC1 → T3, T5
 - AC2 → T2, T3
-- AC3 → T4
+- AC3 → T5
 - AC4 → T3, T5
 - AC5 → T5
 
@@ -121,6 +121,9 @@ sites in Tasks below.
   3 stale comments rewritten; roxygen + NEWS updated. Full suite FAIL 0 /
   PASS 1881; `check()` 0/0/0. Added a contrast print snapshot + a data-level
   plot-exclusion test (existing snapshot/plot fixtures were profile-only).
+- 2026-07-12: review consistency gate found a Coverage mis-map (AC3 pointed at
+  T4, but the plot-exclusion work is T5). Gated Coverage amendment: AC3 → T5
+  (authoring slip from RR-ingest). No code/criteria change; back to review.
 
 ## Decisions
 

--- a/cairn/milestones/M15-contrast-cert-consistency.md
+++ b/cairn/milestones/M15-contrast-cert-consistency.md
@@ -18,51 +18,42 @@ milestone-close review.
 
 ## Scope
 
-The object contract is settled by RR02 (see M15-D1): **measured quantities
-stay in the returned object; only interpretive/presentation surfaces follow
-`print.circumplex_ssm()`'s profiles-only certification stance.**
-
-Per M15-D1, the contrast's interpretive/presentation surfaces (verdict,
-print/summary, plot) go unconditional; its measurement columns stay. Concrete
-sites in Tasks below.
+Object contract settled by RR02 (M15-D1): **measured quantities stay in the
+object; the contrast's interpretive/presentation surfaces (verdict,
+print/summary, plot) follow `print.circumplex_ssm()`'s profiles-only stance.**
+Concrete sites in Tasks below.
 
 **In:**
 - **Verdict + print/summary + plot** made unconditional for the contrast
-  (Parameter `"d"`, no "when certified"/"certified displacement" wording;
-  excluded from the "Displacement (certified)" plot panel — the fourth
-  surface RR02 surfaced). Profiles unchanged.
+  (Parameter `"d"`, no "when certified"/"certified displacement"; excluded from
+  the "Displacement (certified)" plot panel — the fourth surface RR02 found).
+  Profiles unchanged.
 - **Object measurements retained** (not dropped): contrast
   `coverage$Coverage_conditional`/`N_conditional` and `guardrail$Cert_rate`
-  (`Caution` NA) kept as documented joint-certification descriptives; three
-  now-stale comments rewritten.
+  (`Caution` NA) kept as documented descriptives; three stale comments rewritten.
 - Supersede "Milestone-close review #3" (`test-ci_accuracy.R:221-250`); re-pin
-  the `ci_accuracy` snapshot (profiles byte-identical); update roxygen
-  `@return` + the `NEWS.md` development bullet.
+  the `ci_accuracy` snapshot (profiles byte-identical); roxygen `@return` + NEWS.
 
-**Out:**
-- Any change to `print.circumplex_ssm()` — already correct; Direction A leaves
-  it untouched (Direction B/C rejected at the plan gate 2026-07-12).
-- NA'ing/removing the contrast's conditional *measurement* fields (RR02 rejects
-  option (b) — destroys a valid selection-effect diagnostic).
-- Guardrail certification-**rule** replacement (print-precision dependence /
-  scale-free rule) → stays its own ROADMAP candidate.
+**Out:** `print.circumplex_ssm()` (already correct; B/C rejected at plan gate);
+NA'ing the contrast's conditional *measurement* fields (RR02 rejects option b);
+guardrail certification-**rule** replacement → its own ROADMAP candidate.
 
 ## Acceptance criteria
 
-- [ ] For a contrast object, `print()`/`summary()` of `ssm_ci_accuracy()`
+- [x] For a contrast object, `print()`/`summary()` of `ssm_ci_accuracy()`
       report the contrast's displacement coverage unconditionally — no "when
       certified" framing on the line and no "certified displacement" wording in
       the verdict paragraph. Evidence: updated `ci_accuracy` snapshot + a test.
-- [ ] The returned object follows M15-D1: the contrast's `verdict` displacement
+- [x] The returned object follows M15-D1: the contrast's `verdict` displacement
       row is recomputed unconditionally with `Parameter == "d"` and
       `N_reps == reps`, while its `coverage$Coverage_conditional`/`N_conditional`
       and `guardrail$Cert_rate` are retained (populated, `Caution` NA). Evidence:
       regression tests pin each field; profiles keep `Parameter == "d_conditional"`.
-- [ ] `plot.circumplex_ci_accuracy()` excludes the contrast series from the
+- [x] `plot.circumplex_ci_accuracy()` excludes the contrast series from the
       "Displacement (certified)" panel. Evidence: a test on the built plot data.
-- [ ] Profile-side output is byte-unchanged (`ssm_certified()` and profile
+- [x] Profile-side output is byte-unchanged (`ssm_certified()` and profile
       reporting untouched). Evidence: profile portions of the snapshot identical.
-- [ ] Roxygen `@return` documents the contrast rule on all surfaces; the
+- [x] Roxygen `@return` documents the contrast rule on all surfaces; the
       `NEWS.md` development bullet gains the contrast clause; `devtools::check()`
       clean (0 errors / 0 warnings / 0 notes).
 
@@ -144,3 +135,15 @@ doesn't already give. Supersedes "Milestone-close review #3". Milestone-local
 if the "presentation follows print" rule recurs. Source: RR02.
 
 ## Review
+
+**AC evidence (fresh, 2026-07-12, PR #39).** All five verified by command:
+contrast displacement unconditional in print (`... 91.7% -- borderline`, no
+"when certified"; snapshot+test); `verdict` `Parameter=="d"` `N_reps==12` with
+`Coverage_conditional`/`Cert_rate` retained (`Caution` NA); plot excludes
+contrast from the certified panel; profiles byte-identical; `document()` no
+diff; `check()` 0/0/0; full suite FAIL 0 / PASS 1881. Consistency gate PASS (one catch: Coverage AC3→T4 fixed to →T5, gated).
+
+**Independent review (3 lenses, zero findings → nothing to score).** Diff-bug
+(Opus): verdict `k`/`n`, `dkey` wording gating, plot label lookup correct.
+Blame-history (Sonnet): MCR#3 reversal complete, profiles byte-unchanged.
+Prior-PR (Sonnet): no GH-comment evidence.

--- a/man/ssm_ci_accuracy.Rd
+++ b/man/ssm_ci_accuracy.Rd
@@ -64,7 +64,9 @@ A \code{circumplex_ci_accuracy} object: a list with \code{coverage} (per
 Profile x Parameter x Condition: coverage, its Monte Carlo SE, the
 one-sided miss rates, median CI width, and for displacement the
 certification-conditional coverage with the number of certified
-replicates behind it; \code{Structural} flags the amplitude rows whose zero
+replicates behind it -- for a contrast row this conditional column is
+retained as a joint-certification descriptive that no display consumes;
+\code{Structural} flags the amplitude rows whose zero
 coverage is a theorem rather than a measurement), \code{guardrail} (per
 Profile x Condition: certification rate with its 95\% Wilson score
 interval, the user-expectation benchmark \code{(1 - interval) / 2}, the
@@ -76,7 +78,10 @@ rate, and the
 branch-pathology rate -- the rate at which a displacement point estimate
 falls geometrically outside its own interval), \code{verdict}
 (Wilson-vs-Bradley classification of elevation, amplitude, and
-conditional displacement coverage at the as-estimated condition, plus an
+displacement coverage at the as-estimated condition -- a profile's
+displacement is classified certification-conditionally (\code{Parameter}
+\code{"d_conditional"}), a contrast's unconditionally (\code{Parameter} \code{"d"}) --
+plus an
 overall worst-of row per profile; note the printed verdict headline
 additionally elevates to CAUTION whenever the guardrail \code{Caution} fired,
 so it can read worse than the overall coverage class),
@@ -112,8 +117,14 @@ also reported conditional on certification under the shipped decision rule
 \code{round(a_lci, digits) > 0} (the rule the printed \code{\link[=ssm_analyze]{ssm_analyze()}} output
 applies); the
 implied certification threshold, \code{0.5 * 10^-digits} in amplitude units, is
-echoed in the output because it is scale-dependent. For a contrast row,
-"certified" means both profile rows were certified.
+echoed in the output because it is scale-dependent. A contrast row is a
+signed difference, not a prototypicality measure, so
+\code{print.circumplex_ssm()} never certification-gates it; its displacement
+verdict and printed coverage are therefore reported unconditionally
+(matching that profiles-only stance). Its certification-conditional
+coverage -- where "certified" means both profile rows were certified -- is
+still computed and retained in the returned object as a descriptive that no
+display consumes.
 
 The \code{amplitude_factors} ladder manufactures populations whose closed-form
 amplitude is scaled toward zero (the regime where percentile amplitude

--- a/tests/testthat/_snaps/ci_accuracy.md
+++ b/tests/testthat/_snaps/ci_accuracy.md
@@ -109,3 +109,57 @@
                    0                     0     30
                    0                     0     30
 
+# contrast print block reports displacement unconditionally (M15 snapshot)
+
+    Code
+      print(res)
+    Output
+      
+      SSM CI accuracy, simulated at your n and settings (12 replications per condition; bootstrap intervals with 60 replicates at level 0.95)
+      
+        # Profile [Female] (n = 118; 95% bootstrap CIs, 60 replicates):
+          Elevation      coverage 91.7% -- borderline
+          Amplitude      coverage 75.0% -- INADEQUATE (under-coverage; misses fall
+                         on both sides of the interval)
+          Displacement   coverage 83.3% when certified -- borderline
+          Guardrail      if the true amplitude were zero, displacement would still
+                         be certified 100.0% of the time -- the "amplitude CI
+                         excludes zero" rule is far weaker than the 2.5% error rate
+                         its wording suggests
+        Verdict: CAUTION -- amplitude CIs are less reliable than nominal at this
+        sample size and the interpretability guardrail provides almost no
+        protection against a truly zero amplitude. Elevation and certified
+        displacement coverage rates are borderline at this number of replications;
+        a larger `reps` would sharpen the verdict. Consider a larger sample or
+        treat near-zero amplitudes as inconclusive rather than absent.
+      
+        # Profile [Male] (n = 122; 95% bootstrap CIs, 60 replicates):
+          Elevation      coverage 91.7% -- borderline
+          Amplitude      coverage 75.0% -- INADEQUATE (under-coverage; misses are
+                         almost all below the interval: the amplitude CI tends to
+                         sit above the truth)
+          Displacement   coverage 66.7% when certified -- INADEQUATE
+                         (under-coverage)
+          Guardrail      if the true amplitude were zero, displacement would still
+                         be certified 100.0% of the time -- the "amplitude CI
+                         excludes zero" rule is far weaker than the 2.5% error rate
+                         its wording suggests
+        Verdict: CAUTION -- amplitude CIs are less reliable than nominal at this
+        sample size, displacement CIs mis-cover even when certified, and the
+        interpretability guardrail provides almost no protection against a truly
+        zero amplitude. Elevation coverage is borderline at this number of
+        replications; a larger `reps` would sharpen the verdict. Consider a larger
+        sample or treat near-zero amplitudes as inconclusive rather than absent.
+      
+        # Contrast [Male - Female] (95% bootstrap CIs, 60 replicates):
+          Elevation      coverage 100.0% -- borderline
+          Amplitude      coverage 75.0% -- INADEQUATE (under-coverage; misses are
+                         almost all below the interval: the amplitude CI tends to
+                         sit above the truth)
+          Displacement   coverage 91.7% -- borderline
+        Verdict: CAUTION -- amplitude CIs are less reliable than nominal at this
+        sample size. Elevation and displacement coverage rates are borderline at
+        this number of replications; a larger `reps` would sharpen the verdict.
+        Consider a larger sample or treat near-zero amplitudes as inconclusive
+        rather than absent.
+

--- a/tests/testthat/test-ci_accuracy.R
+++ b/tests/testthat/test-ci_accuracy.R
@@ -218,11 +218,14 @@ test_that("suff-stats fallback resolves recorded-call args from the caller's env
   expect_no_error(run(dat))
 })
 
-test_that("contrast row carries no false-certification guardrail (print never gates it)", {
-  # Milestone-close review #3: print.circumplex_ssm() applies no certification
-  # gate to a contrast, so the diagnostic must not report a false-cert verdict
-  # for the contrast row -- only the joint-certification rate that conditions
-  # its certified-displacement coverage.
+test_that("contrast displacement is reported unconditionally, matching print (M15/M15-D1)", {
+  # M15 supersedes Milestone-close review #3: print.circumplex_ssm() applies no
+  # certification gate to a contrast (Delta-a is a signed difference, not a
+  # prototypicality measure), so ssm_ci_accuracy() reports the contrast's
+  # displacement UNCONDITIONALLY. Per M15-D1 the interpretive/presentation
+  # surfaces move (verdict Class recomputed unconditionally, Parameter "d"),
+  # while the measurement columns (Coverage_conditional, Cert_rate) are
+  # retained as documented joint-certification descriptives.
   data("jz2017")
   jz <- jz2017[1:240, ]
   set.seed(311)
@@ -233,18 +236,41 @@ test_that("contrast row carries no false-certification guardrail (print never ga
                          structure = "observed")
 
   con_lab <- names(res$details$row_n)[length(res$details$row_n)]
+  prof_labs <- setdiff(unique(res$verdict$Profile), con_lab)
+
+  # Verdict (interpretation moves): contrast displacement row is unconditional
+  # -- Parameter "d", n = reps; profiles keep the certification-conditional "d".
+  con_v <- res$verdict[res$verdict$Profile == con_lab, ]
+  expect_true("d" %in% con_v$Parameter)
+  expect_false("d_conditional" %in% con_v$Parameter)
+  expect_equal(con_v$N_reps[con_v$Parameter == "d"], 12)
+  prof_v <- res$verdict[res$verdict$Profile %in% prof_labs, ]
+  expect_true("d_conditional" %in% prof_v$Parameter)
+  expect_false("d" %in% prof_v$Parameter)
+
+  # Object (measurement stays): the contrast keeps its conditional coverage and
+  # its joint-certification rate; Caution is NA (no false-cert verdict).
+  con_cov <- res$coverage[res$coverage$Profile == con_lab &
+                            res$coverage$Parameter == "d", ]
+  expect_true(any(!is.na(con_cov$Coverage_conditional)))
   con_g <- res$guardrail[res$guardrail$Profile == con_lab, ]
   prof_g0 <- res$guardrail[res$guardrail$Profile != con_lab &
                              res$guardrail$Condition == 0, ]
-  # Contrast Caution is NA at every rung; profile rows still carry the c = 0
-  # logical decision; the contrast's conditioning Cert_rate is still reported.
   expect_true(all(is.na(con_g$Caution)))
   expect_true(all(!is.na(prof_g0$Caution)))
   expect_true(all(is.finite(con_g$Cert_rate[con_g$Condition == 0])))
 
-  # print()/summary() never frame the contrast as certified; wording bar holds.
-  out <- paste(c(capture.output(print(res)), capture.output(summary(res))),
-               collapse = "\n")
+  # print()/summary() (presentation follows print): the CONTRAST block reports
+  # displacement with no "when certified" and no "certified displacement"
+  # wording; profile blocks still may. Wording bar (no significance framing).
+  po <- capture.output(print(res))
+  ci <- grep("# Contrast \\[", po)
+  expect_length(ci, 1)
+  con_block <- po[ci:length(po)]
+  expect_false(any(grepl("when certified", con_block, fixed = TRUE)))
+  expect_false(any(grepl("certified displacement", con_block, fixed = TRUE)))
+
+  out <- paste(c(po, capture.output(summary(res))), collapse = "\n")
   expect_false(any(grepl("contrast displacement would", out, fixed = TRUE)))
   expect_false(any(grepl("significan", out)))
 })
@@ -778,6 +804,23 @@ test_that("print and summary snapshots (seeded)", {
   expect_snapshot(summary(res), transform = mask_elapsed)
 })
 
+test_that("contrast print block reports displacement unconditionally (M15 snapshot)", {
+  # Local-only format pin for the contrast block: the displacement line carries
+  # no "when certified" suffix and the verdict paragraph no "certified
+  # displacement" wording (M15-D1). Profile blocks are covered above.
+  skip_on_ci()
+  skip_on_cran()
+  data("jz2017")
+  jz <- jz2017[1:240, ]
+  set.seed(311)
+  obj <- ssm_analyze(jz, scales = PANO(), grouping = "Gender",
+                     contrast = TRUE, boots = 60)
+  set.seed(312)
+  res <- ssm_ci_accuracy(obj, reps = 12, amplitude_factors = c(1, 0),
+                         structure = "observed")
+  expect_snapshot(print(res))
+})
+
 # ---- plot method (spec sec. 7) --------------------------------------------------
 
 test_that("plot.circumplex_ci_accuracy builds a faceted coverage plot", {
@@ -799,4 +842,24 @@ test_that("plot.circumplex_ci_accuracy builds a faceted coverage plot", {
   # One panel per parameter, including the certified-displacement panel
   expect_equal(length(unique(built$layout$layout$PANEL)), 6)
   vdiffr::expect_doppelganger("ci accuracy ladder plot", p)
+})
+
+test_that("plot excludes the contrast from the certified-displacement panel (M15)", {
+  # Presentation surface follows print's profiles-only certification (M15-D1):
+  # the contrast appears in "Displacement" (unconditional) but not in
+  # "Displacement (certified)". Data-level assertion -- no vdiffr/platform dep.
+  data("jz2017")
+  jz <- jz2017[1:240, ]
+  set.seed(311)
+  obj <- ssm_analyze(jz, scales = PANO(), grouping = "Gender",
+                     contrast = TRUE, boots = 60)
+  set.seed(312)
+  res <- ssm_ci_accuracy(obj, reps = 12, amplitude_factors = c(1, 0),
+                         structure = "observed")
+  con_lab <- names(res$details$row_n)[length(res$details$row_n)]
+  dfp <- plot(res)$data
+  dcert <- dfp[dfp$Panel == "Displacement (certified)", ]
+  expect_false(con_lab %in% as.character(dcert$Profile))
+  disp <- dfp[dfp$Panel == "Displacement", ]
+  expect_true(con_lab %in% as.character(disp$Profile))
 })


### PR DESCRIPTION
Makes `ssm_ci_accuracy()` report a contrast row's displacement coverage and verdict **unconditionally**, matching `print.circumplex_ssm()`'s profiles-only certification stance (a contrast's Δamplitude is a signed difference, not a prototypicality measure, so print never certification-gates it). Resolves the split left by the M4 milestone-close review #3.

Design settled by an independent Fable review (RB02 → RR02): **measured quantities stay in the returned object; only interpretive/presentation surfaces follow print.**

- `ssm_ci_verdict()`: contrast displacement classified on unconditional coverage, `Parameter == "d"` (profiles keep `"d_conditional"`).
- print/summary: contrast displacement line drops "when certified"; verdict paragraph uses plain "displacement".
- `plot.circumplex_ci_accuracy()`: contrast excluded from the "Displacement (certified)" panel (the fourth surface RR02 surfaced).
- Object measurements retained: `coverage$Coverage_conditional`/`N_conditional` and `guardrail$Cert_rate` stay populated as joint-certification descriptives; three stale comments rewritten; roxygen `@return` + NEWS document the rule.

Tests: superseded the old contrast test with M15 assertions; added a contrast print snapshot and a data-level plot-exclusion test. Full suite FAIL 0 / PASS 1881; `devtools::check()` 0 errors / 0 warnings / 0 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)