### PR TITLE
M18: CIRCUM free-scaling covariance family

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -166,17 +166,24 @@ Structure", for a worked introduction to both.
   (point estimates are deterministic). On the correlation-matrix path,
   intervals are analytic (Wald) — there is no raw data to resample — and
   `summary()` cautions when the sample size is small enough that these may
-  mis-cover.
+  mis-cover. A `scaling` argument selects the covariance-scaling family:
+  `"unit"` (the default) fits the correlation structure, while `"free"` fits
+  Browne's covariance structure with `p` free variance scales — the
+  parameterization CIRCUM and CircE use — so `cpm_fit()` can reproduce their
+  published output exactly. Free scaling adds `p` parameters without changing
+  the degrees of freedom, and reports the fitted variance ratios in a
+  `VarRatio` column (without confidence intervals).
 
 * The `cpm_fit()` estimator has been validated against the published
   CIRCUM/CircE literature (Grassi, Luccio, & Di Blas, 2010, reanalyzing
   Browne's 1992 vocational-interest example) and against independent
   OpenMx and lavaan implementations of the same model (both now in Suggests
-  as test oracles only). One documented difference: CIRCUM and CircE fit
-  Browne's covariance parameterization with free variance scalings, so their
-  finite-sample estimates and chi-square differ slightly from `cpm_fit()`'s
-  correlation-structure fit (same degrees of freedom, asymptotically
-  equivalent); see the package's design notes for details. A large seeded
+  as test oracles only). CIRCUM and CircE fit Browne's covariance
+  parameterization with free variance scalings; `cpm_fit(scaling = "free")`
+  fits that same family and reproduces their published estimates, chi-square,
+  and fit indices to printed precision, while the default correlation-structure
+  fit differs from them slightly in finite samples (same degrees of freedom,
+  asymptotically equivalent); see the package's design notes for details. A large seeded
   simulation study measured the coverage of both interval methods: based on
   its results, `summary()` now also cautions about analytic intervals at any
   sample size below 50,000 when the fitted solution is near a parameter

--- a/R/cpm_fit.R
+++ b/R/cpm_fit.R
@@ -72,6 +72,20 @@ cpm_implied_cor <- function(theta, zeta, beta) {
   P
 }
 
+#' Model-implied covariance matrix Sigma = D_sigma P D_sigma (spec sec. 1, M18)
+#'
+#' The free-scaling family's model matrix: rescale the model-implied correlation
+#' `P` by the variance scales `sigma` (Sigma_ij = sigma_i sigma_j P_ij, so
+#' Sigma_ii = sigma_i^2 -- CIRCUM's "reproduced variance"). With `sigma == 1`
+#' this is `P` bit-for-bit (each entry multiplied by 1.0), so the unit path is
+#' unchanged.
+#'
+#' @noRd
+cpm_implied_cov <- function(theta, zeta, beta, sigma) {
+  P <- cpm_implied_cor(theta, zeta, beta)
+  (sigma %o% sigma) * P
+}
+
 # ---- ML discrepancy ---------------------------------------------------------
 
 #' ML discrepancy F (design sec. 3.1)
