### PR TITLE
M22: free-engine multi-start nesting seed (T_free <= T_unit by construction)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 * `cpm_fit(scaling = "free")` now also starts its optimizer from the
   unit-scaling solution, so the free family's fit statistic can never exceed
-  the default family's on the same input (the free family mathematically
+  the default family's on the same input beyond numerical tolerance (the
+  free family mathematically
   nests the default; previously a rare multi-start tail — about 1 in 2,000
   fits in simulation — could land the free optimizer on a slightly worse
   optimum). Results change only in those rare cases, and only for the

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,11 @@
   nests the default; previously a rare multi-start tail — about 1 in 2,000
   fits in simulation — could land the free optimizer on a slightly worse
   optimum). Results change only in those rare cases, and only for the
-  better; the default family is unaffected.
+  better; the default family is unaffected. The convergence-acceptance
+  criterion is unchanged and still requires the multi-start battery itself
+  to reproduce the reported optimum, so a fit rescued by the new start may
+  now carry the (accurate) acceptance warning where it previously reported
+  a slightly worse optimum silently.
 
 * Displacement and angle confidence-interval endpoints that land exactly on
   the 0/360 pole are now reported as 360, never 0, matching how the package

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # circumplex (development version)
 
+* `cpm_fit(scaling = "free")` now also starts its optimizer from the
+  unit-scaling solution, so the free family's fit statistic can never exceed
+  the default family's on the same input (the free family mathematically
+  nests the default; previously a rare multi-start tail — about 1 in 2,000
+  fits in simulation — could land the free optimizer on a slightly worse
+  optimum). Results change only in those rare cases, and only for the
+  better; the default family is unaffected.
+
 * Displacement and angle confidence-interval endpoints that land exactly on
   the 0/360 pole are now reported as 360, never 0, matching how the package
   labels that pole everywhere else (LM = 360): `ssm_analyze()` bootstrap

--- a/R/cpm_fit.R
+++ b/R/cpm_fit.R
@@ -491,6 +491,17 @@ cpm_start_set <- function(spec, theta_theory, sv) {
   list(starts = starts, start_group = start_group)
 }
 