@@ -99,11 +113,21 @@ cpm_discrepancy <- function(R, P, ldR = NULL) {
 #'   D circulant         : 0 free angles, 1 free zeta, m free beta
 #'
 #' The free-parameter vector gamma* is laid out as
-#'   [ free-angle radians ] [ zeta logits u ] [ beta free logits v_1..v_m ].
+#'   [ free-angle radians ] [ zeta logits u ] [ sigma logs s ] [ beta free logits v_1..v_m ].
+#' The `s` (log-scale) block is present only under `scaling = "free"` (M18); it
+#' sits BETWEEN zeta and beta so beta stays the trailing block that the boundary
+#' polish (`cpm_spec_reduce`) shrinks from the tail (spec sec. 5, mechanical pin
+#' 1). Under `scaling = "unit"` (default) n_sigma = 0 and every index/count is
+#' bit-identical to the pre-M18 correlation-structure family.
 #'
+#' @param scaling "unit" (Sigma = P, correlation structure; the default and the
+#'   pre-M18 behavior) or "free" (Sigma = D_sigma P D_sigma; CIRCUM's covariance
+#'   structure with p free variance scales, spec sec. 1-2).
 #' @noRd
-cpm_spec <- function(p, m, variant = c("A", "B", "C", "D"), reference = 1) {
+cpm_spec <- function(p, m, variant = c("A", "B", "C", "D"), reference = 1,
+                     scaling = c("unit", "free")) {
   variant <- match.arg(variant)
+  scaling <- match.arg(scaling)
   stopifnot(is_scalar_count(p), p >= 3)
   stopifnot(is_scalar_count(m))
   stopifnot(is_scalar_count(reference), reference <= p)
@@ -122,24 +146,36 @@ cpm_spec <- function(p, m, variant = c("A", "B", "C", "D"), reference = 1) {
 
   free_angles <- if (variant %in% c("A", "C")) (p - 1L) else 0L
   n_zeta <- if (variant %in% c("A", "B")) p else 1L
+  # Free scaling adds p log-variance parameters, all free, no identification pin
+  # (spec sec. 2: the map sigma_i = exp(s_i) is injective and F is coercive in
+  # each sigma_i, so diag P = 1 already identifies the decomposition).
+  n_sigma <- if (scaling == "free") p else 0L
   n_beta_free <- m
 
-  q <- free_angles + n_zeta + n_beta_free
-  df <- p * (p - 1L) / 2L - q
+  q <- free_angles + n_zeta + n_sigma + n_beta_free
+  # df is UNCHANGED by free scaling (spec sec. 4): the free family fits the full
+  # p(p+1)/2 covariance moments with q_corr + p parameters, so
+  # p(p+1)/2 - (q_corr + p) = p(p-1)/2 - q_corr = df_unit. Carry the moment count
+  # explicitly and take df = n_moments - q so both families share one formula
+  # (and cpm_spec_reduce cannot drift from it).
+  n_moments <- if (scaling == "free") p * (p + 1L) / 2L else p * (p - 1L) / 2L
+  df <- n_moments - q
 
-  # index blocks within gamma*
+  # index blocks within gamma* ([angle][u][s][v]); i_sigma is empty under unit.
   i_angle <- if (free_angles > 0) seq_len(free_angles) else integer(0)
   i_zeta <- if (n_zeta > 0) free_angles + seq_len(n_zeta) else integer(0)
-  i_beta <- free_angles + n_zeta + seq_len(n_beta_free)
+  i_sigma <- if (n_sigma > 0) free_angles + n_zeta + seq_len(n_sigma) else integer(0)
+  i_beta <- free_angles + n_zeta + n_sigma + seq_len(n_beta_free)
 
   # which theta positions are free (all but the reference), in order
   free_pos <- if (free_angles > 0) setdiff(seq_len(p), reference) else integer(0)
 
   list(
-    p = p, m = m, variant = variant, reference = reference,
-    free_angles = free_angles, n_zeta = n_zeta, n_beta_free = n_beta_free,
-    q = q, df = df,
-    i_angle = i_angle, i_zeta = i_zeta, i_beta = i_beta,
+    p = p, m = m, variant = variant, reference = reference, scaling = scaling,
+    free_angles = free_angles, n_zeta = n_zeta, n_sigma = n_sigma,
+    n_beta_free = n_beta_free,
+    q = q, df = df, n_moments = n_moments,
+    i_angle = i_angle, i_zeta = i_zeta, i_sigma = i_sigma, i_beta = i_beta,
     free_pos = free_pos,
     keep_k = 0:m,             # harmonics with a free beta (0..m unless polished)
     theta_ref_val = NA_real_  # filled by cpm_engine (reference theoretical angle)
@@ -151,10 +187,12 @@ cpm_spec <- function(p, m, variant = c("A", "B", "C", "D"), reference = 1) {
 #' Pack natural parameters into the unconstrained vector gamma* (design sec. 3.3)
 #'
 #' zeta -> logit u; beta -> softmax free logits v (v_0 = 0 fixed); free angles
-#' pass through unchanged (identity map, held on the real line).
+#' pass through unchanged (identity map, held on the real line); sigma -> log s
+#' (free scaling only; s_i = log sigma_i, spec sec. 2). `sigma` defaults to all
+#' ones (s = 0), the starts convention and a no-op under unit scaling.
 #'
 #' @noRd
-cpm_pack <- function(theta, zeta, beta, spec) {
+cpm_pack <- function(theta, zeta, beta, spec, sigma = rep(1, spec$p)) {
   g <- numeric(spec$q)
   if (spec$free_angles > 0) {
     g[spec$i_angle] <- theta[spec$free_pos]
@@ -162,6 +200,10 @@ cpm_pack <- function(theta, zeta, beta, spec) {
   if (spec$n_zeta > 0) {
     z <- if (spec$n_zeta == 1L) zeta[[1]] else zeta
     g[spec$i_zeta] <- stats::qlogis(z)
+  }
+  if (spec$n_sigma > 0) {
+    stopifnot(all(sigma > 0))
+    g[spec$i_sigma] <- log(sigma)
   }
   # softmax inverse with v_0 = 0 over the KEPT harmonics (keep_k; identity
   # 0..m unless polished): v_k = log(beta_k) - log(beta_0). A zero kept beta
@@ -198,6 +240,8 @@ cpm_unpack <- function(gstar, spec) {
   } else {
     zeta <- rep(stats::plogis(gstar[spec$i_zeta]), p)
   }
+  # sigma = exp(s) (free scaling); unit scaling has no s block => sigma == 1.
+  sigma <- if (spec$n_sigma > 0) exp(gstar[spec$i_sigma]) else rep(1, p)
   v <- c(0, gstar[spec$i_beta])
   ev <- exp(v - max(v))                     # softmax (max-shift for stability)
   b_keep <- ev / sum(ev)
@@ -205,7 +249,7 @@ cpm_unpack <- function(gstar, spec) {
   # (polished-out) harmonics are 0. When keep_k == 0:m this is the identity.
   beta <- numeric(spec$m + 1L)
   beta[spec$keep_k + 1L] <- b_keep
-  list(theta = theta, zeta = zeta, beta = beta)
+  list(theta = theta, zeta = zeta, beta = beta, sigma = sigma)
 }
 
 # ---- objective and gradient in unconstrained coordinates --------------------
@@ -214,8 +258,15 @@ cpm_unpack <- function(gstar, spec) {
 #' @noRd
 cpm_objective <- function(gstar, R, spec, ldR = NULL) {
   nat <- cpm_unpack(gstar, spec)
-  P <- cpm_implied_cor(nat$theta, nat$zeta, nat$beta)
-  cpm_discrepancy(R, P, ldR = ldR)
+  # Unit scaling fits P (correlation structure); free scaling fits
+  # Sigma = D_sigma P D_sigma (spec sec. 1). cpm_discrepancy accepts a non-unit
+  # diagonal model matrix (the published-F-hat identity test proves it).
+  M <- if (spec$n_sigma > 0) {
+    cpm_implied_cov(nat$theta, nat$zeta, nat$beta, nat$sigma)
+  } else {
+    cpm_implied_cor(nat$theta, nat$zeta, nat$beta)
+  }
+  cpm_discrepancy(R, M, ldR = ldR)
 }
 
 #' Analytic gradient of F at gamma* (design sec. 3.4)
@@ -233,6 +284,7 @@ cpm_gradient <- function(gstar, R, spec) {
   nat <- cpm_unpack(gstar, spec)
   theta <- nat$theta; zeta <- nat$zeta; beta <- nat$beta
 
+  sigma <- nat$sigma
   Delta <- outer(theta, theta, `-`)
   # Build P inline from a single cpm_rho() so the harmonic matrix and outer()
   # are computed once, not again inside cpm_implied_cor(): Rho is reused for
@@ -241,12 +293,30 @@ cpm_gradient <- function(gstar, R, spec) {
   Rho <- cpm_rho(Delta, beta)               # p x p, diag 1 (zeroed for dF/dzeta)
   P <- (zeta %o% zeta) * Rho
   diag(P) <- 1                              # I - D_zeta^2 restores the unit diag
-  Pinv <- solve(P)
-  A <- Pinv - Pinv %*% R %*% Pinv           # symmetric
-  A <- (A + t(A)) / 2
 
-  # B = A * (zeta zeta^T), diagonal zeroed (only off-diagonal dP enter).
-  B <- A * (zeta %o% zeta)
+  # Core differential (spec sec. 3): dF = tr(A dM), A = M^-1 - M^-1 R M^-1 for
+  # the model matrix M. The gamma (theta/zeta/beta) blocks read a WEIGHTED A:
+  # A-tilde = D_sigma A D_sigma (because dM = D_sigma dP D_sigma; diag dP = 0
+  # since diag P = 1 identically in the gamma parameterization). Under free
+  # scaling M = Sigma and the essential substitution is Sigma^-1 for P^-1 --
+  # they differ EVERYWHERE, not just on the diagonal. Under unit scaling M = P,
+  # A-tilde = A, and every line below is bit-identical to the pre-M18 path
+  # (sigma == 1 makes each `sigma %o% sigma` a multiply by 1.0).
+  if (spec$n_sigma > 0) {
+    Sigma <- (sigma %o% sigma) * P
+    Minv <- solve(Sigma)
+    A <- Minv - Minv %*% R %*% Minv         # symmetric
+    A <- (A + t(A)) / 2
+    At <- (sigma %o% sigma) * A             # A-tilde weights the gamma blocks
+  } else {
+    Minv <- solve(P)
+    A <- Minv - Minv %*% R %*% Minv         # symmetric
+    A <- (A + t(A)) / 2
+    At <- A
+  }
+
+  # B = A-tilde * (zeta zeta^T), diagonal zeroed (only off-diagonal dP enter).
+  B <- At * (zeta %o% zeta)
   diag(B) <- 0
 
   Rhod <- cpm_rho_deriv(Delta, beta)        # p x p
@@ -255,19 +325,27 @@ cpm_gradient <- function(gstar, R, spec) {
   # dF/dtheta_i (length p); reference component is dropped later.
   dF_dtheta <- 2 * rowSums(B * Rhod)
 
-  # dF/dzeta_i: 2 * (A * rho with diag 0) %*% zeta
-  Azero <- A * Rho
+  # dF/dzeta_i: 2 * (A-tilde * rho with diag 0) %*% zeta
+  Azero <- At * Rho
   diag(Azero) <- 0
   dF_dzeta <- 2 * as.numeric(Azero %*% zeta)
 
   # dF/dbeta_k over the kept harmonics (keep_k; identity 0..m unless polished)
   dF_dbeta <- vapply(spec$keep_k, function(k) sum(B * cos(k * Delta)), numeric(1))
 
+  # dF/ds_i = 2 (1 - (Sigma^-1 R)_ii) (spec sec. 3; free scaling only). The log
+  # map is already chained in. (Sigma^-1 R)_ii = rowSums(Minv * R) by symmetry.
+  dF_ds <- if (spec$n_sigma > 0) 2 * (1 - rowSums(Minv * R)) else numeric(0)
+
   # ---- chain to unconstrained coordinates ----
   g <- numeric(spec$q)
 
   if (spec$free_angles > 0) {
     g[spec$i_angle] <- dF_dtheta[spec$free_pos]   # angle Jacobian = 1
+  }
+
+  if (spec$n_sigma > 0) {
+    g[spec$i_sigma] <- dF_ds                      # log-map Jacobian already in dF_ds
   }
 
   if (spec$n_zeta == p) {
@@ -468,8 +546,9 @@ cpm_canonicalize <- function(gstar, spec, theta_theory) {
 #' @param reference index of the scale whose angle is fixed (design sec. 2.1).
 #' @noRd
 cpm_engine <- function(R, angles, m = 3, variant = c("A", "B", "C", "D"),
-                       reference = 1) {
+                       reference = 1, scaling = c("unit", "free")) {
   variant <- match.arg(variant)
+  scaling <- match.arg(scaling)
   R <- as.matrix(R)
   p <- nrow(R)
 
@@ -493,7 +572,7 @@ cpm_engine <- function(R, angles, m = 3, variant = c("A", "B", "C", "D"),
   # making F(R, R) != 0 by the asymmetry magnitude.
   R <- (R + t(R)) / 2
 
-  spec <- cpm_spec(p, m, variant, reference)
+  spec <- cpm_spec(p, m, variant, reference, scaling = scaling)
 
   # df >= 1 required; df = 0 allowed but warns (design sec. 1.4/sec. 4).
   if (spec$df < 0) {
@@ -573,11 +652,15 @@ cpm_engine <- function(R, angles, m = 3, variant = c("A", "B", "C", "D"),
   for (i in setdiff(seq_along(runs), best)) {
     par_i <- runs[[i]]$par
     nat_i <- cpm_unpack(par_i, spec)
-    # zeta/beta compared on the NATURAL scale: an absolute tolerance on the
-    # logit scale explodes near a Heywood boundary (d logit/d zeta ~ 200 at
-    # zeta = 0.995), where a true mirror would be misread as distinct.
+    # zeta/beta/sigma compared on the NATURAL scale: an absolute tolerance on
+    # the logit scale explodes near a Heywood boundary (d logit/d zeta ~ 200 at
+    # zeta = 0.995), where a true mirror would be misread as distinct. The sigma
+    # block MUST enter (spec sec. 5, pin 3): two optima differing only in sigma
+    # is a genuine non-identification signature the angle/zeta/beta comparison
+    # would miss. Under unit scaling sigma == 1 for both, so this is a no-op.
     other_eq <- max(abs(nat_i$zeta - nat_best$zeta)) < 1e-4 &&
-      max(abs(nat_i$beta - nat_best$beta)) < 1e-4
+      max(abs(nat_i$beta - nat_best$beta)) < 1e-4 &&
+      max(abs(nat_i$sigma - nat_best$sigma)) < 1e-4
     if (spec$free_angles > 0) {
       # Angle comparisons must be circular: a scale exactly opposite the
       # reference has relative angle +pi in BOTH mirrors (angle_dist maps the
@@ -684,6 +767,12 @@ cpm_engine <- function(R, angles, m = 3, variant = c("A", "B", "C", "D"),
   }
 
   heywood <- any(nat$zeta > 0.995)
+  # Data-pathology note (free scaling only; spec sec. 5, pin 5): a fitted
+  # variance ratio sigma^2 far from 1 on unit-diagonal input signals a
+  # scale/model mismatch. NOT a boundary flag (the optimum is interior by
+  # coercivity) and NOT wired into the CI-coverage markers.
+  sigma_pathology <- spec$n_sigma > 0 &&
+    any(nat$sigma^2 < 0.5 | nat$sigma^2 > 2)
 
   # wrapped-to-[0,360) reported angles; keep unwrapped radians too.
   theta_deg <- as.numeric(as_degree(as_radian(nat$theta %% (2 * pi))))
@@ -695,6 +784,9 @@ cpm_engine <- function(R, angles, m = 3, variant = c("A", "B", "C", "D"),
     theta_theory = as.numeric(as_degree(as_radian(theta_theory %% (2 * pi)))),
     zeta = nat$zeta,
     beta = nat$beta,
+    sigma = nat$sigma,                 # length p; all 1 under unit scaling
+    scaling = spec$scaling,
+    sigma_pathology = sigma_pathology,
     F = fit$F,
     df = spec$df,
     # m as FITTED (design sec. 3.5/sec. 5.4): decreases iff the polish removed the
@@ -702,7 +794,11 @@ cpm_engine <- function(R, angles, m = 3, variant = c("A", "B", "C", "D"),
     m = max(spec$keep_k),
     variant = spec$variant,
     reference = reference,
-    P = cpm_implied_cor(nat$theta, nat$zeta, nat$beta),
+    # Model-implied matrix: Sigma = D_sigma P D_sigma under free scaling
+    # (non-unit diagonal), P under unit scaling. Used as Phat downstream, so the
+    # reported residuals R - Phat and SRMR carry the free family's non-zero
+    # diagonal residuals (1 - sigma^2; spec sec. 4).
+    P = cpm_implied_cov(nat$theta, nat$zeta, nat$beta, nat$sigma),
     accepted = accepted,
     nlminb_code = fit$code,            # ADVISORY only
     gradient_norm = gnorm,
@@ -734,9 +830,14 @@ cpm_spec_reduce <- function(spec, keep_k) {
   rspec <- spec
   rspec$keep_k <- keep_k
   rspec$n_beta_free <- length(keep_k) - 1L
-  rspec$q <- spec$free_angles + spec$n_zeta + rspec$n_beta_free
-  rspec$df <- spec$p * (spec$p - 1L) / 2L - rspec$q
-  rspec$i_beta <- spec$free_angles + spec$n_zeta + seq_len(rspec$n_beta_free)
+  # Polish only removes trailing beta harmonics; the sigma block is untouched
+  # (position-stable, ahead of beta -- spec sec. 5, mechanical pin 1), so it
+  # stays in q and i_sigma is unchanged. Reuse the spec's moment count so df
+  # cannot drift from cpm_spec (unit p(p-1)/2, free p(p+1)/2).
+  rspec$q <- spec$free_angles + spec$n_zeta + spec$n_sigma + rspec$n_beta_free
+  rspec$df <- spec$n_moments - rspec$q
+  rspec$i_beta <- spec$free_angles + spec$n_zeta + spec$n_sigma +
+    seq_len(rspec$n_beta_free)
   rspec
 }
 
@@ -772,6 +873,8 @@ cpm_polish_beta <- function(fit, R, spec) {
   g0 <- numeric(rspec$q)
   if (spec$free_angles > 0) g0[rspec$i_angle] <- fit$par[spec$i_angle]
   if (spec$n_zeta > 0) g0[rspec$i_zeta] <- fit$par[spec$i_zeta]
+  # sigma block is position-stable across the reduce (spec sec. 5, pin 1).
+  if (spec$n_sigma > 0) g0[rspec$i_sigma] <- fit$par[spec$i_sigma]
   v <- log(beta_keep) - log(beta_keep[1])
   g0[rspec$i_beta] <- v[-1]
 
@@ -1228,6 +1331,18 @@ cpm_boundary_proximity <- function(object) {
 #'   (default; free angles and communalities), `"constrained-angles"` (angles
 #'   fixed at their theoretical values), `"equal-communality"` (a single shared
 #'   communality), or `"circulant"` (both constraints).
+#' @param scaling The covariance-scaling family, orthogonal to `model`:
+#'   `"unit"` (default) fits the correlation structure with a unit model-implied
+#'   diagonal (the historical behaviour); `"free"` fits Browne's covariance
+#'   structure \eqn{\Sigma = D_\sigma P D_\sigma} with `p` free variance scales,
+#'   the parameterization CIRCUM and CircE use, so `cpm_fit()` can reproduce
+#'   their published output exactly. Free scaling adds `p` parameters but leaves
+#'   the degrees of freedom unchanged (it fits the `p` extra diagonal
+#'   covariance moments). The fitted \eqn{\hat\sigma^2} are reported as a
+#'   `VarRatio` column (the ratio of reproduced to input variance); they carry
+#'   no confidence interval, and the analytic intervals for the remaining
+#'   parameters are not yet coverage-validated for this family (`summary()`
+#'   cautions). The input is still a correlation matrix (unit diagonal).
 #' @param reference The index into `scales` of the variable whose angle is fixed
 #'   at its theoretical value to identify the rotation (default = 1).
 #' @param interval The confidence level for the parameter intervals (default =
@@ -1292,12 +1407,14 @@ cpm_fit <- function(data = NULL, scales = NULL, angles = octants(),
                     cormat = NULL, n = NULL, m = 3,
                     model = c("quasi-circumplex", "constrained-angles",
                               "equal-communality", "circulant"),
+                    scaling = c("unit", "free"),
                     reference = 1, interval = 0.95,
                     ci_method = c("bootstrap", "analytic"),
                     boots = 2000, listwise = TRUE) {
 
   call <- match.call()
   model <- match.arg(model)
+  scaling <- match.arg(scaling)
   # Path-conditional default (design sec. 5.2): bootstrap on the raw-data
   # path, analytic on the cormat path (nothing to resample there). Only an
   # EXPLICIT bootstrap request with `cormat` is an error.
@@ -1382,7 +1499,7 @@ cpm_fit <- function(data = NULL, scales = NULL, angles = octants(),
 
   # ---- fit the engine (deterministic; RNG is consumed only by the bootstrap) ----
   engine <- cpm_engine(R, angles = angles, m = m, variant = variant,
-                       reference = reference)
+                       reference = reference, scaling = scaling)
 
   # ---- fit indices ----
   q <- engine$spec$q
@@ -1432,6 +1549,13 @@ cpm_fit <- function(data = NULL, scales = NULL, angles = octants(),
     Communality = engine$zeta^2,
     stringsAsFactors = FALSE
   )
+  # Free scaling reports sigma^2 = Sigma_ii, CIRCUM's ratio of reproduced to
+  # input variance (M18-D2). Estimate-only (no CI ever; spec sec. 4), and the
+  # column is present ONLY under free scaling -- under unit scaling sigma^2 == 1
+  # by construction (a fixed constraint, not an estimate), so it is omitted.
+  if (identical(scaling, "free")) {
+    results$VarRatio <- engine$sigma^2
+  }
 
   betas <- data.frame(
     k = 0:engine$spec$m,
@@ -1457,6 +1581,9 @@ cpm_fit <- function(data = NULL, scales = NULL, angles = octants(),
     m_requested = m,
     model = model,
     variant = variant,
+    scaling = scaling,
+    sigma = engine$sigma,                     # length p (all 1 under unit)
+    sigma_pathology = engine$sigma_pathology,
     reference = reference,
     scales = scales,
     ci_method = ci_method,
@@ -1522,9 +1649,12 @@ cpm_fit <- function(data = NULL, scales = NULL, angles = octants(),
 #'   number.
 #' @return A numeric matrix with `n` rows and one column per fitted scale,
 #'   columns in the fitted scale order with `colnames` set to the scale names
-#'   (`rownames` are `NULL`). The population margins are zero-mean and
-#'   unit-variance, so `cor()` of the returned matrix converges to
-#'   `object$matrices$Phat` as `n` grows.
+#'   (`rownames` are `NULL`). The population covariance is
+#'   `object$matrices$Phat`, so `cov()` of the returned matrix converges to it
+#'   as `n` grows. Under the default unit scaling `Phat` is a correlation matrix
+#'   (zero-mean, unit-variance margins), so `cor()` converges to it too; under
+#'   `scaling = "free"` the margins carry the fitted variance ratios
+#'   \eqn{\hat\sigma^2}.
 #' @section Reproducibility:
 #'   `cpm_simulate()` consumes R's global random number stream (the
 #'   common-factor scores then the unique deviates, drawn in that fixed order),
@@ -1570,6 +1700,7 @@ cpm_sim_root <- function(object) {
   theta <- nat$theta
   zeta <- nat$zeta
   beta <- nat$beta                          # length m + 1; 0 at any removed k
+  sigma <- nat$sigma                        # length p; all 1 under unit scaling
   p <- spec$p
   m <- spec$m
 
@@ -1583,9 +1714,12 @@ cpm_sim_root <- function(object) {
                     sb[k + 1L] * cos(k * theta),
                     sb[k + 1L] * sin(k * theta))
   }
+  # Free scaling generates Sigma = D_sigma P D_sigma: scale each variable's
+  # loadings and uniqueness by sigma_i (spec sec. 1). Under unit scaling
+  # sigma == 1, so this is byte-identical to the correlation-structure draw.
   list(
-    Lambda = zeta * common,                          # D_zeta scales each row
-    uniq = sqrt(pmax(1 - zeta^2, 0)),                # (I - D_zeta^2)^{1/2}, diag
+    Lambda = sigma * zeta * common,                  # D_sigma D_zeta scales rows
+    uniq = sigma * sqrt(pmax(1 - zeta^2, 0)),        # D_sigma (I - D_zeta^2)^{1/2}
     p = p,
     scales = object$details$scales
   )

--- a/R/cpm_oop.R
+++ b/R/cpm_oop.R
@@ -233,7 +233,7 @@ summary.circumplex_cpm <- function(object, digits = 3, ...) {
         "\n  Note: analytic (Wald) confidence intervals for the free-scaling ",
         "family have not\n  been coverage-validated; interpret them with ",
         "caution and prefer the bootstrap\n  on the raw-data path when ",
-        "available. The variance ratios (σ²) carry no interval.\n",
+        "available. The variance ratios (\u03c3\u00b2) carry no interval.\n",
         sep = ""
       )
     } else if (d$N < cpm_analytic_ci_n_caution) {

--- a/R/cpm_oop.R
+++ b/R/cpm_oop.R
@@ -62,6 +62,12 @@ cpm_diagnostic_lines <- function(details) {
       "(\u03b6 > 0.995, a Heywood-type solution).\n"
     ))
   }
+  if (isTRUE(details$sigma_pathology)) {
+    msg <- c(msg, paste0(
+      "  Note: a fitted variance ratio (\u03c3\u00b2) departs materially from 1 ",
+      "(outside [0.5, 2]);\n  the scaling or model may be misspecified.\n"
+    ))
+  }
   if (length(details$removed_harmonics) > 0) {
     msg <- c(msg, paste0(
       "  Note: harmonic(s) ",
@@ -218,7 +224,19 @@ summary.circumplex_cpm <- function(object, digits = 3, ...) {
   # boundary-marker-conditional below cpm_analytic_ci_n_boundary_caution
   # (see the constants in R/cpm_fit.R for the measured coverage behind both).
   if (identical(d$ci_method, "analytic")) {
-    if (d$N < cpm_analytic_ci_n_caution) {
+    if (identical(d$scaling, "free")) {
+      # Free-scaling analytic CIs are NOT yet coverage-validated (M18-D3): the
+      # free-family coverage oracle is a deferred pre-ship gate, so the
+      # diag-calibrated N thresholds below are not reused as a trust boundary
+      # here. Unconditional caution instead.
+      cat(
+        "\n  Note: analytic (Wald) confidence intervals for the free-scaling ",
+        "family have not\n  been coverage-validated; interpret them with ",
+        "caution and prefer the bootstrap\n  on the raw-data path when ",
+        "available. The variance ratios (σ²) carry no interval.\n",
+        sep = ""
+      )
+    } else if (d$N < cpm_analytic_ci_n_caution) {
       cat(
         "\n  Note: analytic (Wald) confidence intervals may materially mis-cover ",
         "at this sample size\n  (N < ", cpm_analytic_ci_n_caution,

--- a/R/ssm_ci_accuracy.R
+++ b/R/ssm_ci_accuracy.R
@@ -82,7 +82,10 @@
 #'   `NULL` uses `min(3, floor((p - 1) / 2))`).
 #' @param cpm Optional. A pre-fitted `circumplex_cpm` object to reuse for the
 #'   population structure instead of refitting (its scales must match the ssm
-#'   object's). Ignored when `structure = "observed"`.
+#'   object's). Must be a unit-scaling fit (the default `cpm_fit()` scaling);
+#'   a free-scaling fit models a covariance structure and is not a valid
+#'   population correlation structure for this diagnostic. Ignored when
+#'   `structure = "observed"`.
 #' @param data Optional. The original data set, required only for ssm objects
 #'   created before sufficient statistics were stored at analysis time; the
 #'   statistics are then recomputed and checked against the stored profile
@@ -203,6 +206,20 @@ ssm_ci_accuracy <- function(ssm_object, reps = 1000,
   structure <- match.arg(structure)
   stopifnot(is.null(m) || is_scalar_count(m))
   stopifnot(is.null(cpm) || inherits(cpm, "circumplex_cpm"))
+  # This diagnostic characterizes the population *correlation* structure and
+  # embeds the cpm's model-implied scale matrix into a joint correlation matrix
+  # (unit-variance scales). A free-scaling fit's `matrices$Phat` is a covariance
+  # (Sigma = D_sigma P D_sigma, diagonal sigma^2 != 1), which would make that
+  # joint matrix internally inconsistent and silently miscalibrate the simulated
+  # coverage. Refuse it (M18 review). A legacy object predating the `scaling`
+  # field (NULL) is a unit fit by construction and passes.
+  if (!is.null(cpm) && !is.null(cpm$details$scaling) &&
+      !identical(cpm$details$scaling, "unit")) {
+    stop("`cpm` must be a unit-scaling fit: ssm_ci_accuracy() characterizes the ",
+         "population correlation structure, but the supplied cpm_fit() object ",
+         "was fitted with scaling = \"", cpm$details$scaling, "\". Refit with the ",
+         "default scaling = \"unit\".", call. = FALSE)
+  }
   parallel <- match.arg(parallel, c("no", "multicore", "snow"))
   stopifnot(is_scalar_count(ncpus))
   # The dimensionless certification constant, single-sourced from the rule it

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | planned | M18 | high | milestones/M7-v2-release-prep.md |
-| M18 | CIRCUM free-scaling — implementation + oracle validation | in-progress | M17 | high | milestones/M18-circum-free-scaling-build.md |
+| M18 | CIRCUM free-scaling — implementation + oracle validation | review | M17 | high | milestones/M18-circum-free-scaling-build.md |
 | M17 | CIRCUM free-scaling — Fable-reviewed design decision + spec | done | — | high | milestones/archive/M17-circum-free-scaling-design.md |
 | M16 | Print-independent, scale-free displacement-certification rule | done | — | high | milestones/archive/M16-cert-rule-replacement.md |
 | M15 | Contrast certification-conditional reporting consistency (ci_accuracy ↔ print) | done | — | normal | milestones/archive/M15-contrast-cert-consistency.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | planned | M18 | high | milestones/M7-v2-release-prep.md |
-| M18 | CIRCUM free-scaling — implementation + oracle validation | planned | M17 | high | milestones/M18-circum-free-scaling-build.md |
+| M18 | CIRCUM free-scaling — implementation + oracle validation | in-progress | M17 | high | milestones/M18-circum-free-scaling-build.md |
 | M17 | CIRCUM free-scaling — Fable-reviewed design decision + spec | done | — | high | milestones/archive/M17-circum-free-scaling-design.md |
 | M16 | Print-independent, scale-free displacement-certification rule | done | — | high | milestones/archive/M16-cert-rule-replacement.md |
 | M15 | Contrast certification-conditional reporting consistency (ci_accuracy ↔ print) | done | — | normal | milestones/archive/M15-contrast-cert-consistency.md |

--- a/cairn/boundary-coverage.md
+++ b/cairn/boundary-coverage.md
@@ -26,6 +26,7 @@ point-estimate level is an engine property tested once, not re-proved per path.
 | Monte Carlo engine | engine-level point estimate (see mean A); pole interval → `:94` | `test-ssm_montecarlo.R:94` | `test-ssm_montecarlo.R:117`, `:224` | `test-ssm_montecarlo.R:141` (flat + singular covariance) |
 | `ssm_ci_accuracy()` | `test-ci_accuracy.R:343` (population peaks at 0/360) | `test-ci_accuracy.R:50` (membership mod 360) | `test-ci_accuracy.R:72`, `:562` | `test-ci_accuracy.R:419` (flat population refused) |
 | SEM (`ssm_sem`) | `test-ssm_sem.R:181`; `test-ssm_sem_groups.R:442` | `test-ssm_sem.R:181`; `test-ssm_sem_groups.R:442`, `:463` | `test-ssm_sem_groups.R:182` (group contrast) | `test-ssm_sem.R:239`, `:58`, `:209`; `test-ssm_sem_groups.R:466` |
+| `cpm_fit()` free scaling (**M18**) | `test-cpm_boundary.R:22`, `:40` (pole item recovers; σ̂ untouched) | shared circular-quantile engine (angle CIs reuse `quantile.circumplex_radian`; σ block orthogonal to angles) → unit-path B | N/A — a CPM fit has no angular contrast estimand | `test-cpm_boundary.R:60`, `:72`, `:86` (singular / zero-variance / near-flat refused, fail-closed) |
 
 ## Audit notes (M11)
 
@@ -41,3 +42,9 @@ point-estimate level is an engine property tested once, not re-proved per path.
 - SEM class C lives only on the grouped path (`ssm_sem` contrasts require
   ≥2 groups); the single-group SEM path has no contrast estimand, so no C cell
   is expected there.
+- **CPM free scaling (M18):** the σ (variance-scale) block is orthogonal to the
+  angle block (spec sec. 5, pins 2–3), so the pole (A) and flat (D) behaviour is
+  the estimator's, exercised on the new `scaling = "free"` path in
+  `test-cpm_boundary.R`. Class B reuses the shared circular-quantile machinery
+  unchanged; class C is not a CPM estimand (no angular contrast). The unit-path
+  CPM pole/flat coverage stays in `test-cpm_fit.R:190`, `:245`.

--- a/cairn/milestones/M18-circum-free-scaling-build.md
+++ b/cairn/milestones/M18-circum-free-scaling-build.md
@@ -39,9 +39,10 @@ published CIRCUM/CircE solution.
 
 ## Acceptance criteria
 
-- [ ] `cpm_fit(..., free_scaling = TRUE)` fits the covariance family and returns
+- [ ] `cpm_fit(..., scaling = "free")` fits the covariance family and returns
       σ̂; a regression test in `tests/testthat/test-cpm_fit.R` exercises the path
-      end-to-end.
+      end-to-end. (AC1 wording amended 2026-07-13: `scaling = c("unit","free")`
+      per spec §7, superseding the plan's `free_scaling = TRUE`.)
 - [ ] Reproduces the OpenMx free-scaling oracle to the tolerance fixed by the
       M17 spec, in `tests/testthat/test-cpm_oracles.R` (the free-scaling OpenMx
       transcription already present there is the oracle).
@@ -91,7 +92,27 @@ published CIRCUM/CircE solution.
   free-scaling split (design gate = M17). Depends on M17's ratified spec and
   go decision — if M17 decides no-go, this milestone is retired unbuilt. In
   v2.0.0 scope per D-008.
+- 2026-07-13: status → in-progress; branch m18-circum-free-scaling cut from
+  synced master. Question gate settled (see Decisions M18-D1..D3).
+- 2026-07-13 (amendment, minor): AC1 wording `free_scaling = TRUE` →
+  `scaling = "free"` per spec §7 (M18-D1).
 
 ## Decisions
+
+- **M18-D1 (API name):** the free-scaling flag is `scaling = c("unit","free")`,
+  default `"unit"` (bit-identical to today), orthogonal to `model` — spec §7's
+  preferred form over the plan's boolean `free_scaling`. Jeff, 2026-07-13.
+- **M18-D2 (σ̂² surface):** report σ̂² (reproduced/input variance ratios) as a
+  `VarRatio` column in `results`, populated/printed **only** on the free path
+  (identically 1 under unit → omitted), no CI. Rationale: unit-mode σ²≡1 is a
+  fixed constraint, not an estimate; column presence is the honest "σ estimated"
+  signal. Jeff leaned toward always-present for assumption transparency — a
+  trivial pre-review flip if preferred. 2026-07-13.
+- **M18-D3 (free-path analytic caution):** on `scaling="free"` + analytic CIs,
+  `summary()` prints an **unconditional** caution that free-family Wald CIs for
+  θ/ζ/β are not yet coverage-validated (the free-family coverage oracle is a
+  deferred pre-ship gate, out of M18 scope per spec §4/§6), never reusing the
+  diag-calibrated N=2000/50000 thresholds as a validated trust boundary. σ has
+  no analytic CI ever (spec §4). Jeff, 2026-07-13.
 
 ## Review

--- a/cairn/milestones/M18-circum-free-scaling-build.md
+++ b/cairn/milestones/M18-circum-free-scaling-build.md
@@ -67,17 +67,24 @@ published CIRCUM/CircE solution.
 
 ## Tasks
 
-- [ ] **T1** — Implement the free-family discrepancy `F(S, Σ)` and its analytic
+- [x] **T1** — Implement the free-family discrepancy `F(S, Σ)` and its analytic
       gradient (diagonal terms per the M17 spec) as internal functions;
       test-first against finite differences at ≥ 50 random feasible points.
       (RB tripwire: no-oracle for the gradient derivation until the FD check and
       the OpenMx oracle both pass — treat FD agreement as the first gate.)
-- [ ] **T2** — Add the σ parameterization/packing and the `free_scaling`
+      Done 2026-07-13: `Ã = D_σ A D_σ` weight + `∂F/∂s = 2(1−(Σ⁻¹R)_ii)`; FD
+      err 2.4e-9, σ=1 legacy identity exact 0. Tests pending (T4/below).
+- [x] **T2** — Add the σ parameterization/packing and the `scaling = "free"`
       argument plumbing through `cpm_fit()` (spec/pack/unpack/starts), holding
-      the existing correlation path bit-identical when `free_scaling = FALSE`.
-- [ ] **T3** — Wire the fit path: canonicalization/identification of σ, df/χ²,
+      the existing correlation path bit-identical when `scaling = "unit"`.
+      Done 2026-07-13: `[angle][u][s][v]` layout, `n_moments`-driven df, s⁰=0
+      starts; full existing suite green (unit path unchanged).
+- [x] **T3** — Wire the fit path: canonicalization/identification of σ, df/χ²,
       CI treatment per spec, and the output surface (σ̂ in the returned object;
-      print/summary). Regression test the end-to-end fit.
+      print/summary). Regression test the end-to-end fit. Done 2026-07-13:
+      `VarRatio` column (free only), free-path analytic caution (M18-D3), σ
+      pathology note, σ-aware `cpm_sim_root`. End-to-end free fit reproduces
+      published fit indices (χ²/RMSEA/CFI/TLI). Formal regression tests below.
 - [ ] **T4** — Validation tests: OpenMx free-scaling oracle to spec tolerance;
       Grassi et al. (2010) published CircE targets to printed precision.
 - [ ] **T5** — Boundary suite on the free-scaling path (peak at 0/360; flat);

--- a/cairn/milestones/M18-circum-free-scaling-build.md
+++ b/cairn/milestones/M18-circum-free-scaling-build.md
@@ -120,6 +120,10 @@ published CIRCUM/CircE solution.
 - 2026-07-13: all tasks done; status → review. Free-scaling covariance family
   reproduces published CircE fit to printed precision (F̂/χ²/RMSEA/CFI/TLI/σ²);
   FD gradient err 2.4e-9; check clean 0/0/0 (NOT_CRAN); full test() green.
+- 2026-07-13 (review): fresh-context fan-out found 1 finding (scored 90):
+  free-scaled Phat (=Σ) fed to `ssm_ci_accuracy(cpm=)` corrupts the correlation
+  population. Fixed on-branch: guard refusing non-unit cpm + roxygen note +
+  regression test. Re-verified: ci_accuracy suite green, cpm suites green.
 
 ## Decisions
 
@@ -168,3 +172,27 @@ AC1→T2,T3 · AC2→T4 · AC3→T4 · AC4→T1,T5 · AC5→T6 — every criteri
 existing task. No DESIGN.md principle changed → `cairn_impact` N/A. Toolchain
 (r-package consistency-gate): R CMD check 0/0/0, roxygen/NAMESPACE regenerated
 and committed.
+
+**Independent fresh-context review (3 lenses + scorer).**
+- **[O] diff-bug:** no correctness findings in the M18 diff — verified unit path
+  bit-identical, gradient (Σ⁻¹/Ã) correct, df/AIC/q counting, σ-index integrity,
+  both oracles. (It cleared the `ssm_ci_accuracy` consumer by checking only the
+  internal unit-fit path and missed the user-supplied `cpm=` path — caught by
+  the blame lens below.)
+- **[S] blame-history:** **1 finding (scored 90, actioned/fixed).** M18 changed
+  `cpm_fit()`'s `matrices$Phat` from a correlation matrix to Σ (diagonal σ²)
+  under free scaling. `ssm_ci_accuracy(structure="cpm", cpm=<free fit>)` embeds
+  that Phat as the scale block of a joint *correlation* matrix (line 371) whose
+  measure↔scale cross-blocks assume unit-variance scales → internally
+  inconsistent population → silently miscalibrated coverage. Reachable only via
+  the user-supplied `cpm=` arg (internal fit is always unit); PSD repair does
+  **not** neutralize it (unit-diag rescale runs only on the eigen-clamp branch).
+  Independently code-verified + fresh-scorer-confirmed (90).
+  **Fix:** `ssm_ci_accuracy()` now refuses a non-unit `cpm` object with a clear
+  message (`R/ssm_ci_accuracy.R`); roxygen documents the unit-scaling
+  requirement; regression test in `test-ci_accuracy.R`. A legacy object with no
+  `scaling` field passes (unit by construction).
+- **[S] prior-PR-comments:** no prior-PR evidence (repo reviews via cairn
+  commits, not GitHub threads) — clean no-op.
+- Sub-threshold findings excluded: none (only the one finding surfaced, scored
+  ≥80).

--- a/cairn/milestones/M18-circum-free-scaling-build.md
+++ b/cairn/milestones/M18-circum-free-scaling-build.md
@@ -85,8 +85,14 @@ published CIRCUM/CircE solution.
       `VarRatio` column (free only), free-path analytic caution (M18-D3), σ
       pathology note, σ-aware `cpm_sim_root`. End-to-end free fit reproduces
       published fit indices (χ²/RMSEA/CFI/TLI). Formal regression tests below.
-- [ ] **T4** — Validation tests: OpenMx free-scaling oracle to spec tolerance;
+- [x] **T4** — Validation tests: OpenMx free-scaling oracle to spec tolerance;
       Grassi et al. (2010) published CircE targets to printed precision.
+      Done 2026-07-13: frozen oracle (App. A angles/ζ/β/σ²/F̂/χ²/RMSEA/RMSEA-CI/
+      CFI/TLI/SRMR-converted to printed precision) + live OpenMx cross-check
+      (θ/ζ/β/σ² agree; σ² offset = exactly (N−1)/N, OpenMx's ML rescale absorbed
+      into σ — confirms equivariance) + Table 2 model-3c fixed-grid row. Plus
+      engine invariants in test-cpm_fit.R: FD gradient ≥50 pts, σ=1 legacy
+      identity, stationarity, exact recovery σ̂=1, rescale-equivariance, nesting.
 - [ ] **T5** — Boundary suite on the free-scaling path (peak at 0/360; flat);
       update `cairn/boundary-coverage.md` with the new cells.
 - [ ] **T6** — `devtools::document()` (if the API surface changed), full

--- a/cairn/milestones/M18-circum-free-scaling-build.md
+++ b/cairn/milestones/M18-circum-free-scaling-build.md
@@ -93,8 +93,12 @@ published CIRCUM/CircE solution.
       into σ — confirms equivariance) + Table 2 model-3c fixed-grid row. Plus
       engine invariants in test-cpm_fit.R: FD gradient ≥50 pts, σ=1 legacy
       identity, stationarity, exact recovery σ̂=1, rescale-equivariance, nesting.
-- [ ] **T5** — Boundary suite on the free-scaling path (peak at 0/360; flat);
-      update `cairn/boundary-coverage.md` with the new cells.
+- [x] **T5** — Boundary suite on the free-scaling path (peak at 0/360; flat);
+      update `cairn/boundary-coverage.md` with the new cells. Done 2026-07-13:
+      new `test-cpm_boundary.R` (class A pole recovery incl a genuine σ≠1
+      pattern; class D singular/zero-variance/near-flat refusal fail-closed).
+      B is the shared circular-quantile engine (σ orthogonal to angles); C is
+      not a CPM estimand. boundary-coverage.md row + audit note added.
 - [ ] **T6** — `devtools::document()` (if the API surface changed), full
       `devtools::check()` + `devtools::test()` (`NOT_CRAN=true`); NEWS entry for
       the new `free_scaling` argument.

--- a/cairn/milestones/M18-circum-free-scaling-build.md
+++ b/cairn/milestones/M18-circum-free-scaling-build.md
@@ -7,7 +7,7 @@
 - **Priority:** high
 - **Depends on:** M17
 - **Principles touched:** — (no formal IP/GP ids yet; works under DESIGN.md "Statistical conventions" and "CPM confidence intervals: measured coverage")
-- **Branch/PR:** m18-circum-free-scaling / —
+- **Branch/PR:** m18-circum-free-scaling / #42
 
 ## Goal
 
@@ -39,22 +39,22 @@ published CIRCUM/CircE solution.
 
 ## Acceptance criteria
 
-- [ ] `cpm_fit(..., scaling = "free")` fits the covariance family and returns
+- [x] `cpm_fit(..., scaling = "free")` fits the covariance family and returns
       σ̂; a regression test in `tests/testthat/test-cpm_fit.R` exercises the path
       end-to-end. (AC1 wording amended 2026-07-13: `scaling = c("unit","free")`
       per spec §7, superseding the plan's `free_scaling = TRUE`.)
-- [ ] Reproduces the OpenMx free-scaling oracle to the tolerance fixed by the
+- [x] Reproduces the OpenMx free-scaling oracle to the tolerance fixed by the
       M17 spec, in `tests/testthat/test-cpm_oracles.R` (the free-scaling OpenMx
       transcription already present there is the oracle).
-- [ ] Reproduces the published Grassi et al. (2010, Appendix A) CircE solution
+- [x] Reproduces the published Grassi et al. (2010, Appendix A) CircE solution
       to its printed precision (ζ/β to 4 decimals, angles to ~0.01°, F̂ per the
       §11 nesting/allowance protocol) — test in `test-cpm_oracles.R`.
       Source: Grassi et al. (2010), Appendix A.
-- [ ] The free-family analytic gradient agrees with finite differences to the
+- [x] The free-family analytic gradient agrees with finite differences to the
       spec tolerance at ≥ 50 random feasible points, and the boundary suite
       (peak at 0/360; flat) passes on the free-scaling path — tests in
       `test-cpm_fit.R` / `test-cpm_boundary.R`.
-- [ ] `devtools::check()` clean (0 errors / 0 warnings / 0 notes) and
+- [x] `devtools::check()` clean (0 errors / 0 warnings / 0 notes) and
       `devtools::test()` green (run with `NOT_CRAN=true`, per M16 lesson).
 
 ## Coverage
@@ -140,3 +140,31 @@ published CIRCUM/CircE solution.
   no analytic CI ever (spec §4). Jeff, 2026-07-13.
 
 ## Review
+
+**AC evidence (fresh, 2026-07-13; OpenMx live, `NOT_CRAN=true`).** CPM suites:
+test-cpm_fit.R 294 pass, test-cpm_oracles.R 102 pass, test-cpm_boundary.R 9
+pass — 0 fail / 0 skip.
+
+- **AC1** — PASS. `test-cpm_fit.R` "free-scaling cpm_fit end-to-end: VarRatio
+  column, no CI, df unchanged" + "unit-scaling cpm_fit is unchanged": free path
+  returns σ̂ (VarRatio = σ̂²), unit path bit-identical (no VarRatio, σ≡1).
+- **AC2** — PASS. `test-cpm_oracles.R` "free-scaling live oracle: our engine
+  agrees with OpenMx free-scaling" (OpenMx CSOLNP live): θ/ζ/β agree; σ̂² offset
+  = exactly (N−1)/N, F̂ to 5e-4.
+- **AC3** — PASS. `test-cpm_oracles.R` "free-scaling frozen oracle: our engine
+  reproduces Grassi App. A" (angles ≤0.01°, ζ/β/σ² to printed precision,
+  F̂/χ²/RMSEA/RMSEA-CI/CFI/TLI/SRMR-converted) + "fixed-grid (variant B)
+  reproduces Table 2 model 3c".
+- **AC4** — PASS. `test-cpm_fit.R` "free-scaling analytic gradient matches
+  central FD at >= 50 points" (55 feasible pts incl pole/near-equal/non-unit-
+  diagonal/polished; err ≤1e-7) + σ=1 legacy identity (exact) + boundary suite
+  `test-cpm_boundary.R` (class A pole recovery, class D flat/singular refusal).
+- **AC5** — PASS. `devtools::check(args="--no-manual")` `NOT_CRAN=true`:
+  **0 errors / 0 warnings / 0 notes**; full `test()` green.
+
+**Consistency gate (by command).** `cairn_validate.py` exit 0 (all 15 checks
+PASS incl coverage-complete, mirror, single in-progress, caps). Coverage map:
+AC1→T2,T3 · AC2→T4 · AC3→T4 · AC4→T1,T5 · AC5→T6 — every criterion maps to an
+existing task. No DESIGN.md principle changed → `cairn_impact` N/A. Toolchain
+(r-package consistency-gate): R CMD check 0/0/0, roxygen/NAMESPACE regenerated
+and committed.

--- a/cairn/milestones/M18-circum-free-scaling-build.md
+++ b/cairn/milestones/M18-circum-free-scaling-build.md
@@ -3,11 +3,11 @@
      Per-section owners are tagged below. -->
 # M18: CIRCUM free-scaling — implementation + oracle validation
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** high
 - **Depends on:** M17
 - **Principles touched:** — (no formal IP/GP ids yet; works under DESIGN.md "Statistical conventions" and "CPM confidence intervals: measured coverage")
-- **Branch/PR:** —
+- **Branch/PR:** m18-circum-free-scaling / —
 
 ## Goal
 

--- a/cairn/milestones/M18-circum-free-scaling-build.md
+++ b/cairn/milestones/M18-circum-free-scaling-build.md
@@ -3,7 +3,7 @@
      Per-section owners are tagged below. -->
 # M18: CIRCUM free-scaling — implementation + oracle validation
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** high
 - **Depends on:** M17
 - **Principles touched:** — (no formal IP/GP ids yet; works under DESIGN.md "Statistical conventions" and "CPM confidence intervals: measured coverage")
@@ -99,9 +99,13 @@ published CIRCUM/CircE solution.
       pattern; class D singular/zero-variance/near-flat refusal fail-closed).
       B is the shared circular-quantile engine (σ orthogonal to angles); C is
       not a CPM estimand. boundary-coverage.md row + audit note added.
-- [ ] **T6** — `devtools::document()` (if the API surface changed), full
+- [x] **T6** — `devtools::document()` (if the API surface changed), full
       `devtools::check()` + `devtools::test()` (`NOT_CRAN=true`); NEWS entry for
-      the new `free_scaling` argument.
+      the new `scaling` argument. Done 2026-07-13: docs regenerated (`scaling`
+      param in cpm_fit.Rd); NEWS entry (scaling="free"/VarRatio; CIRCUM/CircE
+      now reproducible); design-doc debt cleared (m4-browne-design.md §3.2
+      correction + §6.3 SRMR conversion). `check()` clean: 0 errors / 0 warnings
+      / 0 notes (`NOT_CRAN=true`); full `test()` green.
 
 ## Work log
 
@@ -113,6 +117,9 @@ published CIRCUM/CircE solution.
   synced master. Question gate settled (see Decisions M18-D1..D3).
 - 2026-07-13 (amendment, minor): AC1 wording `free_scaling = TRUE` →
   `scaling = "free"` per spec §7 (M18-D1).
+- 2026-07-13: all tasks done; status → review. Free-scaling covariance family
+  reproduces published CircE fit to printed precision (F̂/χ²/RMSEA/CFI/TLI/σ²);
+  FD gradient err 2.4e-9; check clean 0/0/0 (NOT_CRAN); full test() green.
 
 ## Decisions
 

--- a/devel/m4-browne-design.md
+++ b/devel/m4-browne-design.md
@@ -254,10 +254,18 @@ rules out.
 
 Fitting a *correlation* structure with the Wishart (covariance) likelihood is
 the classic trap (Cudeck, 1989, *Psych Bull*): χ² and SEs are only valid if
-the model is scale-invariant. This model is: `diag P(γ) = 1` identically, and
-embedding `Σ = D_σ P(γ) D_σ` with free scale factors `σ` reproduces any
-rescaling, with `σ̂ = 1` at the optimum when fitted to `R`. All parameters
-(θ, ζ, β) are scale-free. So:
+the model is scale-invariant. The invariance device is the free-scaling family
+`Σ = D_σ P(γ) D_σ` with `diag P(γ) = 1` identically: θ, ζ, β are all scale-free
+(RR04 §4i). **Correction (RR04 / D-009, 2026-07-13):** the earlier claim that
+`σ̂ = 1` at the optimum when the free family is fitted to `R` is false at finite
+N — it holds *only* at perfect fit. The finite-N ML projection preserves
+`diag(Σ̂⁻¹R) = 1`, **not** `diag Σ̂ = 1` (the B6 refutation, changelog below);
+that is the exact content of the free family's stationarity condition. The
+scale-invariance ⇒ χ²/Wald-validity argument therefore has its true home in the
+*free* family (now `cpm_fit(scaling = "free")`, M18), not in the σ ≡ 1
+*correlation-structure* family that ships as the default — for which the
+argument does not hold and analytic-CI trust rests on the §6.3 gate and the
+measured coverage instead. So:
 
 - point estimates and `T = n·F̂` are asymptotically valid;
 - information-based SEs for θ, ζ, β are justified by the same invariance
@@ -650,9 +658,13 @@ differences, try the mirror); (2) `n = N − 1` vs `N` in `T` and RMSEA;
 boundary constraints likely report the *unreduced* df); (4) their matrix
 transcription (re-diff the input `R` against the paper); (5) ζ vs ζ²
 labeling; (6) SRMR denominator convention — off-diagonal-only `p(p−1)/2`
-(ours, §5.3) vs diagonal-inclusive `p(p+1)/2`: since diagonal residuals are
-identically 0 here, the two differ by `√((p−1)/(p+1))` ≈ 0.88 at p = 8, far
-beyond tolerance (A-review F6); (7) CI shape — symmetric on the natural
+(ours, §5.3) vs diagonal-inclusive `p(p+1)/2`. Under the **σ ≡ 1**
+correlation-structure fit the diagonal residuals are identically 0, so the two
+differ by a fixed `√((p−1)/(p+1))` ≈ 0.88 at p = 8, far beyond tolerance
+(A-review F6). Under **free scaling** (M18) the diagonal residuals are
+`1 − σ̂_i²` and no longer vanish, so the exact conversion is
+`SRMR_CircE² = [ (p(p−1)/2)·SRMR_ours² + Σ_i (1 − σ̂_i²)² ] / (p(p+1)/2)`
+(RR04 §4iii; encoded in `test-cpm_oracles.R`, not as a fixed allowance); (7) CI shape — symmetric on the natural
 scale vs back-transformed from an unconstrained scale (decides what the
 analytic-CI gate compares); (8) BIC's `ln N` vs `ln n`; only then
 (9) suspect the code.

--- a/man/cpm_fit.Rd
+++ b/man/cpm_fit.Rd
@@ -12,6 +12,7 @@ cpm_fit(
   n = NULL,
   m = 3,
   model = c("quasi-circumplex", "constrained-angles", "equal-communality", "circulant"),
+  scaling = c("unit", "free"),
   reference = 1,
   interval = 0.95,
   ci_method = c("bootstrap", "analytic"),
@@ -49,6 +50,19 @@ free-angle variants and \code{floor(p / 2)} for the fixed-angle variants.}
 (default; free angles and communalities), \code{"constrained-angles"} (angles
 fixed at their theoretical values), \code{"equal-communality"} (a single shared
 communality), or \code{"circulant"} (both constraints).}
+
+\item{scaling}{The covariance-scaling family, orthogonal to \code{model}:
+\code{"unit"} (default) fits the correlation structure with a unit model-implied
+diagonal (the historical behaviour); \code{"free"} fits Browne's covariance
+structure \eqn{\Sigma = D_\sigma P D_\sigma} with \code{p} free variance scales,
+the parameterization CIRCUM and CircE use, so \code{cpm_fit()} can reproduce
+their published output exactly. Free scaling adds \code{p} parameters but leaves
+the degrees of freedom unchanged (it fits the \code{p} extra diagonal
+covariance moments). The fitted \eqn{\hat\sigma^2} are reported as a
+\code{VarRatio} column (the ratio of reproduced to input variance); they carry
+no confidence interval, and the analytic intervals for the remaining
+parameters are not yet coverage-validated for this family (\code{summary()}
+cautions). The input is still a correlation matrix (unit diagonal).}
 
 \item{reference}{The index into \code{scales} of the variable whose angle is fixed
 at its theoretical value to identify the rotation (default = 1).}

--- a/man/cpm_simulate.Rd
+++ b/man/cpm_simulate.Rd
@@ -15,9 +15,12 @@ number.}
 \value{
 A numeric matrix with \code{n} rows and one column per fitted scale,
 columns in the fitted scale order with \code{colnames} set to the scale names
-(\code{rownames} are \code{NULL}). The population margins are zero-mean and
-unit-variance, so \code{cor()} of the returned matrix converges to
-\code{object$matrices$Phat} as \code{n} grows.
+(\code{rownames} are \code{NULL}). The population covariance is
+\code{object$matrices$Phat}, so \code{cov()} of the returned matrix converges to it
+as \code{n} grows. Under the default unit scaling \code{Phat} is a correlation matrix
+(zero-mean, unit-variance margins), so \code{cor()} converges to it too; under
+\code{scaling = "free"} the margins carry the fitted variance ratios
+\eqn{\hat\sigma^2}.
 }
 \description{
 Draw \code{n} standardized observations from the model-implied correlation matrix

--- a/man/ssm_ci_accuracy.Rd
+++ b/man/ssm_ci_accuracy.Rd
@@ -39,7 +39,10 @@ itself material).}
 
 \item{cpm}{Optional. A pre-fitted \code{circumplex_cpm} object to reuse for the
 population structure instead of refitting (its scales must match the ssm
-object's). Ignored when \code{structure = "observed"}.}
+object's). Must be a unit-scaling fit (the default \code{cpm_fit()} scaling);
+a free-scaling fit models a covariance structure and is not a valid
+population correlation structure for this diagnostic. Ignored when
+\code{structure = "observed"}.}
 
 \item{data}{Optional. The original data set, required only for ssm objects
 created before sufficient statistics were stored at analysis time; the

--- a/tests/testthat/test-ci_accuracy.R
+++ b/tests/testthat/test-ci_accuracy.R
@@ -520,6 +520,24 @@ test_that("a pre-fitted CPM is reused rather than refit", {
   expect_identical(res$cpm$matrices$Phat, pre$matrices$Phat)
 })
 
+test_that("a free-scaling CPM is refused (correlation-structure diagnostic)", {
+  # M18 review: a free-scaling fit's Phat is a covariance (non-unit diagonal),
+  # which would embed inconsistent variances into the simulated population and
+  # silently miscalibrate coverage. Refuse it up front rather than corrupt.
+  data("jz2017")
+  jz <- jz2017[1:200, ]
+  set.seed(913)
+  obj <- ssm_analyze(jz, scales = PANO(), boots = 40)
+  stats <- obj$details$suff_stats
+  free_fit <- cpm_fit(cormat = stats$cormats[[1]], n = stats$n[[1]],
+                      scales = PANO(), angles = as.numeric(octants()),
+                      scaling = "free")
+  expect_error(
+    ssm_ci_accuracy(obj, reps = 3, amplitude_factors = 1, cpm = free_fit),
+    regexp = "unit-scaling|scaling"
+  )
+})
+
 test_that("input validation rejects bad arguments", {
   data("aw2009")
   set.seed(921)

--- a/tests/testthat/test-cpm_boundary.R
+++ b/tests/testthat/test-cpm_boundary.R
@@ -1,0 +1,102 @@
+# Boundary-condition suite for the free-scaling CPM path (M18).
+#
+# The four angular/boundary invariant classes (cairn/boundary-coverage.md):
+#   A -- profile peaking exactly at 0/360 (angle lands on the pole)
+#   B -- angle CI straddling 0/360
+#   C -- contrasts near +/-180 (branch-cut agreement)
+#   D -- flat / zero-variance profiles (graceful refusal, no crash)
+#
+# For the CPM free-scaling path (scaling = "free"), the applicable classes are
+# A (pole) and D (flat/degenerate). Class C has no CPM estimand (there are no
+# angular contrasts in a CPM fit). Class B is a property of the shared circular
+# quantile machinery (quantile.circumplex_radian) that free scaling reuses
+# unchanged -- the sigma block is orthogonal to the angle block -- so it is
+# covered once on the unit path and not re-proved here (boundary-coverage.md
+# "shared engine" convention).
+#
+# Oracle rule unchanged: expected values are closed-form / construction /
+# invariants, never from memory.
+
+# ---- Class A: an angle exactly at the 0/360 pole, free scaling --------------
+
+test_that("free scaling, class A: an in-family angle at the 0/360 pole recovers", {
+  # Non-reference scale 2 sits at exactly 0 (the reference-relative pole), as in
+  # the unit-path pole test. Data are exactly in the correlation family
+  # (sigma = 1), so free scaling must recover sigma-hat = 1 AND report the pole
+  # angle as ~0 or ~360 (DESIGN G2 / D-003), with the sigma block leaving the
+  # angle handling untouched (spec sec. 5, pin 2).
+  theta0 <- c(0, 0, 0.9, 1.8, 2.7, 3.6, 4.5, 5.4)
+  zeta0 <- rep(0.75, 8)
+  beta0 <- c(0.5, 0.3, 0.2)
+  P0 <- cpm_implied_cor(theta0, zeta0, beta0)
+  fit <- cpm_engine(P0, angles = theta0 * 180 / pi, m = 3, variant = "A",
+                    reference = 1, scaling = "free")
+  expect_lte(fit$F, 1e-8)
+  expect_equal(fit$sigma, rep(1, 8), tolerance = 1e-6)
+  a2 <- fit$theta[2]
+  expect_true(min(abs(a2 - 0), abs(a2 - 360)) < 1e-3)
+})
+
+test_that("free scaling, class A: a genuine sigma != 1 pattern recovers at the pole", {
+  # Inject non-trivial variance scales with a pole angle, then fit the resulting
+  # covariance directly (engine level -- the cormat path requires unit-diagonal
+  # input; here we test the estimator's pole+scale recovery). Rescale-
+  # equivariance guarantees sigma-hat = sigma and the pole angle is unchanged.
+  theta0 <- c(0, 0, 0.9, 1.8, 2.7, 3.6, 4.5, 5.4)
+  zeta0 <- rep(0.75, 8)
+  beta0 <- c(0.5, 0.3, 0.2)
+  sigma0 <- c(1.3, 0.8, 1.1, 0.9, 1.2, 0.7, 1.0, 1.15)
+  Sigma0 <- cpm_implied_cov(theta0, zeta0, beta0, sigma0)
+  fit <- cpm_engine(Sigma0, angles = theta0 * 180 / pi, m = 3, variant = "A",
+                    reference = 1, scaling = "free")
+  expect_lte(fit$F, 1e-8)
+  expect_equal(fit$sigma, sigma0, tolerance = 1e-5)
+  a2 <- fit$theta[2]
+  expect_true(min(abs(a2 - 0), abs(a2 - 360)) < 1e-3)
+})
+
+# ---- Class D: flat / zero-variance input, free scaling ----------------------
+
+test_that("free scaling, class D: a singular correlation matrix is refused", {
+  # A rank-deficient (flat) matrix has ln|R| = -Inf; the PD guard refuses it
+  # BEFORE the scaling family matters, so free scaling refuses identically to
+  # unit. Same clear error.
+  Rsing <- matrix(1, 5, 5)
+  expect_error(
+    cpm_engine(Rsing, angles = c(0, 72, 144, 216, 288), m = 1, variant = "A",
+               scaling = "free"),
+    regexp = "positive definite|singular|PD"
+  )
+})
+
+test_that("free scaling, class D: a zero-variance raw column is refused", {
+  # A constant (zero-variance) scale column makes cor() undefined (NA); cpm_fit
+  # must refuse rather than fit garbage, on the free path as on the unit path.
+  set.seed(1)
+  df <- as.data.frame(matrix(stats::rnorm(200 * 8), 200, 8))
+  names(df) <- paste0("V", 1:8)
+  df$V3 <- 5                                   # constant column
+  expect_error(
+    suppressWarnings(cpm_fit(df, scales = paste0("V", 1:8),
+                             angles = octants(), scaling = "free")),
+    regexp = "positive definite|singular|PD|NA|missing|constant|variance"
+  )
+})
+
+test_that("free scaling, class D: a near-flat (tiny-eigenvalue) matrix is refused", {
+  # Build an almost-singular correlation matrix (one eigenvalue ~1e-12) and
+  # confirm the free path refuses it with the PD message (fail-closed, no crash
+  # inside solve(Sigma)).
+  p <- 6
+  V <- qr.Q(qr(matrix(stats::rnorm(p * p), p)))
+  ev <- c(rep(1, p - 1), 1e-12)
+  M <- V %*% diag(ev) %*% t(V)
+  d <- 1 / sqrt(diag(M))
+  R <- d * M * rep(d, each = p)
+  R <- (R + t(R)) / 2
+  expect_error(
+    cpm_engine(R, angles = 360 * (0:5) / 6, m = 1, variant = "A",
+               scaling = "free"),
+    regexp = "positive definite|singular|PD"
+  )
+})

--- a/tests/testthat/test-cpm_fit.R
+++ b/tests/testthat/test-cpm_fit.R
@@ -700,3 +700,225 @@ test_that("vanishing-harmonic populations yield strictly interior starts that pa
     expect_silent(cpm_pack(cs$theta, sv$zeta, sv$beta, spec))
   }
 })
+
+# =============================================================================
+# Free-scaling covariance family (M18): Sigma = D_sigma P D_sigma, sigma free.
+# Oracle rule unchanged: every expected value is closed-form, an internal
+# invariant, or an independent recomputation -- never from memory.
+# =============================================================================
+
+# A random PD matrix with a NON-unit diagonal (covariance, not correlation),
+# for exercising cpm_discrepancy / the gradient on general S in free mode.
+rand_cov <- function(p) {
+  A <- matrix(stats::rnorm(p * (p + 2)), nrow = p)
+  S <- tcrossprod(A)
+  (S + t(S)) / 2
+}
+
+test_that("free-scaling spec: layout [angle][u][s][v], df unchanged, q += p", {
+  for (v in c("A", "B", "C", "D")) {
+    su <- cpm_spec(8, 3, v, 1, scaling = "unit")
+    sf <- cpm_spec(8, 3, v, 1, scaling = "free")
+    # df is identical (free fits p extra moments with p extra parameters).
+    expect_equal(sf$df, su$df, info = paste("variant", v))
+    expect_equal(sf$q, su$q + 8L)
+    expect_equal(sf$n_sigma, 8L)
+    expect_equal(su$n_sigma, 0L)
+    # s block sits between zeta and beta, beta trailing.
+    expect_true(all(sf$i_sigma > max(c(sf$i_angle, sf$i_zeta), 0)))
+    expect_true(all(sf$i_beta > max(sf$i_sigma)))
+    expect_equal(sf$n_moments, 8L * 9L / 2L)
+    expect_equal(su$n_moments, 8L * 7L / 2L)
+  }
+})
+
+test_that("free-scaling pack/unpack round-trips sigma (log map)", {
+  spec <- cpm_spec(p = 6, m = 2, variant = "A", reference = 1, scaling = "free")
+  spec$theta_ref_val <- 0
+  theta <- c(0, 0.7, 1.4, 2.1, 2.8, 3.5)
+  zeta <- c(0.9, 0.8, 0.7, 0.6, 0.85, 0.75)
+  beta <- c(0.5, 0.3, 0.2)
+  sigma <- c(0.8, 1.2, 1.0, 0.95, 1.1, 0.7)
+  g <- cpm_pack(theta, zeta, beta, spec, sigma = sigma)
+  nat <- cpm_unpack(g, spec)
+  expect_equal(nat$sigma, sigma, tolerance = 1e-12)
+  expect_equal(nat$zeta, zeta, tolerance = 1e-10)
+  expect_equal(nat$beta, beta, tolerance = 1e-10)
+  # default sigma = 1 (s = 0) when omitted
+  expect_equal(cpm_unpack(cpm_pack(theta, zeta, beta, spec), spec)$sigma,
+               rep(1, 6), tolerance = 1e-14)
+})
+
+test_that("free-scaling analytic gradient matches central FD at >= 50 points", {
+  # spec sec. 6: theta random (incl a 0/360-pole and a near-equal-angles
+  # config), zeta in (.3,.95), beta interior via v ~ U(-1,1), s ~ U(-.35,.35),
+  # random PD R incl a few non-unit-diagonal, and one reduced (polished) spec.
+  # Criterion (A-review F8 mixed): |g_a - g_fd| <= 1e-7 max(1, |g_fd|); central
+  # diff, step 1e-6; redraw any point with kappa(Sigma) > 1e6 (FD, not the
+  # gradient, degrades there).
+  set.seed(20260713)
+  on.exit(rm(".Random.seed", envir = globalenv()), add = TRUE)
+  h <- 1e-6
+  p <- 7; m <- 2
+  full <- cpm_spec(p, m, "A", 1, scaling = "free"); full$theta_ref_val <- 0
+  reduced <- cpm_spec_reduce(full, c(0, 1))       # drop k = 2 (polished spec)
+  n_pts <- 55L
+  npass <- 0L
+  t <- 0L
+  while (npass < n_pts) {
+    t <- t + 1L
+    stopifnot(t < 5000L)
+    spec <- if (t %% 7L == 0L) reduced else full
+    # angle config: pole every 11th, near-equal every 13th, else random
+    theta <- if (t %% 11L == 0L) {
+      c(0, sort(stats::runif(p - 1, 0, 2 * pi)))    # reference at the 0/360 pole
+    } else if (t %% 13L == 0L) {
+      c(0, 0.01 * (1:(p - 1)) + stats::runif(p - 1, -1e-3, 1e-3))  # near-equal
+    } else {
+      c(0, sort(stats::runif(p - 1, 0, 2 * pi)))
+    }
+    zeta <- stats::runif(p, 0.3, 0.95)
+    nb <- length(spec$keep_k) - 1L
+    v <- c(0, stats::runif(nb, -1, 1))
+    beta_keep <- exp(v) / sum(exp(v))
+    beta <- numeric(m + 1L); beta[spec$keep_k + 1L] <- beta_keep
+    sigma <- exp(stats::runif(p, -0.35, 0.35))
+    R <- if (t %% 5L == 0L) rand_cov(p) else rand_cor(p)
+    g <- cpm_pack(theta, zeta, beta, spec, sigma = sigma)
+    Sig <- cpm_implied_cov(cpm_unpack(g, spec)$theta, cpm_unpack(g, spec)$zeta,
+                           cpm_unpack(g, spec)$beta, cpm_unpack(g, spec)$sigma)
+    kappa <- kappa(Sig, exact = TRUE)
+    if (!is.finite(kappa) || kappa > 1e6) next      # redraw: FD degrades here
+    ga <- cpm_gradient(g, R, spec)
+    gfd <- numeric(spec$q)
+    for (i in seq_len(spec$q)) {
+      gp <- g; gm <- g; gp[i] <- gp[i] + h; gm[i] <- gm[i] - h
+      gfd[i] <- (cpm_objective(gp, R, spec) - cpm_objective(gm, R, spec)) / (2 * h)
+    }
+    expect_true(
+      all(abs(ga - gfd) <= 1e-7 * pmax(1, abs(gfd))),
+      info = paste0("free gradient point ", t, ": max err ",
+                    max(abs(ga - gfd) / pmax(1, abs(gfd))))
+    )
+    npass <- npass + 1L
+  }
+  expect_gte(npass, 50L)
+})
+
+test_that("free-scaling gradient at sigma = 1 equals the unit gradient exactly", {
+  # spec sec. 6: at s = 0 the gamma-block gradient must equal the legacy unit
+  # gradient bit-for-bit -- kills the 'used A not A-tilde' and 'used P^-1 not
+  # Sigma^-1' error classes in one assertion.
+  set.seed(11)
+  on.exit(rm(".Random.seed", envir = globalenv()), add = TRUE)
+  p <- 7; m <- 2
+  uf <- cpm_spec(p, m, "A", 1, scaling = "unit"); uf$theta_ref_val <- 0
+  ff <- cpm_spec(p, m, "A", 1, scaling = "free"); ff$theta_ref_val <- 0
+  for (rep in 1:20) {
+    R <- rand_cor(p)
+    theta <- c(0, sort(stats::runif(p - 1, 0, 2 * pi)))
+    zeta <- stats::runif(p, 0.3, 0.95)
+    v <- c(0, stats::rnorm(m)); beta <- exp(v) / sum(exp(v))
+    gu <- cpm_pack(theta, zeta, beta, uf)
+    gf <- cpm_pack(theta, zeta, beta, ff, sigma = rep(1, p))   # s = 0
+    grad_u <- cpm_gradient(gu, R, uf)
+    grad_f <- cpm_gradient(gf, R, ff)
+    # gamma blocks identical (indices differ only by the inserted s block)
+    expect_identical(grad_f[c(ff$i_angle, ff$i_zeta, ff$i_beta)],
+                     grad_u[c(uf$i_angle, uf$i_zeta, uf$i_beta)])
+  }
+})
+
+test_that("free-scaling: stationarity diag(Sigma^-1 R) = 1 at the optimum", {
+  voc <- cpm_oracle_voc()
+  fit <- cpm_engine(voc$R, angles = voc$th_start, m = 1, variant = "A",
+                    reference = 1, scaling = "free")
+  # At any accepted optimum the sigma first-order condition dF/ds = 0 gives
+  # (Sigma^-1 R)_ii = 1 for all i (spec sec. 3) -- an internal invariant with
+  # no external source. Sigma-hat = fit$P (the reported model matrix).
+  expect_equal(diag(solve(fit$P) %*% voc$R), rep(1, 7), tolerance = 1e-6,
+               ignore_attr = TRUE)
+  # ... which implies tr(Sigma^-1 R) = p, so F-hat = ln|Sigma| - ln|R| (to
+  # optimizer-tail precision: tr - p ~ sum(diag(Sigma^-1 R) - 1) ~ 1e-6).
+  ld <- function(M) as.numeric(determinant(M, logarithm = TRUE)$modulus)
+  expect_equal(fit$F, ld(fit$P) - ld(voc$R), tolerance = 1e-5)
+})
+
+test_that("free-scaling exact recovery: in-family Sigma gives F = 0, sigma = 1", {
+  # Population exactly in the correlation family (sigma = 1) => F-hat ~ 0 and,
+  # crucially, sigma-hat = 1 to 1e-6 (a free family that could not recover
+  # sigma = 1 on in-family data would be mis-specified).
+  theta <- c(0, 40, 95, 150, 190, 230, 285, 330) * pi / 180
+  zeta <- c(.85, .7, .8, .65, .75, .8, .7, .6)
+  beta <- c(.35, .30, .20, .15)
+  P0 <- cpm_implied_cor(theta, zeta, beta)
+  fit <- cpm_engine(P0, angles = theta * 180 / pi, m = 3, variant = "A",
+                    reference = 1, scaling = "free")
+  expect_lt(fit$F, 1e-8)
+  expect_equal(fit$sigma, rep(1, 8), tolerance = 1e-6)
+})
+
+test_that("free-scaling rescale-equivariance: fit(D R D) => sigma -> D sigma", {
+  # The sharpest single test of the whole construction (spec sec. 6): scaling
+  # the input by a positive diagonal D scales sigma-hat by D and leaves
+  # theta/zeta/beta/F-hat invariant. No diag-constrained analog exists.
+  voc <- cpm_oracle_voc()
+  base <- cpm_engine(voc$R, angles = voc$th_start, m = 1, variant = "A",
+                     reference = 1, scaling = "free")
+  set.seed(7)
+  on.exit(rm(".Random.seed", envir = globalenv()), add = TRUE)
+  D <- exp(stats::runif(7, -0.5, 0.5))
+  S <- (D %o% D) * voc$R                              # D R D (non-unit diagonal)
+  scaled <- cpm_engine(S, angles = voc$th_start, m = 1, variant = "A",
+                       reference = 1, scaling = "free")
+  expect_equal(scaled$sigma, base$sigma * D, tolerance = 1e-6, ignore_attr = TRUE)
+  expect_equal(scaled$F, base$F, tolerance = 1e-8)
+  expect_equal(scaled$zeta, base$zeta, tolerance = 1e-6)
+  expect_equal(scaled$beta, base$beta, tolerance = 1e-6)
+  expect_lt(max(cpm_angdiff_deg(scaled$theta, base$theta)), 1e-4)
+})
+
+test_that("free-scaling nesting: F_free <= F_unit on every fixture", {
+  # sigma = 1 is a feasible point of the free family (nested), so its optimum
+  # cannot be worse: F-hat_free <= F-hat_unit + 1e-8. Checked on the published
+  # vocational matrix (m = 1) and a well-identified clean in-family R (m = 3).
+  voc <- cpm_oracle_voc()
+  ct <- cpm_clean_truth()
+  P0 <- cpm_implied_cor(as.numeric(as_radian(as_degree(ct$angles))),
+                        ct$zeta, ct$beta)
+  for (fx in list(list(R = voc$R, a = voc$th_start, m = 1),
+                  list(R = P0, a = ct$angles, m = 3))) {
+    fu <- cpm_engine(fx$R, angles = fx$a, m = fx$m, variant = "A", reference = 1)
+    ff <- cpm_engine(fx$R, angles = fx$a, m = fx$m, variant = "A", reference = 1,
+                     scaling = "free")
+    expect_lte(ff$F, fu$F + 1e-8)
+  }
+})
+
+test_that("unit-scaling cpm_fit is unchanged by the free-scaling machinery", {
+  # Regression guard: the default (unit) path must be byte-identical to before.
+  voc <- cpm_oracle_voc()
+  fu <- cpm_fit(cormat = voc$R, scales = voc$names, angles = voc$th_start,
+                n = voc$N, m = 1)
+  # no VarRatio column, sigma all 1, scaling recorded as unit
+  expect_false("VarRatio" %in% names(fu$results))
+  expect_equal(fu$details$sigma, rep(1, 7))
+  expect_identical(fu$details$scaling, "unit")
+  expect_false(isTRUE(fu$details$sigma_pathology))
+})
+
+test_that("free-scaling cpm_fit end-to-end: VarRatio column, no CI, df unchanged", {
+  voc <- cpm_oracle_voc()
+  ff <- cpm_fit(cormat = voc$R, scales = voc$names, angles = voc$th_start,
+                n = voc$N, m = 1, scaling = "free")
+  expect_true("VarRatio" %in% names(ff$results))
+  expect_equal(ff$results$VarRatio, ff$details$sigma^2, tolerance = 1e-12)
+  # df identical to the unit fit on the same (p, m, variant)
+  fu <- cpm_fit(cormat = voc$R, scales = voc$names, angles = voc$th_start,
+                n = voc$N, m = 1)
+  expect_equal(ff$fit$df, fu$fit$df)
+  # sigma carries no CI surface (no VarRatio_lci/uci columns)
+  expect_false(any(grepl("VarRatio_", names(ff$results))))
+  # AIC/BIC penalize the full parameter count (q includes the p sigmas)
+  expect_gt(ff$details$spec$q, fu$details$spec$q)
+})

--- a/tests/testthat/test-cpm_oracles.R
+++ b/tests/testthat/test-cpm_oracles.R
@@ -492,3 +492,83 @@ test_that("zeta is the communality index; Communality is its square", {
   app <- cpm_oracle_voc_appendix()
   expect_gt(max(abs(fit$results$Communality - app$comm)), 0.05)
 })
+
+# ---- free-scaling family (M18): OUR engine vs the published/CircE oracles ----
+# The payoff of scaling = "free": compare at SAME-MODEL tolerances (spec sec. 6),
+# retiring the B6 model-difference allowances -- our covariance fit is the same
+# estimand CIRCUM/CircE report. Two independent oracle types back every value:
+# published program output (frozen; Grassi App. A) and an independent
+# cross-implementation (live; the OpenMx free-scaling fit).
+
+test_that("free-scaling frozen oracle: our engine reproduces Grassi App. A", {
+  voc <- cpm_oracle_voc()
+  app <- cpm_oracle_voc_appendix()
+  fit <- cpm_fit(cormat = voc$R, scales = voc$names, angles = voc$th_start,
+                 n = voc$N, m = 1, scaling = "free")
+  # Angles to published precision (mirror-aware, reference-relative; sec. 6.5).
+  expect_lt(cpm_mirror_diff_deg(fit$results$Angle, app$theta), 0.01)
+  # Communality index zeta = 1/sqrt(1 + v) to their 4 printed decimals.
+  expect_equal(fit$results$Zeta, round(1 / sqrt(1 + app$v), 4),
+               tolerance = 5e-4, ignore_attr = TRUE)
+  # Correlation-function weights to 4 decimals.
+  expect_equal(fit$betas$Beta, app$beta, tolerance = 5e-4, ignore_attr = TRUE)
+  # Variance ratios sigma^2 = reproduced/input variance (Appendix A .963-1.042).
+  expect_equal(fit$results$VarRatio, app$var_ratios, tolerance = 5e-4,
+               ignore_attr = TRUE)
+  # Discrepancy and the full fit-index set, now at same-model tolerances.
+  expect_equal(fit$fit$F, app$Fhat, tolerance = 1e-4)
+  expect_equal(fit$fit$chisq, app$Tstat, tolerance = 5e-3)
+  expect_equal(fit$fit$df, app$df)
+  expect_lt(abs(fit$fit$pvalue - app$pvalue), 1e-3)   # published to 3 dp
+  # RMSEA .0842 -> published .084 (spec sec. 4); published to 3 dp, so compare
+  # within half a printed unit (absolute), like the RMSEA-CI below.
+  expect_lt(abs(fit$fit$rmsea - app$rmsea), 1e-3)
+  expect_lt(max(abs(fit$fit$rmsea_ci - app$rmsea_ci)), 1e-3)
+  expect_equal(fit$fit$cfi, app$cfi, tolerance = 1e-3)
+  expect_equal(fit$fit$tli, app$tli, tolerance = 1e-3)
+  # SRMR: our off-diagonal convention converted to CircE's diagonal-inclusive
+  # value (spec sec. 4). The free family's diagonal residuals are 1 - sigma^2.
+  # Published SRMR is printed to 2 dp, so compare within half a printed unit.
+  p <- 7
+  srmr_circe <- sqrt((p * (p - 1) / 2 * fit$fit$srmr^2 +
+                        sum((1 - fit$results$VarRatio)^2)) / (p * (p + 1) / 2))
+  expect_lt(abs(srmr_circe - app$srmr), 5e-3)
+})
+
+test_that("free-scaling live oracle: our engine agrees with OpenMx free-scaling", {
+  skip_if_not_installed("OpenMx")
+  skip_on_cran()
+  voc <- cpm_oracle_voc()
+  fit <- cpm_fit(cormat = voc$R, scales = voc$names, angles = voc$th_start,
+                 n = voc$N, m = 1, scaling = "free")
+  mx <- cpm_mx_run(cpm_mx_model(voc$R, voc$N, m = 1,
+                                th0_rad = voc$th_start * pi / 180,
+                                free_scaling = TRUE))
+  # Independent optimizer (CSOLNP), independent model code, same covariance
+  # discrepancy: agreement to publication precision.
+  expect_lt(cpm_mirror_diff_deg(fit$results$Angle, mx$theta_deg), 0.02)
+  expect_equal(fit$results$Zeta, mx$zeta, tolerance = 1e-3, ignore_attr = TRUE)
+  expect_equal(fit$betas$Beta, mx$beta, tolerance = 1e-3, ignore_attr = TRUE)
+  # sigma^2 vs diag(Sigma_mx): OpenMx fits R un-premultiplied on the free path
+  # (the family is closed under rescaling), so its ML (N-1)/N rescale of the
+  # observed matrix is absorbed ENTIRELY into sigma-hat -- diag(Sigma_mx) =
+  # VarRatio * (N-1)/N -- while theta/zeta/beta/F stay invariant (asserted
+  # above). A clean cross-implementation confirmation of the rescale-
+  # equivariance property. cpm_discrepancy at Sigma_mx matches our F to CSOLNP's
+  # optimizer tail (its p free scales + p zeta stop a hair short of our optimum).
+  expect_equal(fit$results$VarRatio * (voc$N - 1) / voc$N, diag(mx$Sigma),
+               tolerance = 1e-3, ignore_attr = TRUE)
+  expect_lt(abs(cpm_discrepancy(voc$R, mx$Sigma) - fit$fit$F), 5e-4)
+})
+
+test_that("free-scaling: fixed-grid (variant B) reproduces Table 2 model 3c", {
+  # Table 2 model 3c: equally spaced angles, free scaling. Our variant-B free
+  # fit lands on the published beta and F at same-model tolerances (the B6
+  # model-difference allowance that variant B needed against the diag family is
+  # retired for its own free-scaling comparison).
+  voc <- cpm_oracle_voc()
+  fB <- cpm_fit(cormat = voc$R, scales = voc$names, angles = 360 * (0:6) / 7,
+                n = voc$N, m = 1, model = "constrained-angles", scaling = "free")
+  expect_equal(fB$betas$Beta, c(.704, .296), tolerance = 2e-3, ignore_attr = TRUE)
+  expect_equal(fB$fit$F, .574, tolerance = 1e-3)
+})


### PR DESCRIPTION
## M18: CIRCUM free-scaling — covariance estimation family

Adds `cpm_fit(..., scaling = "free")`, fitting Browne's covariance structure
Σ = D_σ P D_σ with `p` free variance scales — the parameterization CIRCUM and
CircE use — so the package reproduces published CIRCUM/CircE output exactly.
Builds the M17 spec (`devel/circum-free-scaling-spec.md`, GO per D-009 / RR04).

### What it does
- `scaling = c("unit", "free")`, orthogonal to `model`; default `"unit"` is
  bit-identical to before.
- Free scaling adds `p` params but **df unchanged** (fits the `p` extra
  covariance moments); reports σ̂² as a `VarRatio` column (no CI ever).

### Statistically load-bearing
- Gradient: `Σ⁻¹`-for-`P⁻¹` substitution, `Ã = D_σ A D_σ` weight on the γ
  blocks, `∂F/∂s = 2(1−(Σ⁻¹R)_ii)`. FD-verified to 2.4e-9; σ=1 legacy-gradient
  identity exact.
- Validation: published Grassi App. A (frozen, printed precision) + OpenMx
  free-scaling (live cross-check — σ̂² offset = exactly (N−1)/N, confirming
  rescale-equivariance) + engine invariants (stationarity, exact recovery,
  equivariance, nesting) + free-path boundary suite (pole, flat).

### Decisions
- M18-D1 API name `scaling`; M18-D2 `VarRatio` free-only; M18-D3 free+analytic
  CIs carry an unconditional not-yet-coverage-validated caution (the free-family
  coverage oracle is a deferred pre-ship gate, out of scope).

`check()` clean (0/0/0, NOT_CRAN); full `test()` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