+# Reproduction half of the convergence acceptance criterion (design sec. 3.5):
+# the multi-start best F-hat must be reproduced by >= 2 INDEPENDENT start
+# groups. Group 0 is the sentinel for the unit-solution nesting seed (M22)
+# and never counts: a warm start certifies nesting, not start-independent
+# reproduction. Factored out so the group-0 exclusion is directly unit-tested
+# (test-cpm_nesting.R) rather than pinned only by the stochastic SE oracle.
+cpm_reproduced <- function(start_group, at_min) {
+  grp_min <- start_group[at_min]
+  length(unique(grp_min[grp_min > 0L])) >= 2L
+}
+
 # ---- single optimization run ------------------------------------------------
 
 cpm_optimize_one <- function(gstar0, R, spec) {
@@ -787,8 +798,7 @@ cpm_engine <- function(R, angles, m = 3, variant = c("A", "B", "C", "D"),
   # start-independent reproduction (see the seed block above). Acceptance
   # semantics are therefore identical to the unit family's and to the
   # pre-seed engine: only data-blind battery groups certify.
-  grp_min <- start_group[at_min]
-  reproduced <- length(unique(grp_min[grp_min > 0L])) >= 2L
+  reproduced <- cpm_reproduced(start_group, at_min)
   accepted <- grad_ok && reproduced
 
   if (!accepted) {
@@ -1434,7 +1444,9 @@ cpm_boundary_proximity <- function(object) {
 #'   statistics are close but not interchangeable digit-for-digit: the free
 #'   family nests the unit family, and its optimizer is additionally started
 #'   from the unit solution, so on the same input the free statistic never
-#'   exceeds the unit statistic — by construction.) `"unit"` remains
+#'   exceeds the unit statistic beyond the engine's numerical tolerance —
+#'   fits whose boundary harmonics are polished away are compared on their
+#'   own reduced model.) `"unit"` remains
 #'   the default because free scaling buys no inferential benefit for
 #'   correlation input while adding `p` parameters whose analytic standard
 #'   errors are frequently undefined below `n = 2000`; choose `"free"` when the

--- a/R/cpm_fit.R
+++ b/R/cpm_fit.R
@@ -454,6 +454,43 @@ cpm_jitter_offsets_deg <- function(n_free) {
   )
 }
 
+# ---- multi-start battery construction (design sec. 3.5) --------------------
+
+# Build the deterministic start set and its independence groups for one spec.
+# Factored out of cpm_engine() so the free-scaling path can run the same
+# battery under its unit-family twin to obtain the nesting seed (M22).
+cpm_start_set <- function(spec, theta_theory, sv) {
+  g0 <- cpm_pack(theta_theory, sv$zeta, sv$beta, spec)
+  # Mirror start only when angles are free: with fixed angles (B/D) the
+  # reflection is a no-op and would merely duplicate g0.
+  starts <- list(g0)
+  if (spec$free_angles > 0) {
+    starts[[2L]] <- cpm_reflect_par(g0, spec)
+    offs <- cpm_jitter_offsets_deg(spec$free_angles)
+    for (off in offs) {
+      theta_j <- theta_theory
+      theta_j[spec$free_pos] <- theta_theory[spec$free_pos] + off * pi / 180
+      starts[[length(starts) + 1L]] <-
+        cpm_pack(theta_j, sv$zeta, sv$beta, spec)
+    }
+  } else {
+    # No free angles: jitter zeta start instead (deterministic).
+    for (fac in c(0.85, 1.1, 0.7)) {
+      z <- pmin(pmax(sv$zeta * fac, 0.05), 0.99)
+      starts[[length(starts) + 1L]] <-
+        cpm_pack(theta_theory, z, sv$beta, spec)
+    }
+  }
+  # Independence groups for the acceptance criterion: only group
+  # DISTINCTNESS is consumed, so every start is its own group except the
+  # mirror (starts[[2]] when angles are free), which is a deterministic image
+  # of g0 under an exact F-isometry (rho is even) -- its run can only echo
+  # g0's evidence, so it is folded into g0's group.
+  start_group <- seq_along(starts)
+  if (spec$free_angles > 0) start_group[2L] <- 1L
+  list(starts = starts, start_group = start_group)
+}
+
 # ---- single optimization run ------------------------------------------------
 
 cpm_optimize_one <- function(gstar0, R, spec) {
@@ -599,37 +636,60 @@ cpm_engine <- function(R, angles, m = 3, variant = c("A", "B", "C", "D"),
 
   # ---- starting values and multi-start set ----
   sv <- cpm_start_values(R, theta_theory, m)
-  g0 <- cpm_pack(theta_theory, sv$zeta, sv$beta, spec)
+  battery <- cpm_start_set(spec, theta_theory, sv)
+  starts <- battery$starts
+  start_group <- battery$start_group
 
-  # Mirror start only when angles are free: with fixed angles (B/D) the
-  # reflection is a no-op and would merely duplicate g0.
-  starts <- list(g0)
-  if (spec$free_angles > 0) {
-    starts[[2L]] <- cpm_reflect_par(g0, spec)
-    offs <- cpm_jitter_offsets_deg(spec$free_angles)
-    for (off in offs) {
-      theta_j <- theta_theory
-      theta_j[spec$free_pos] <- theta_theory[spec$free_pos] + off * pi / 180
-      starts[[length(starts) + 1L]] <-
-        cpm_pack(theta_j, sv$zeta, sv$beta, spec)
-    }
-  } else {
-    # No free angles: jitter zeta start instead (deterministic).
-    for (fac in c(0.85, 1.1, 0.7)) {
-      z <- pmin(pmax(sv$zeta * fac, 0.05), 0.99)
-      starts[[length(starts) + 1L]] <-
-        cpm_pack(theta_theory, z, sv$beta, spec)
-    }
+  # ---- unit-solution nesting seed (M22; RR05 B2/rec 5) ----
+  # The free family nests the unit family: sigma = 1 recovers it, and the
+  # discrepancy at (theta, zeta, beta, sigma = 1) is bit-identical to the
+  # unit family's at (theta, zeta, beta) (cpm_implied_cov multiplies P by
+  # exactly 1). Embedding the unit fit's pre-polish optimum into the free
+  # layout (s block = 0) therefore starts one run AT F-hat_unit, so the
+  # reported free optimum can only match or undercut it: T_free <= T_unit
+  # holds by construction rather than up to multi-start luck (the M21 paired
+  # calibration measured 3/5,751 optimizer-tail violations without the seed,
+  # worst +5.52 T-units). Top-level fits only by design (M22 plan gate):
+  # cpm_bootstrap() warm-starts replicates from gamma-hat and never
+  # re-enters this battery.
+  seed_idx <- 0L
+  unit_F <- NA_real_
+  if (spec$n_sigma > 0) {
+    spec_unit <- cpm_spec(p, m, variant, reference, scaling = "unit")
+    spec_unit$theta_ref_val <- spec$theta_ref_val
+    spec_unit$theta_fixed <- spec$theta_fixed
+    bat_u <- cpm_start_set(spec_unit, theta_theory, sv)
+    runs_u <- lapply(bat_u$starts, cpm_optimize_one, R = R, spec = spec_unit)
+    Fs_u <- vapply(runs_u, function(r) r$F, numeric(1))
+    gu <- runs_u[[which.min(Fs_u)]]$par
+    unit_F <- min(Fs_u)
+    # Block-exact embedding ([angle][u][v] -> [angle][u][s = 0][v]): no
+    # natural-scale roundtrip, so F(seed) == unit_F to the bit.
+    seed <- numeric(spec$q)
+    seed[spec$i_angle] <- gu[spec_unit$i_angle]
+    seed[spec$i_zeta] <- gu[spec_unit$i_zeta]
+    seed[spec$i_sigma] <- 0
+    seed[spec$i_beta] <- gu[spec_unit$i_beta]
+    starts[[length(starts) + 1L]] <- seed
+    # Own independence group: the seed is a data-derived point (the unit
+    # objective's optimum), not an F-isometric image of g0 like the mirror,
+    # so its run reaching min F is genuine reproduction evidence.
+    start_group <- c(start_group, max(start_group) + 1L)
+    seed_idx <- length(starts)
   }
-  # Independence groups for the acceptance criterion below: only group
-  # DISTINCTNESS is consumed, so every start is its own group except the
-  # mirror (starts[[2]] when angles are free), which is a deterministic image
-  # of g0 under an exact F-isometry (rho is even) -- its run can only echo
-  # g0's evidence, so it is folded into g0's group.
-  start_group <- seq_along(starts)
-  if (spec$free_angles > 0) start_group[2L] <- 1L
 
   runs <- lapply(starts, cpm_optimize_one, R = R, spec = spec)
+
+  # Belt for the by-construction guarantee: nlminb's PORT core is monotone in
+  # practice, but nothing contractual forbids a final iterate above the start.
+  # If the seeded run ends above its own start value, fall back to the seed
+  # point itself, whose objective is exactly unit_F (bit-identical embedding
+  # above) -- nesting then holds unconditionally.
+  if (seed_idx > 0L && runs[[seed_idx]]$F > unit_F) {
+    runs[[seed_idx]] <- list(par = starts[[seed_idx]], F = unit_F,
+                             code = 0L, message = "unit-seed fallback")
+  }
+
   Fs <- vapply(runs, function(r) r$F, numeric(1))
   best <- which.min(Fs)
   fit <- runs[[best]]
@@ -1358,7 +1418,11 @@ cpm_boundary_proximity <- function(object) {
 #'   calibration-indistinguishable at correlation input — in paired simulation
 #'   at the measured truths (`n` from 250 to 50,000) their test statistics
 #'   differed by well under 1 percent of the degrees of freedom — so neither
-#'   family's chi-square is more trustworthy than the other's. `"unit"` remains
+#'   family's chi-square is more trustworthy than the other's. (The two
+#'   statistics are close but not interchangeable digit-for-digit: the free
+#'   family nests the unit family, and its optimizer is additionally started
+#'   from the unit solution, so on the same input the free statistic never
+#'   exceeds the unit statistic — by construction.) `"unit"` remains
 #'   the default because free scaling buys no inferential benefit for
 #'   correlation input while adding `p` parameters whose analytic standard
 #'   errors are frequently undefined below `n = 2000`; choose `"free"` when the

--- a/R/cpm_fit.R
+++ b/R/cpm_fit.R
@@ -671,10 +671,16 @@ cpm_engine <- function(R, angles, m = 3, variant = c("A", "B", "C", "D"),
     seed[spec$i_sigma] <- 0
     seed[spec$i_beta] <- gu[spec_unit$i_beta]
     starts[[length(starts) + 1L]] <- seed
-    # Own independence group: the seed is a data-derived point (the unit
-    # objective's optimum), not an F-isometric image of g0 like the mirror,
-    # so its run reaching min F is genuine reproduction evidence.
-    start_group <- c(start_group, max(start_group) + 1L)
+    # Sentinel group 0: EXCLUDED from the reproduced acceptance count. The
+    # seed is a warm start from a data-derived optimum -- at correlation
+    # input sigma-hat ~= 1, so it starts essentially AT the free optimum and
+    # reaching min F certifies nesting, never reproduction. Counting it
+    # would silently accept start-dependent optima that the data-blind
+    # battery cannot reproduce (observed: the free-family SE cross-check
+    # oracle admitted rare permutation-basin replicates the shipped
+    # criterion excludes). The seeded run still competes on F (nesting) and
+    # participates in the multimodality comparison (it visits real optima).
+    start_group <- c(start_group, 0L)
     seed_idx <- length(starts)
   }
 
@@ -776,7 +782,13 @@ cpm_engine <- function(R, angles, m = 3, variant = c("A", "B", "C", "D"),
   gnorm <- max(abs(cpm_gradient(fit$par, R, spec)))
   grad_ok <- gnorm <= 1e-6 * max(1, abs(fit$F))
   at_min <- abs(Fs - min(Fs)) <= 1e-8
-  reproduced <- length(unique(start_group[at_min])) >= 2L
+  # Group 0 (the unit-solution nesting seed, free scaling only) never counts:
+  # it is a warm start whose convergence to min F certifies nesting, not
+  # start-independent reproduction (see the seed block above). Acceptance
+  # semantics are therefore identical to the unit family's and to the
+  # pre-seed engine: only data-blind battery groups certify.
+  grp_min <- start_group[at_min]
+  reproduced <- length(unique(grp_min[grp_min > 0L])) >= 2L
   accepted <- grad_ok && reproduced
 
   if (!accepted) {

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | planned | M22 | high | milestones/M7-v2-release-prep.md |
-| M22 | Free-engine multi-start nesting seed (T_free ≤ T_unit by construction) | in-progress | — | high | milestones/M22-free-multistart-nesting-seed.md |
+| M22 | Free-engine multi-start nesting seed (T_free ≤ T_unit by construction) | review | — | high | milestones/M22-free-multistart-nesting-seed.md |
 | M20 | 0-vs-360 pole CI-endpoint alignment | done | — | high | milestones/archive/M20-pole-endpoint-alignment.md |
 | M21 | T_diag-vs-T_free inference-default decision + application | done | — | high | milestones/archive/M21-t-calibration-decision.md |
 | M19 | CIRCUM free-scaling — analytic-CI coverage oracle + caution calibration | done | M18 | high | milestones/archive/M19-free-family-coverage-oracle.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | planned | M22 | high | milestones/M7-v2-release-prep.md |
-| M22 | Free-engine multi-start nesting seed (T_free ≤ T_unit by construction) | planned | — | high | milestones/M22-free-multistart-nesting-seed.md |
+| M22 | Free-engine multi-start nesting seed (T_free ≤ T_unit by construction) | in-progress | — | high | milestones/M22-free-multistart-nesting-seed.md |
 | M20 | 0-vs-360 pole CI-endpoint alignment | done | — | high | milestones/archive/M20-pole-endpoint-alignment.md |
 | M21 | T_diag-vs-T_free inference-default decision + application | done | — | high | milestones/archive/M21-t-calibration-decision.md |
 | M19 | CIRCUM free-scaling — analytic-CI coverage oracle + caution calibration | done | M18 | high | milestones/archive/M19-free-family-coverage-oracle.md |

--- a/cairn/milestones/M22-free-multistart-nesting-seed.md
+++ b/cairn/milestones/M22-free-multistart-nesting-seed.md
@@ -121,8 +121,29 @@ construction, eliminating the optimizer-tail violations RR05 measured
   post-fix the file is 20/20 green. T4 done: roxygen + vignette + NEWS
   nesting notes, document() clean.
 
+- 2026-07-16: T3 first full-suite run caught a real interaction (1 FAIL:
+  free-family SE cross-check, test-cpm_oracles.R:677) — diagnosed to the
+  seed's group semantics, not the oracle or the estimates (top-level fits
+  bit-identical pre/post; deviant replicates are genuine better-F
+  permutation basins found by native starts too). Fixed via sentinel group
+  0 (see Decisions); NEWS refined; re-running nesting + oracle files.
+
 ## Decisions
 
+- 2026-07-16 (T3, supersedes the T2 entry below): the seed gets **sentinel
+  group 0, excluded from the `reproduced` acceptance count**. The own-group
+  choice below was empirically wrong: the full suite caught the free-family
+  SE cross-check oracle failing (ratio 0.34 vs > 0.7) because the seeded run
+  — a warm start that at correlation input begins essentially at the free
+  optimum — counted as the second "independent" group, silently accepting
+  replicates whose optimum only ONE data-blind group could reach (verified:
+  the 3 inflating replicates each had exactly 1 native group at min F, and
+  the pre-seed commit passes the oracle file 108/108). The seed certifies
+  nesting, never reproduction; acceptance semantics now match the pre-seed
+  engine exactly. The seeded run still competes on F and participates in the
+  multimodality comparison. Consequence (NEWS-documented): a fit whose
+  better optimum only the seed reaches now reports that optimum WITH the
+  acceptance warning, where pre-seed it reported a worse optimum silently.
 - 2026-07-16 (T2): the unit-solution seed gets its **own independence group**
   in the `reproduced` acceptance criterion — it is a data-derived point (the
   unit objective's optimum), not an F-isometric image of g0 like the mirror,

--- a/cairn/milestones/M22-free-multistart-nesting-seed.md
+++ b/cairn/milestones/M22-free-multistart-nesting-seed.md
@@ -163,3 +163,28 @@ Consistency gate: cairn_validate all pass (after trimming the milestone file
 back under the 150-line cap); document() no diff; pkgdown::check_pkgdown()
 clean; NEWS.md entry present (no milestone numbers); no new top-level files;
 no principle change (cairn_impact skipped).
+
+Independent review (three lenses + scorer): blame-history [S] — clean (M4
+mirror-fold invariant preserved; D-011 wording guardrails honored; bootstrap
+isolation verified). Prior-PR [S] — no prior-PR evidence (no GitHub-native
+review comments exist); cross-checks clean. Diff-bug [O] — deep checks clean
+(refactor byte-equivalent, embedding bit-identity verified empirically,
+mirror interaction safe); 3 findings. Scorer triage:
+
+- F1 (82, actioned → fixed): the sentinel-group-0 exclusion had no
+  deterministic test — pinned only by the stochastic SE oracle. Fixed by
+  extracting `cpm_reproduced()` and unit-testing the group-0 filter
+  directly (6 cases) + acceptance pins on the clean battery fits
+  (platform-robust; deliberately NOT asserting the RR05 fit's accepted
+  flag, which rides knife-edge optimizer luck across BLAS builds).
+- F2 (42, logged, not actioned): belt fallback would inject a
+  non-stationary point into the multimodality comparison — requires the
+  never-observed fallback AND a ≤1e-6 F-gap; errs conservative (spurious
+  warning at worst).
+- F3 (68, sub-threshold but fixed voluntarily — CLAUDE.md vignette-precision
+  doctrine, two-line change): "never exceeds — by construction" overstated
+  the post-polish guarantee; roxygen/vignette/NEWS now say "beyond numerical
+  tolerance" with the polish caveat in the roxygen.
+
+Post-fix: nesting file 34/34; full check() re-run after these edits (result
+recorded below).

--- a/cairn/milestones/M22-free-multistart-nesting-seed.md
+++ b/cairn/milestones/M22-free-multistart-nesting-seed.md
@@ -3,11 +3,11 @@
      Per-section owners are tagged below. -->
 # M22: Free-engine multi-start nesting seed (T_free ≤ T_unit by construction)
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** high
 - **Depends on:** —
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** m22-nesting-seed
 
 ## Goal
 
@@ -80,25 +80,28 @@ construction, eliminating the optimizer-tail violations RR05 measured
 
 ## Tasks
 
-- [ ] **T1** — Tests first: regression test regenerating the RR05
+- [x] **T1** — Tests first: regression test regenerating the RR05
       boundary_N2000 violating replicate from its exact seed, asserting
       T_free ≤ T_unit + 1e-8 (red against current code — record the red
       run); plus a small deterministic nesting property battery (a few
       seeds × variants A and C). Runtime-budget with `skip_on_cran()` if
       needed; remember bare `Rscript` needs `NOT_CRAN=true` (M16 lesson).
-- [ ] **T2** — Implement the seed in `cpm_fit()` (`R/cpm_fit.R:600–630`):
+- [x] **T2** — Implement the seed in `cpm_engine()` (`R/cpm_fit.R`):
       when `scaling == "free"`, run the unit-family fit internally
-      (unit spec, existing battery machinery) and append its winning
-      solution — packed into the free spec, σ = 1 — as one extra start in
-      its own independence group. Resolve and record the `reproduced`/
-      multimodality-flag interaction (milestone-local decision). T1 goes
-      green; unit-path behavior untouched.
+      (unit spec, existing battery machinery via the factored
+      `cpm_start_set()`) and append its winning solution — block-exact
+      embedding, s block = 0 — as one extra start in its own independence
+      group. Resolve and record the `reproduced`/multimodality-flag
+      interaction (milestone-local decision). T1 goes green; unit-path
+      behavior untouched.
 - [ ] **T3** — Oracle + gate: re-run `test-cpm_oracles.R` (M18 lesson:
       OpenMx `type="cov"` needs the (N−1)/N factor; CSOLNP agrees only to
       ~5e-4) and full `devtools::check()`.
-- [ ] **T4** — Docs: nesting note in the `scaling` roxygen block
+- [x] **T4** — Docs: nesting note in the `scaling` roxygen block
       (`R/cpm_fit.R:1358`) and the vignette passage
       (`evaluating-circumplex-structure.Rmd:164`); `devtools::document()`.
+      Plus a NEWS.md entry (consistency-gate requirement; no milestone
+      numbers in user-facing text).
 
 ## Work log
 
@@ -110,6 +113,25 @@ construction, eliminating the optimizer-tail violations RR05 measured
   shipped in M13 (PR #37, squash 95936f2); the stale infra-row clause
   re-added by the 2026-07-16 candidate cleanup was struck.
 
+- 2026-07-16: T1+T2 done (one checkpoint: red test committed with the fix so
+  every branch commit keeps the suite green). Red run recorded: pre-fix, the
+  RR05 replicate (seed 20260706+12e7+1e6·1+1e4·3+29, identified by a 500-rep
+  scan of the boundary_N2000 cell) failed with F_free 0.0069 > F_unit 0.0041
+  (diff ×(N−1) = +5.52 T-units, matching RR05's recorded max exactly);
+  post-fix the file is 20/20 green. T4 done: roxygen + vignette + NEWS
+  nesting notes, document() clean.
+
 ## Decisions
+
+- 2026-07-16 (T2): the unit-solution seed gets its **own independence group**
+  in the `reproduced` acceptance criterion — it is a data-derived point (the
+  unit objective's optimum), not an F-isometric image of g0 like the mirror,
+  so its run reaching min F is genuine reproduction evidence. Multimodality
+  flag: the seeded run is compared like any other; landing distinct-but-
+  competitive correctly fires the flag. Belt: if the seeded run's final F
+  ever exceeds its start value (PORT is monotone in practice but not by
+  contract), the engine falls back to the seed point itself, whose objective
+  equals F̂_unit bit-identically (block-exact embedding, s = 0) — nesting is
+  unconditional.
 
 ## Review

--- a/cairn/milestones/M22-free-multistart-nesting-seed.md
+++ b/cairn/milestones/M22-free-multistart-nesting-seed.md
@@ -7,7 +7,7 @@
 - **Priority:** high
 - **Depends on:** —
 - **Principles touched:** —
-- **Branch/PR:** m22-nesting-seed
+- **Branch/PR:** m22-nesting-seed · https://github.com/jmgirard/circumplex/pull/46
 
 ## Goal
 
@@ -52,22 +52,22 @@ construction, eliminating the optimizer-tail violations RR05 measured
 
 ## Acceptance criteria
 
-- [ ] AC1 — Under `scaling = "free"`, the reported optimum satisfies
+- [x] AC1 — Under `scaling = "free"`, the reported optimum satisfies
       F̂_free ≤ F̂_unit (hence T_free ≤ T_unit) on the same input `R`,
       enforced by the unit-solution start; the unit-family code path and
       the bootstrap warm-start path are behavior-unchanged (existing suite
       green, no snapshot drift).
-- [ ] AC2 — The RR05 boundary_N2000 violating replicate, regenerated from
+- [x] AC2 — The RR05 boundary_N2000 violating replicate, regenerated from
       its exact seed, satisfies T_free ≤ T_unit + 1e-8 after the change;
       the test is demonstrated red on pre-change code (evidence in the
       work log / Review section).
-- [ ] AC3 — Oracle suite green at unchanged tolerances: live OpenMx
+- [x] AC3 — Oracle suite green at unchanged tolerances: live OpenMx
       free-scaling oracle + frozen Grassi et al. (2010) App. A anchors
       (`tests/testthat/test-cpm_oracles.R`) — the ≥2-independent-oracle-types
       bar for an estimation-code change (validation doctrine).
-- [ ] AC4 — Roxygen + vignette wording gains the by-construction nesting
+- [x] AC4 — Roxygen + vignette wording gains the by-construction nesting
       note with no claim extended beyond D-011's scoping.
-- [ ] AC5 — `devtools::test()` and `devtools::check()` clean
+- [x] AC5 — `devtools::test()` and `devtools::check()` clean
       (0 errors / 0 warnings / 0 notes).
 
 ## Coverage
@@ -105,58 +105,61 @@ construction, eliminating the optimizer-tail violations RR05 measured
 
 ## Work log
 
-- 2026-07-16: created by /milestone-plan (promoted from the infra candidate
-  row; source RR05 B2/R5). Plan-gate decisions: M13-D1 export status stands;
-  seed applies to the top-level fit only; M7 re-pointed to depend on M22.
-  Of the three items in the original ask, only the nesting seed remained —
-  the RR01 S3 follow-ups (incl. the export decision, M13-D1) had already
-  shipped in M13 (PR #37, squash 95936f2); the stale infra-row clause
-  re-added by the 2026-07-16 candidate cleanup was struck.
-
-- 2026-07-16: T1+T2 done (one checkpoint: red test committed with the fix so
-  every branch commit keeps the suite green). Red run recorded: pre-fix, the
-  RR05 replicate (seed 20260706+12e7+1e6·1+1e4·3+29, identified by a 500-rep
-  scan of the boundary_N2000 cell) failed with F_free 0.0069 > F_unit 0.0041
-  (diff ×(N−1) = +5.52 T-units, matching RR05's recorded max exactly);
-  post-fix the file is 20/20 green. T4 done: roxygen + vignette + NEWS
-  nesting notes, document() clean.
-
-- 2026-07-16: T3 first full-suite run caught a real interaction (1 FAIL:
-  free-family SE cross-check, test-cpm_oracles.R:677) — diagnosed to the
-  seed's group semantics, not the oracle or the estimates (top-level fits
-  bit-identical pre/post; deviant replicates are genuine better-F
-  permutation basins found by native starts too). Fixed via sentinel group
-  0 (see Decisions); NEWS refined; re-running nesting + oracle files.
-
-- 2026-07-16: T3 done — nesting file 20/20, oracle file 108/108, full
-  check() 0 errors / 0 warnings / 0 notes. All tasks complete; status →
-  review.
+- 2026-07-16: created by /milestone-plan (promoted from the infra row; RR05
+  B2/R5). Gate: M13-D1 stands; top-level seed only; M7 now depends on M22.
+- 2026-07-16: T1+T2 done, one green checkpoint (62752f7). Red run recorded:
+  pre-fix, the RR05 replicate (seed 20260706+12e7+1e6·1+1e4·3+29) violated by
+  +5.52 T-units — RR05's exact max; post-fix 20/20 green. T4: roxygen +
+  vignette + NEWS notes, document() clean.
+- 2026-07-16: T3 full suite caught 1 FAIL (SE cross-check oracle,
+  test-cpm_oracles.R:677) — seed group semantics, not estimates (top-level
+  fits bit-identical pre/post; deviant replicates are genuine better-F
+  permutation basins natives also find). Fixed: sentinel group 0 (f72e2dc).
+- 2026-07-16: T3 done — nesting 20/20, oracles 108/108, check() 0 errors /
+  0 warnings / 0 notes. All tasks complete; status → review.
 
 ## Decisions
 
-- 2026-07-16 (T3, supersedes the T2 entry below): the seed gets **sentinel
-  group 0, excluded from the `reproduced` acceptance count**. The own-group
-  choice below was empirically wrong: the full suite caught the free-family
-  SE cross-check oracle failing (ratio 0.34 vs > 0.7) because the seeded run
-  — a warm start that at correlation input begins essentially at the free
-  optimum — counted as the second "independent" group, silently accepting
-  replicates whose optimum only ONE data-blind group could reach (verified:
-  the 3 inflating replicates each had exactly 1 native group at min F, and
-  the pre-seed commit passes the oracle file 108/108). The seed certifies
-  nesting, never reproduction; acceptance semantics now match the pre-seed
-  engine exactly. The seeded run still competes on F and participates in the
-  multimodality comparison. Consequence (NEWS-documented): a fit whose
-  better optimum only the seed reaches now reports that optimum WITH the
-  acceptance warning, where pre-seed it reported a worse optimum silently.
-- 2026-07-16 (T2): the unit-solution seed gets its **own independence group**
-  in the `reproduced` acceptance criterion — it is a data-derived point (the
-  unit objective's optimum), not an F-isometric image of g0 like the mirror,
-  so its run reaching min F is genuine reproduction evidence. Multimodality
-  flag: the seeded run is compared like any other; landing distinct-but-
-  competitive correctly fires the flag. Belt: if the seeded run's final F
-  ever exceeds its start value (PORT is monotone in practice but not by
-  contract), the engine falls back to the seed point itself, whose objective
-  equals F̂_unit bit-identically (block-exact embedding, s = 0) — nesting is
-  unconditional.
+- 2026-07-16 (T3, supersedes the T2 entry): seed gets **sentinel group 0 —
+  excluded from `reproduced`**. Own-group was empirically wrong: the seed is
+  a warm start (starts ≈ at the free optimum at correlation input), so
+  counting it silently accepted fits only ONE data-blind group could reach
+  (the 3 SE-inflating replicates each had exactly 1 native group at min F;
+  pre-seed commit passes the oracle file 108/108). The seed certifies
+  nesting, never reproduction; acceptance semantics match the pre-seed
+  engine exactly; the seed run still competes on F and in the multimodality
+  comparison. NEWS-documented consequence: a seed-rescued fit now reports
+  the better optimum WITH the acceptance warning.
+- 2026-07-16 (T2): seed as own independence group in `reproduced` (genuine
+  data-derived point, unlike the mirror). Belt: if the seeded run ends above
+  its start value, fall back to the seed point (F = F̂_unit bit-identically).
+  The group choice was superseded at T3 (above); the belt stands.
 
 ## Review
+
+Reviewed 2026-07-16 (/milestone-review, same session as implement). PR #46.
+Evidence gathered fresh, post final code commit (f72e2dc):
+
+- **AC1**: test-cpm_nesting.R 20/20 (re-run at review) — nesting on the RR05
+  replicate + deterministic battery (variants A, C; unpolished, equal df
+  asserted). Unit path and bootstrap warm-start path unchanged: full suite
+  green inside check() (all existing pins intact); cpm_bootstrap()
+  warm-starts via cpm_optimize_one (R/cpm_fit.R:1180) and never re-enters
+  the battery — the seed lives only in cpm_engine().
+- **AC2**: red run recorded pre-fix (work log, 62752f7): F_free 0.0069 >
+  F_unit 0.0041 (+5.52 T-units — RR05's exact recorded max) on the exact
+  seed; green at review (same file, 20/20).
+- **AC3**: test-cpm_oracles.R 108/108 at review — live OpenMx free-scaling
+  oracle + frozen Grassi App. A anchors, tolerances unchanged (≥2 oracle
+  types). The SE cross-check (:677) failed under the first group semantics
+  and passes under sentinel-group-0; diagnosis logged in Decisions.
+- **AC4**: nesting note added to the scaling roxygen (R/cpm_fit.R) and the
+  vignette equivalence passage; wording stays inside D-011's scoping (model
+  test, correlation input, measured envelope). document() no diff.
+- **AC5**: devtools::check(args = "--no-manual") — 0 errors / 0 warnings /
+  0 notes (5m17s), post f72e2dc.
+
+Consistency gate: cairn_validate all pass (after trimming the milestone file
+back under the 150-line cap); document() no diff; pkgdown::check_pkgdown()
+clean; NEWS.md entry present (no milestone numbers); no new top-level files;
+no principle change (cairn_impact skipped).

--- a/cairn/milestones/M22-free-multistart-nesting-seed.md
+++ b/cairn/milestones/M22-free-multistart-nesting-seed.md
@@ -3,7 +3,7 @@
      Per-section owners are tagged below. -->
 # M22: Free-engine multi-start nesting seed (T_free ≤ T_unit by construction)
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** high
 - **Depends on:** —
 - **Principles touched:** —
@@ -94,7 +94,7 @@ construction, eliminating the optimizer-tail violations RR05 measured
       group. Resolve and record the `reproduced`/multimodality-flag
       interaction (milestone-local decision). T1 goes green; unit-path
       behavior untouched.
-- [ ] **T3** — Oracle + gate: re-run `test-cpm_oracles.R` (M18 lesson:
+- [x] **T3** — Oracle + gate: re-run `test-cpm_oracles.R` (M18 lesson:
       OpenMx `type="cov"` needs the (N−1)/N factor; CSOLNP agrees only to
       ~5e-4) and full `devtools::check()`.
 - [x] **T4** — Docs: nesting note in the `scaling` roxygen block
@@ -127,6 +127,10 @@ construction, eliminating the optimizer-tail violations RR05 measured
   bit-identical pre/post; deviant replicates are genuine better-F
   permutation basins found by native starts too). Fixed via sentinel group
   0 (see Decisions); NEWS refined; re-running nesting + oracle files.
+
+- 2026-07-16: T3 done — nesting file 20/20, oracle file 108/108, full
+  check() 0 errors / 0 warnings / 0 notes. All tasks complete; status →
+  review.
 
 ## Decisions
 

--- a/cairn/milestones/M22-free-multistart-nesting-seed.md
+++ b/cairn/milestones/M22-free-multistart-nesting-seed.md
@@ -186,5 +186,7 @@ mirror interaction safe); 3 findings. Scorer triage:
   the post-polish guarantee; roxygen/vignette/NEWS now say "beyond numerical
   tolerance" with the polish caveat in the roxygen.
 
-Post-fix: nesting file 34/34; full check() re-run after these edits (result
-recorded below).
+Post-fix: nesting file 34/34; full check() re-run after these edits —
+0 errors / 0 warnings / 0 notes (4m 9s, on 768c0b9's tree). CI on the
+pre-fix review commit was green across all 7 checks (macOS/Linux×3/Windows/
+coverage/pkgdown); final-commit CI gates the merge.

--- a/man/cpm_fit.Rd
+++ b/man/cpm_fit.Rd
@@ -66,7 +66,9 @@ family's chi-square is more trustworthy than the other's. (The two
 statistics are close but not interchangeable digit-for-digit: the free
 family nests the unit family, and its optimizer is additionally started
 from the unit solution, so on the same input the free statistic never
-exceeds the unit statistic — by construction.) \code{"unit"} remains
+exceeds the unit statistic beyond the engine's numerical tolerance —
+fits whose boundary harmonics are polished away are compared on their
+own reduced model.) \code{"unit"} remains
 the default because free scaling buys no inferential benefit for
 correlation input while adding \code{p} parameters whose analytic standard
 errors are frequently undefined below \code{n = 2000}; choose \code{"free"} when the

--- a/man/cpm_fit.Rd
+++ b/man/cpm_fit.Rd
@@ -62,7 +62,11 @@ covariance moments). For the model test the two families are
 calibration-indistinguishable at correlation input — in paired simulation
 at the measured truths (\code{n} from 250 to 50,000) their test statistics
 differed by well under 1 percent of the degrees of freedom — so neither
-family's chi-square is more trustworthy than the other's. \code{"unit"} remains
+family's chi-square is more trustworthy than the other's. (The two
+statistics are close but not interchangeable digit-for-digit: the free
+family nests the unit family, and its optimizer is additionally started
+from the unit solution, so on the same input the free statistic never
+exceeds the unit statistic — by construction.) \code{"unit"} remains
 the default because free scaling buys no inferential benefit for
 correlation input while adding \code{p} parameters whose analytic standard
 errors are frequently undefined below \code{n = 2000}; choose \code{"free"} when the

--- a/tests/testthat/test-cpm_nesting.R
+++ b/tests/testthat/test-cpm_nesting.R
@@ -1,0 +1,72 @@
+# Nesting of the free-scaling family in the unit family (M22; RR05 B2/R5).
+#
+# The free family nests the unit family (sigma = 1 recovers it, with an
+# identical discrepancy value at the same theta/zeta/beta), so the minimized
+# discrepancy must satisfy F_free <= F_unit on the same input R. Without the
+# unit-solution seed this held only up to multi-start luck: the free engine
+# could land on a worse optimum than the unit fit of the same R (3/5,751 used
+# replicates in the M21 paired calibration, worst +5.52 T-units). The engine
+# seeds the free battery with the accepted unit solution, enforcing nesting
+# by construction (top-level fits only; bootstrap replicates keep their
+# warm starts).
+
+test_that("free fit never exceeds the unit fit's discrepancy (RR05 worst violator)", {
+  skip_on_cran()
+  # Provenance: replicate i = 29 of the M21 paired T-calibration cell
+  # boundary_N2000 — generator devel/m21-t-calibration.R, seed formula
+  # BASE_SEED + OFFSET + 1e6*cfg_idx + 1e4*N_idx + i with BASE_SEED =
+  # 20260706, OFFSET = 12e7, cfg_idx = 1 (boundary), N_idx = 3 (N = 2000).
+  # This replicate is RR05's recorded worst nesting violation (T_free -
+  # T_unit = +5.52 pre-seed): red before the unit-solution seed, green after.
+  p <- 8
+  angles <- octants()
+  angles_rad <- as.numeric(as_radian(as_degree(angles)))
+  P0 <- cpm_implied_cor(angles_rad, rep(0.75, p), c(.45, .35, .15, .05))
+  N <- 2000
+  set.seed(20260706 + 12e7 + 1e6 * 1 + 1e4 * 3 + 29)
+  X <- matrix(stats::rnorm(N * p), nrow = N) %*% chol(P0)
+  R <- stats::cor(X)
+
+  eu <- suppressWarnings(
+    cpm_engine(R, angles = angles, m = 3, variant = "A", scaling = "unit")
+  )
+  ef <- suppressWarnings(
+    cpm_engine(R, angles = angles, m = 3, variant = "A", scaling = "free")
+  )
+
+  # Nesting is well-posed only on the same spec: neither family polished.
+  expect_length(eu$removed_harmonics, 0)
+  expect_length(ef$removed_harmonics, 0)
+  expect_identical(ef$df, eu$df)
+
+  expect_lte(ef$F, eu$F + 1e-8)
+})
+
+test_that("nesting holds across a small deterministic battery (variants A and C)", {
+  skip_on_cran()
+  # Interior truth (M21 configs); N small enough to keep the battery quick.
+  # Seeds are arbitrary but fixed; verified unpolished at write time so the
+  # equal-df comparison stays well-posed.
+  p <- 8
+  angles <- octants()
+  angles_rad <- as.numeric(as_radian(as_degree(angles)))
+  P0 <- cpm_implied_cor(angles_rad, rep(0.75, p), c(.35, .30, .20, .15))
+  N <- 500
+  for (variant in c("A", "C")) {
+    for (seed in c(101, 202)) {
+      set.seed(seed)
+      X <- matrix(stats::rnorm(N * p), nrow = N) %*% chol(P0)
+      R <- stats::cor(X)
+      eu <- suppressWarnings(
+        cpm_engine(R, angles = angles, m = 3, variant = variant, scaling = "unit")
+      )
+      ef <- suppressWarnings(
+        cpm_engine(R, angles = angles, m = 3, variant = variant, scaling = "free")
+      )
+      expect_length(eu$removed_harmonics, 0)
+      expect_length(ef$removed_harmonics, 0)
+      expect_identical(ef$df, eu$df)
+      expect_lte(ef$F, eu$F + 1e-8)
+    }
+  }
+})

--- a/tests/testthat/test-cpm_nesting.R
+++ b/tests/testthat/test-cpm_nesting.R
@@ -67,6 +67,30 @@ test_that("nesting holds across a small deterministic battery (variants A and C)
       expect_length(ef$removed_harmonics, 0)
       expect_identical(ef$df, eu$df)
       expect_lte(ef$F, eu$F + 1e-8)
+      # The seed must not DISTURB acceptance on clean data: the data-blind
+      # battery reproduces the optimum here, so both families stay accepted.
+      expect_true(eu$accepted)
+      expect_true(ef$accepted)
     }
   }
+})
+
+test_that("the nesting seed's sentinel group never certifies reproduction", {
+  # Deterministic pin of the group-0 exclusion in the convergence-acceptance
+  # criterion. The seed is a warm start: it certifies nesting, never
+  # start-independent reproduction. A refactor that drops the group > 0
+  # filter (letting the seed count as an independent group) flips the first
+  # two cases and silently accepts start-dependent optima that only the
+  # warm start can reach — the failure mode the free-family SE cross-check
+  # oracle caught when the seed briefly carried its own group.
+  # Seed (group 0) alone at min F: not reproduced.
+  expect_false(cpm_reproduced(c(1L, 1L, 2L, 3L, 0L), c(FALSE, FALSE, FALSE, FALSE, TRUE)))
+  # Seed plus exactly ONE native group at min F: still not reproduced.
+  expect_false(cpm_reproduced(c(1L, 1L, 2L, 3L, 0L), c(TRUE, FALSE, FALSE, FALSE, TRUE)))
+  # Two native groups at min F: reproduced, with or without the seed.
+  expect_true(cpm_reproduced(c(1L, 1L, 2L, 3L, 0L), c(TRUE, FALSE, TRUE, FALSE, FALSE)))
+  expect_true(cpm_reproduced(c(1L, 1L, 2L, 3L, 0L), c(TRUE, FALSE, TRUE, FALSE, TRUE)))
+  # Unit family (no group 0 present): pre-seed semantics, unchanged.
+  expect_true(cpm_reproduced(c(1L, 1L, 2L, 3L), c(TRUE, FALSE, TRUE, FALSE)))
+  expect_false(cpm_reproduced(c(1L, 1L, 2L, 3L), c(TRUE, TRUE, FALSE, FALSE)))
 })

--- a/vignettes/evaluating-circumplex-structure.Rmd
+++ b/vignettes/evaluating-circumplex-structure.Rmd
@@ -163,8 +163,9 @@ reproduce published CIRCUM/CircE output exactly. For the model test the choice
 does not matter here: with correlation input the two families' test statistics
 are calibration-indistinguishable (differing by well under 1% of the model
 degrees of freedom in paired simulation at sample sizes 250–50,000; the free
-statistic never exceeds the default's on the same input, since the free
-family nests the default and is additionally started from its solution), and
+statistic never exceeds the default's on the same input beyond numerical
+tolerance, since the free family nests the default and is additionally
+started from its solution), and
 the default is recommended for
 routine inference because free scaling adds parameters whose analytic standard
 errors are often undefined at small-to-moderate samples. The

--- a/vignettes/evaluating-circumplex-structure.Rmd
+++ b/vignettes/evaluating-circumplex-structure.Rmd
@@ -162,8 +162,10 @@ sizes; pass `scaling = "free"` to fit their covariance parameterization and
 reproduce published CIRCUM/CircE output exactly. For the model test the choice
 does not matter here: with correlation input the two families' test statistics
 are calibration-indistinguishable (differing by well under 1% of the model
-degrees of freedom in paired simulation at sample sizes 250–50,000), and the
-default is recommended for
+degrees of freedom in paired simulation at sample sizes 250–50,000; the free
+statistic never exceeds the default's on the same input, since the free
+family nests the default and is additionally started from its solution), and
+the default is recommended for
 routine inference because free scaling adds parameters whose analytic standard
 errors are often undefined at small-to-moderate samples. The
 *conclusion* — ordered octants with unequal spacing, adequate approximate


### PR DESCRIPTION
## Summary

- `cpm_engine(scaling = "free")` now seeds its multi-start battery with the internally-fitted unit-family solution (block-exact embedding, sigma = 1), so the free family's minimized discrepancy can never exceed the unit family's on the same input — the nesting property T_free <= T_unit that the docs' calibration-equivalence wording leans on now holds by construction (RR05 B2/rec 5; 3/5,751 optimizer-tail violations measured without it, worst +5.52 T-units).
- The seed run is EXCLUDED from the `reproduced` convergence-acceptance count (sentinel group 0): it is a warm start certifying nesting, never start-independent reproduction — acceptance semantics are bit-identical to the shipped engine. The first (own-group) attempt was caught by the free-family SE cross-check oracle admitting start-dependent permutation-basin fits; see the milestone Decisions log.
- Regression test regenerates RR05's worst violating replicate from its exact seed (red pre-fix, green post-fix) plus a deterministic nesting battery (variants A and C); roxygen/vignette/NEWS notes.

## Evidence

- test-cpm_nesting.R 20/20; test-cpm_oracles.R 108/108 (OpenMx + Grassi anchors, unchanged tolerances); devtools::check() 0 errors / 0 warnings / 0 notes.
- Bootstrap replicates keep warm starts (cpm_bootstrap never re-enters the battery) — top-level fits only, per the plan gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)