### PR TITLE
M24: tidyverse NSE in the user API — evaluation + standing decision (verdict: NO, D-014)

### DIFF
--- a/cairn/DECISIONS.md
+++ b/cairn/DECISIONS.md
@@ -352,8 +352,9 @@ Import, bare-rlang `enquo()`, or an in-house parser (the datawizard route).
 Grounds: (1) peer group — the modeling packages circumplex interoperates
 with (lavaan engine, OpenMx oracle, psych) are SE/formula; tidy-eval NSE
 marks tidyverse-identity packages (memo §1); (2) dependency delta — 6
-net-new Imports incl. vctrs (refused by D-006) and an R-floor jump
-3.4 → 4.1 via glue (memo §2); (3) measured ergonomics — `PANO()` is already
+net-new Imports incl. vctrs (refused by D-006); the closure's R floors are
+neutral — circumplex's effective install floor is already 4.1 via
+ggplot2/htmlTable (memo §2, corrected at review); (3) measured ergonomics — `PANO()` is already
 shorter than the NSE form at the canonical call, and NSE's best case
 (`starts_with()` for items) undermines `score()`'s ascending-order
 contract, a silent mis-scoring channel (memo §3.1); (4) ambiguity spikes —

--- a/cairn/DECISIONS.md
+++ b/cairn/DECISIONS.md
@@ -338,3 +338,37 @@ gate with a work-log line; challenges to reviewed holdings need a new RB.
 none merge-gated behind M7 (D-012). D-002/D-003/D-006/D-007 reinforced,
 none superseded. Source: RR06 (Fable, 2026-07-16); M23 T3.
 
+### D-014 (2026-07-16): tidyverse-style NSE stays out of the user API (M24)
+
+**Context:** Pre-1.0 circumplex had rlang tidy-eval NSE; the v1.0.0
+breaking release removed it ("streamline and reduce dependencies",
+NEWS.md:412–416). M24 re-evaluated adoption on four evidence strata
+(`devel/m24-nse-evaluation.md`).
+**Decision:** The user-facing API remains standard evaluation — character
+names / numeric indices via `is_var()` — with instrument helpers
+(`PANO()`-family) as the ergonomic layer. **Full rejection**: bare-name
+capture AND tidyselect-style select helpers, whether via a tidyselect
+Import, bare-rlang `enquo()`, or an in-house parser (the datawizard route).
+Grounds: (1) peer group — the modeling packages circumplex interoperates
+with (lavaan engine, OpenMx oracle, psych) are SE/formula; tidy-eval NSE
+marks tidyverse-identity packages (memo §1); (2) dependency delta — 6
+net-new Imports incl. vctrs (refused by D-006) and an R-floor jump
+3.4 → 4.1 via glue (memo §2); (3) measured ergonomics — `PANO()` is already
+shorter than the NSE form at the canonical call, and NSE's best case
+(`starts_with()` for items) undermines `score()`'s ascending-order
+contract, a silent mis-scoring channel (memo §3.1); (4) ambiguity spikes —
+data-mask column/env collision silently selects wrong columns (a
+statistical wrong-answer channel SE cannot produce) and user wrappers
+require `{{ }}` (memo §3.2, runnable); (5) back-compat — a second
+API-philosophy reversal for users who absorbed v1.0.0 (memo §4).
+**Re-trigger:** reopen only on concrete evidence the SE interface fails
+users — recurring user reports that name-vector/instrument helpers cannot
+solve, or a hard interop requirement from a downstream tidyverse-native
+consumer. Modernization or style advocacy alone never re-triggers. Any
+reopening supersedes this entry and passes the `irreversible-api` RB gate
+(Fable) before any build.
+**Consequences:** DESIGN.md Dependency policy gains the one-line doctrine;
+rlang stays imported solely for the ggplot2 `.data` pronoun; no NEWS entry
+(no user-facing change). Confirms and evidences the v1.0.0 removal; D-006
+reinforced. Source: M24 memo; plan-gate answers (Jeff, 2026-07-16).
+

--- a/cairn/DESIGN.md
+++ b/cairn/DESIGN.md
@@ -356,7 +356,10 @@ the **runtime engine of the SEM-based SSM feature family** (`ssm_sem()`,
 `ssm_sem_parameters()`): those entry points gate on `requireNamespace()`
 with a clear install-hint error, the package loads and all non-SEM
 functionality runs without lavaan, and it is never load-required (amended
-2026-07-07 per the M5 spec §7.4). No tidyverse in package code.
+2026-07-07 per the M5 spec §7.4). No tidyverse in package code. The user
+API is standard evaluation by design — character names / numeric indices,
+never tidy-eval NSE (v1.0.0 removal re-affirmed with evidence: D-014,
+`devel/m24-nse-evaluation.md`).
 
 ## Testing strategy
 

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | planned | M22 | high | milestones/M7-v2-release-prep.md |
-| M24 | Tidyverse NSE in the user API — evaluation + standing decision | planned | — | normal | milestones/M24-nse-evaluation.md |
+| M24 | Tidyverse NSE in the user API — evaluation + standing decision | in-progress | — | normal | milestones/M24-nse-evaluation.md |
 | M23 | Longitudinal & intraindividual SSM — Fable-reviewed design + build-ready spec | done | — | high | milestones/archive/M23-longitudinal-ssm-design.md |
 | M22 | Free-engine multi-start nesting seed (T_free ≤ T_unit by construction) | done | — | high | milestones/archive/M22-free-multistart-nesting-seed.md |
 | M20 | 0-vs-360 pole CI-endpoint alignment | done | — | high | milestones/archive/M20-pole-endpoint-alignment.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | planned | M22 | high | milestones/M7-v2-release-prep.md |
-| M24 | Tidyverse NSE in the user API — evaluation + standing decision | in-progress | — | normal | milestones/M24-nse-evaluation.md |
+| M24 | Tidyverse NSE in the user API — evaluation + standing decision | review | — | normal | milestones/M24-nse-evaluation.md |
 | M23 | Longitudinal & intraindividual SSM — Fable-reviewed design + build-ready spec | done | — | high | milestones/archive/M23-longitudinal-ssm-design.md |
 | M22 | Free-engine multi-start nesting seed (T_free ≤ T_unit by construction) | done | — | high | milestones/archive/M22-free-multistart-nesting-seed.md |
 | M20 | 0-vs-360 pole CI-endpoint alignment | done | — | high | milestones/archive/M20-pole-endpoint-alignment.md |

--- a/cairn/milestones/M24-nse-evaluation.md
+++ b/cairn/milestones/M24-nse-evaluation.md
@@ -111,6 +111,10 @@ memo's spike snippets are evidence, not shipped code).
   appended (full rejection + re-trigger clause); DESIGN.md Dependency-policy
   one-liner added. Verify slot vacuously clean (docs-only diff: devel/ +
   cairn/ only; R/, src/, tests/ untouched). Status → review.
+- 2026-07-16: review correction (supersedes the T2 line's floor claim): the
+  "R-floor jump 3.4 → 4.1" was false — ggplot2/htmlTable already put the
+  effective floor at 4.1 (diff-bug reviewer, scored 84); memo §2/§4 and
+  D-014 corrected pre-merge, verdict unaffected.
 
 ## Decisions
 <!-- owner: implement / review · append-only; milestone-local; promote
@@ -139,3 +143,29 @@ Review 2026-07-16 (PR #48). Evidence gathered fresh, by command.
   the task's tripwire condition). PASS.
 - AC4: `git diff --name-only master..HEAD` = 5 files, all under `cairn/` or
   `devel/`; 0 files under R/, src/, tests/. PASS.
+
+Consistency gate 2026-07-16: `cairn_validate.py` all checks passed;
+`cairn_impact` skipped (no IP/GP changed — none exist yet);
+`devtools::document()` no diff; pkgdown `check_pkgdown()` no problems;
+`^devel$`/`^cairn$` in .Rbuildignore; NEWS entry not owed (no user-visible
+change; docs-only); README untouched (inherited state); full
+`devtools::check(args = "--no-manual")`: 0 errors, 0 warnings, 0 notes.
+
+Independent review (3 lenses + scorer):
+- [S] prior-PR-comments: no prior-PR evidence (no review comments on any of
+  the 20 milestone-pattern PRs). Zero findings.
+- [S] blame-history: zero findings; NEWS citations, D-006 quote, DESIGN.md
+  section history, and the rlang-only-for-.data claim all verified accurate;
+  legacy "tidyverse-ectomy" records corroborate the memo narrative.
+- [O] diff-bug: ONE finding — the memo/D-014 "R-floor jump 3.4 → 4.1" claim
+  is false by the memo's own method (ggplot2 and htmlTable already Depend on
+  R ≥ 4.1 on current CRAN, so the effective floor is already 4.1 and
+  tidyselect adds no floor increase). Independently re-verified by the
+  orchestrator against live CRAN metadata. All other memo claims verified
+  correct by the reviewer (closure, spikes, citations, survey table, D-006
+  consistency, ACs).
+- [S] scorer: finding scored 84 (≥ 80 → actioned). Sub-80 findings: none.
+- Triage: FIX NOW — floor-jump clause corrected in memo §2/§4 (marked as a
+  review correction) and in D-014 ground 2 (pre-merge, entry unpublished);
+  the NO verdict stands on the remaining independently verified grounds.
+  Verdict unaffected; no other changes.

--- a/cairn/milestones/M24-nse-evaluation.md
+++ b/cairn/milestones/M24-nse-evaluation.md
@@ -77,7 +77,7 @@ memo's spike snippets are evidence, not shipped code).
       (candidates: lavaan, psych, lme4, survey, mirt, semTools, easystats
       family; pick for comparability, not convenience) accept variable/
       column specifications; memo §1 with doc citations. (Sonnet-suitable.)
-- [ ] T2: Dependency-delta — tidyselect's transitive Imports closure and
+- [x] T2: Dependency-delta — tidyselect's transitive Imports closure and
       minimum R version vs current DESCRIPTION (R >= 3.4, rlang already
       imported for `.data` only); note D-006's vctrs refusal; memo §2.
 - [ ] T3: Ergonomics + ambiguity spike — rewrite ≥3 vignette call sites
@@ -99,6 +99,9 @@ memo's spike snippets are evidence, not shipped code).
 - 2026-07-16: T1 done — 7-package survey (6 inspected locally, rstatix via
   CRAN), memo §1; peer modeling packages are SE/formula, tidy-eval NSE only
   in tidyverse-identity or in-house-reimplementation packages.
+- 2026-07-16: T2 done — memo §2: 6 net-new Imports (incl. vctrs, refused by
+  D-006) and an R-floor jump 3.4 → 4.1 (glue ≥ 4.1); closure computed from
+  live CRAN metadata, method shown.
 
 ## Decisions
 <!-- owner: implement / review · append-only; milestone-local; promote

--- a/cairn/milestones/M24-nse-evaluation.md
+++ b/cairn/milestones/M24-nse-evaluation.md
@@ -7,7 +7,7 @@
 - **Priority:** normal   <!-- owner: plan · create/amend-via-gate -->
 - **Depends on:** —   <!-- owner: plan · create/amend-via-gate -->
 - **Principles touched:** —   <!-- no numbered IP/GP exist yet (deferred to /design-interview); governs DESIGN.md "Dependency policy" prose -->
-- **Branch/PR:** m24-nse-evaluation   <!-- owner: implement (branch) / review (PR URL) · create -->
+- **Branch/PR:** m24-nse-evaluation · https://github.com/jmgirard/circumplex/pull/48   <!-- owner: implement (branch) / review (PR URL) · create -->
 
 ## Goal
 <!-- owner: plan · create; a wrong goal returns to plan, never edited in place -->
@@ -40,7 +40,7 @@ memo's spike snippets are evidence, not shipped code).
 ## Acceptance criteria
 <!-- owner: plan · create/amend-via-gate; review reads, never reinterprets -->
 
-- [ ] AC1: `devel/m24-nse-evaluation.md` exists and covers all four strata:
+- [x] AC1: `devel/m24-nse-evaluation.md` exists and covers all four strata:
       (a) column-spec interfaces of ≥6 comparable CRAN statistics packages,
       each with a citation to its documentation; (b) the exact Imports
       closure and R-version floor tidyselect would add (computed from
@@ -48,16 +48,16 @@ memo's spike snippets are evidence, not shipped code).
       shipped vignettes rewritten in hypothetical NSE form beside the
       current SE form, including one programming/wrapper case requiring
       embracing; (d) back-compat analysis vs the v1.0.0 removal.
-- [ ] AC2: the memo's ambiguity spike is runnable R (data-mask
+- [x] AC2: the memo's ambiguity spike is runnable R (data-mask
       column/env-variable collision + the embracing case), with output
       shown — evidence, not vibes.
-- [ ] AC3: the decision is recorded per the plan-gate answers: NO → a
+- [x] AC3: the decision is recorded per the plan-gate answers: NO → a
       full-rejection D-entry (re-trigger clause included) + the DESIGN.md
       Dependency-policy one-liner citing it; GO → a superseding D-entry
       (v1.0.0 removal explicitly superseded) + a build-candidate ROADMAP
       row, with the `irreversible-api` RB gate honored before the GO is
       final.
-- [ ] AC4: docs-only — `git diff` for the milestone touches no files under
+- [x] AC4: docs-only — `git diff` for the milestone touches no files under
       R/, src/, or tests/.
 
 ## Coverage
@@ -119,3 +119,23 @@ memo's spike snippets are evidence, not shipped code).
 ## Review
 <!-- owner: review · exclusive; evidence per criterion, consistency-gate
      results, review findings + triage. EXEMPT from the 150-line cap (M55). -->
+
+Review 2026-07-16 (PR #48). Evidence gathered fresh, by command.
+
+- AC1: memo exists with all four strata as `## §1–§4` headers (grep); §1
+  table has 7 packages each with a citation column entry (6 inspected
+  locally with versions, rstatix via CRAN); §2 shows the
+  `tools::package_dependencies()` method and CRAN Depends floors; §3 has 3
+  vignette sites (grep "Site N" = 3) incl. the embracing wrapper case; §4
+  carries the back-compat stratum. PASS.
+- AC2: both spikes re-run fresh in a clean Rscript session; all five
+  documented outcomes asserted via `stopifnot()` (collision selects column
+  `sel`; `all_of()` corrects; direct NSE works; naive wrapper errors
+  "object 'PA' not found"; embraced wrapper works) — "AC2 spikes: all five
+  assertions hold". PASS.
+- AC3: NO path taken — `D-014` present in DECISIONS.md (line 341) with an
+  explicit **Re-trigger** clause; DESIGN.md Dependency policy cites D-014
+  (line 361). RB gate n/a (rejection leaves the shipped API untouched, per
+  the task's tripwire condition). PASS.
+- AC4: `git diff --name-only master..HEAD` = 5 files, all under `cairn/` or
+  `devel/`; 0 files under R/, src/, tests/. PASS.

--- a/cairn/milestones/M24-nse-evaluation.md
+++ b/cairn/milestones/M24-nse-evaluation.md
@@ -3,11 +3,11 @@
      Per-section owners are tagged below. -->
 # M24: Tidyverse NSE in the user API — evaluation + standing decision
 
-- **Status:** planned   <!-- owner: transitioning skill · mirror-update; cairn/ROADMAP.md is the authority -->
+- **Status:** in-progress   <!-- owner: transitioning skill · mirror-update; cairn/ROADMAP.md is the authority -->
 - **Priority:** normal   <!-- owner: plan · create/amend-via-gate -->
 - **Depends on:** —   <!-- owner: plan · create/amend-via-gate -->
 - **Principles touched:** —   <!-- no numbered IP/GP exist yet (deferred to /design-interview); governs DESIGN.md "Dependency policy" prose -->
-- **Branch/PR:** —   <!-- owner: implement (branch) / review (PR URL) · create -->
+- **Branch/PR:** m24-nse-evaluation   <!-- owner: implement (branch) / review (PR URL) · create -->
 
 ## Goal
 <!-- owner: plan · create; a wrong goal returns to plan, never edited in place -->
@@ -73,7 +73,7 @@ memo's spike snippets are evidence, not shipped code).
 <!-- owner: plan (create) / implement (check-off, minor edits); substantive
      change is amend-via-gate -->
 
-- [ ] T1: Prior-art survey — how do ≥6 comparable CRAN statistics packages
+- [x] T1: Prior-art survey — how do ≥6 comparable CRAN statistics packages
       (candidates: lavaan, psych, lme4, survey, mirt, semTools, easystats
       family; pick for comparability, not convenience) accept variable/
       column specifications; memo §1 with doc citations. (Sonnet-suitable.)
@@ -96,6 +96,9 @@ memo's spike snippets are evidence, not shipped code).
 
 - 2026-07-16: created by /milestone-plan (plan-gate: deeper decision
   milestone; rejection-scope = full; DESIGN.md one-liner = yes).
+- 2026-07-16: T1 done — 7-package survey (6 inspected locally, rstatix via
+  CRAN), memo §1; peer modeling packages are SE/formula, tidy-eval NSE only
+  in tidyverse-identity or in-house-reimplementation packages.
 
 ## Decisions
 <!-- owner: implement / review · append-only; milestone-local; promote

--- a/cairn/milestones/M24-nse-evaluation.md
+++ b/cairn/milestones/M24-nse-evaluation.md
@@ -3,7 +3,7 @@
      Per-section owners are tagged below. -->
 # M24: Tidyverse NSE in the user API — evaluation + standing decision
 
-- **Status:** in-progress   <!-- owner: transitioning skill · mirror-update; cairn/ROADMAP.md is the authority -->
+- **Status:** review   <!-- owner: transitioning skill · mirror-update; cairn/ROADMAP.md is the authority -->
 - **Priority:** normal   <!-- owner: plan · create/amend-via-gate -->
 - **Depends on:** —   <!-- owner: plan · create/amend-via-gate -->
 - **Principles touched:** —   <!-- no numbered IP/GP exist yet (deferred to /design-interview); governs DESIGN.md "Dependency policy" prose -->
@@ -85,7 +85,7 @@ memo's spike snippets are evidence, not shipped code).
       `intermediate-ssm-analysis.Rmd` measures/grouping calls, a long
       `score()` items case) in NSE form; runnable snippets for the
       column/env collision and embracing cases; memo §3.
-- [ ] T4: Synthesis + decision — memo §4 verdict weighing all strata against
+- [x] T4: Synthesis + decision — memo §4 verdict weighing all strata against
       the v1.0.0 rationale; append the D-entry and DESIGN.md line (NO path)
       or superseding D-entry + build candidate (GO path). (RB tripwire:
       irreversible-api — offer Fable escalation before finalizing a GO;
@@ -106,6 +106,11 @@ memo's spike snippets are evidence, not shipped code).
   beats NSE; score()'s ascending-order contract makes starts_with() a
   mis-scoring channel); both spikes run with verbatim output (collision
   silently selects the wrong column; naive wrappers error without {{ }}).
+- 2026-07-16: T4 done — memo §4 verdict NO (all four strata against; RB
+  tripwire not fired — rejection leaves the shipped API untouched); D-014
+  appended (full rejection + re-trigger clause); DESIGN.md Dependency-policy
+  one-liner added. Verify slot vacuously clean (docs-only diff: devel/ +
+  cairn/ only; R/, src/, tests/ untouched). Status → review.
 
 ## Decisions
 <!-- owner: implement / review · append-only; milestone-local; promote

--- a/cairn/milestones/M24-nse-evaluation.md
+++ b/cairn/milestones/M24-nse-evaluation.md
@@ -80,7 +80,7 @@ memo's spike snippets are evidence, not shipped code).
 - [x] T2: Dependency-delta — tidyselect's transitive Imports closure and
       minimum R version vs current DESCRIPTION (R >= 3.4, rlang already
       imported for `.data` only); note D-006's vctrs refusal; memo §2.
-- [ ] T3: Ergonomics + ambiguity spike — rewrite ≥3 vignette call sites
+- [x] T3: Ergonomics + ambiguity spike — rewrite ≥3 vignette call sites
       (e.g., `ssm_analyze(jz2017, scales = PANO())`,
       `intermediate-ssm-analysis.Rmd` measures/grouping calls, a long
       `score()` items case) in NSE form; runnable snippets for the
@@ -102,6 +102,10 @@ memo's spike snippets are evidence, not shipped code).
 - 2026-07-16: T2 done — memo §2: 6 net-new Imports (incl. vctrs, refused by
   D-006) and an R-floor jump 3.4 → 4.1 (glue ≥ 4.1); closure computed from
   live CRAN metadata, method shown.
+- 2026-07-16: T3 done — memo §3: 3 vignette sites rewritten (PANO() already
+  beats NSE; score()'s ascending-order contract makes starts_with() a
+  mis-scoring channel); both spikes run with verbatim output (collision
+  silently selects the wrong column; naive wrappers error without {{ }}).
 
 ## Decisions
 <!-- owner: implement / review · append-only; milestone-local; promote

--- a/devel/m24-nse-evaluation.md
+++ b/devel/m24-nse-evaluation.md
@@ -1,0 +1,54 @@
+# M24 — Tidyverse-style NSE in the circumplex user API: evaluation memo
+
+Deliverable of milestone M24 (`cairn/milestones/M24-nse-evaluation.md`).
+Question: should circumplex's user-facing functions support tidyverse-style
+non-standard evaluation (bare column names and/or tidyselect helpers), in
+place of or alongside the current standard-evaluation (SE) interface
+(character names or numeric indices, validated by `is_var()`, `R/utils.R:199`)?
+
+Historical anchor: pre-1.0 circumplex **had** rlang tidy-eval NSE
+(NEWS.md:660); the v1.0.0 breaking release deliberately removed it —
+"Nearly all code rewritten/refactored to streamline and reduce dependencies
+… Removed support for non-standard evaluation" (NEWS.md:412–416). This memo
+evaluates whether that decision should stand, on four evidence strata.
+
+## §1 Prior art: column-spec interfaces of comparable CRAN packages
+
+Seven packages surveyed; versions are the locally installed ones whose
+signatures/docs were inspected directly (2026-07-16), except rstatix (CRAN
+page). "Formula-NSE" (classical S formulas) is distinguished from
+tidy-eval/tidyselect NSE throughout — formulas are ubiquitous in statistical
+R and are not what this question is about.
+
+| Package (version) | Interface for variable/column spec | Style | Citation |
+|---|---|---|---|
+| lavaan (0.6-21) | model as a character syntax string; variables named as strings inside it (`cfa(model, data)`) | SE | `?lavaan::cfa` (args `model`, `data`) |
+| psych (2.6.5) | matrices/data frames; `scoreItems(keys, items)` with keys as item names/numbers | SE | `?psych::fa`, `?psych::scoreItems` |
+| lme4 (2.0.1) | `lmer(formula, data)` | formula-NSE | `?lme4::lmer` |
+| survey (4.5) | `svydesign(ids = ~psu, strata = ~stype, …)` | formula-NSE | `?survey::svydesign` |
+| OpenMx (2.22.11) | `mxModel(manifestVars = <character>)` | SE | `?OpenMx::mxModel` |
+| datawizard (1.3.1) | `select` accepts literal names, strings, `"a:c"` ranges, formulas, positions, in-house `starts_with()`-style helpers, predicate functions — **without tidyselect** (Imports: insight, stats, utils only) | dual SE + in-house NSE | `?datawizard::extract_column_names` |
+| rstatix (CRAN) | tidyverse-native throughout; Imports dplyr, tidyr, tidyselect (≥ 1.2.0), rlang, purrr, broom, tibble, … | tidy-eval NSE | CRAN rstatix page: "coherent with the 'tidyverse' design philosophy" |
+
+**Reading.** Mainstream statistical *modeling* packages — including every
+package circumplex already interoperates with (lavaan as SEM engine, OpenMx
+as test oracle, psych as the closest substantive neighbor) — use SE strings/
+indices or classical formulas. Tidy-eval NSE appears only where it is the
+package's identity (rstatix) or where a package re-implemented selection
+in-house at real complexity cost to avoid the dependency stack (datawizard
+documents ~8 accepted `select` input forms — evidence both that some users
+value flexible selection *and* that supporting it dependency-free is a large
+ambiguity surface to own). circumplex's peer group is the modeling column,
+not the tidyverse-workflow column.
+
+## §2 Dependency delta
+
+(to follow — T2)
+
+## §3 Ergonomics and ambiguity on real call sites
+
+(to follow — T3)
+
+## §4 Synthesis and verdict
+
+(to follow — T4)

--- a/devel/m24-nse-evaluation.md
+++ b/devel/m24-nse-evaluation.md
@@ -167,4 +167,30 @@ learn `{{ }}`. The current SE interface makes the naive wrapper just work.
 
 ## §4 Synthesis and verdict
 
-(to follow — T4)
+**Back-compat vs the v1.0.0 removal (stratum d).** CRAN users absorbed one
+API-philosophy reversal at v1.0.0 (NSE removed, arguments renamed, NEWS
+"Breaking changes"). Re-adding NSE now would be a second reversal of the
+same axis within two major versions: every vignette, the pkgdown site, and
+published tutorials teach the SE idiom; a dual interface (strings still
+work, bare names added) avoids breakage but imports §3.2's collision
+ambiguity into a package where a silently wrong column selection feeds a
+statistical estimate. The 1.0.0 rationale — streamline, reduce dependencies
+— is *strengthened* by the current evidence (§2's floor jump did not exist
+then; D-006 had not yet refused vctrs).
+
+**Weighing.** For adoption: unquoted ergonomics for tidyverse-native users;
+selection helpers for long item lists. Against: the ergonomic win is
+already captured by instrument helpers (`PANO()` is shorter than the NSE
+call, §3.1); the helper win is a mis-scoring channel at the one site it
+would matter (`score()`'s ascending-order contract, §3.1); 6 net-new
+Imports incl. D-006-refused vctrs and an R-floor jump to 4.1 (§2); a
+data-mask wrong-answer channel SE cannot produce plus `{{ }}` literacy
+demanded of exactly this package's power users (§3.2); and a peer group
+that is uniformly SE/formula (§1).
+
+**Verdict: NO — full rejection** (bare-name capture *and* tidyselect-style
+helpers, whether via a tidyselect Import, bare-rlang `enquo()`, or an
+in-house parser), per the M24 plan-gate scope answer. Recorded as
+DECISIONS.md **D-014** with a re-trigger clause; DESIGN.md Dependency
+policy carries the one-line doctrine. The v1.0.0 removal stands, now with
+recorded evidence rather than NEWS-line archaeology.

--- a/devel/m24-nse-evaluation.md
+++ b/devel/m24-nse-evaluation.md
@@ -43,7 +43,41 @@ not the tidyverse-workflow column.
 
 ## §2 Dependency delta
 
-(to follow — T2)
+Method: recursive Imports closure from live CRAN metadata (2026-07-16),
+
+```r
+ap <- available.packages(repos = "https://cloud.r-project.org")
+tools::package_dependencies("tidyselect", db = ap,
+                            which = "Imports", recursive = TRUE)
+```
+
+then subtract base packages and circumplex's current Imports (DESCRIPTION:
+boot, ggforce, ggplot2, htmlTable, parallel, Rcpp, rlang, stats; rlang is
+imported today **only** for the ggplot2 `.data` pronoun — zero user-facing
+NSE machinery in package code).
+
+**Net-new Imports** (6): `tidyselect`, `vctrs`, `cli`, `glue`, `lifecycle`,
+`withr`.
+
+**R-version floors** (CRAN Depends fields): tidyselect ≥ 3.4, cli ≥ 3.4,
+lifecycle ≥ 3.6, withr ≥ 3.6, **vctrs ≥ 4.0.0, glue ≥ 4.1** — adopting
+tidyselect raises circumplex's floor from `R (>= 3.4)` to `R (>= 4.1)`.
+
+Two aggravating precedents:
+
+- **vctrs is in the closure.** D-006 (2026-07-12, Fable-reviewed RB01→RR01)
+  explicitly refused a direct vctrs Import as breaching the minimal-deps /
+  no-tidyverse-in-package-code doctrine (`cairn/DESIGN.md` "Dependency
+  policy"). Taking it transitively via tidyselect lands the same dependency
+  weight the same decision refused.
+- **The no-dependency alternatives are not free.** (a) Bare-rlang NSE
+  (`enquo()`/`eval_tidy`, no tidyselect) adds no packages — rlang is already
+  imported — but delivers only bare-name capture (no `starts_with()`), while
+  importing the full ambiguity surface of §3. (b) The datawizard route
+  (in-house re-implementation) avoids the stack but means owning a parser
+  for ~8 input forms in a package whose doctrine is that statistical
+  correctness outranks all other concerns — maintenance surface in exactly
+  the wrong place.
 
 ## §3 Ergonomics and ambiguity on real call sites
 

--- a/devel/m24-nse-evaluation.md
+++ b/devel/m24-nse-evaluation.md
@@ -60,10 +60,16 @@ NSE machinery in package code).
 `withr`.
 
 **R-version floors** (CRAN Depends fields): tidyselect ≥ 3.4, cli ≥ 3.4,
-lifecycle ≥ 3.6, withr ≥ 3.6, **vctrs ≥ 4.0.0, glue ≥ 4.1** — adopting
-tidyselect raises circumplex's floor from `R (>= 3.4)` to `R (>= 4.1)`.
+lifecycle ≥ 3.6, withr ≥ 3.6, vctrs ≥ 4.0.0, glue ≥ 4.1. The closure's
+floors are **neutral, not aggravating**: applying the same method to
+circumplex's *existing* Imports shows ggplot2 and htmlTable already carry
+`Depends: R (>= 4.1)` on current CRAN, so the effective install floor is
+4.1 today and tidyselect adds no floor increase (the declared
+`R (>= 3.4)` in DESCRIPTION is also unaffected — transitive floors are not
+declared). [Corrected at review: the draft claimed a 3.4 → 4.1 "floor
+jump"; the M24 diff-bug reviewer refuted it by the memo's own method.]
 
-Two aggravating precedents:
+One aggravating precedent:
 
 - **vctrs is in the closure.** D-006 (2026-07-12, Fable-reviewed RB01→RR01)
   explicitly refused a direct vctrs Import as breaching the minimal-deps /
@@ -175,15 +181,16 @@ published tutorials teach the SE idiom; a dual interface (strings still
 work, bare names added) avoids breakage but imports §3.2's collision
 ambiguity into a package where a silently wrong column selection feeds a
 statistical estimate. The 1.0.0 rationale — streamline, reduce dependencies
-— is *strengthened* by the current evidence (§2's floor jump did not exist
-then; D-006 had not yet refused vctrs).
+— is *strengthened* by the current evidence (the closure is now quantified
+at 6 packages, and D-006's vctrs refusal postdates it).
 
 **Weighing.** For adoption: unquoted ergonomics for tidyverse-native users;
 selection helpers for long item lists. Against: the ergonomic win is
 already captured by instrument helpers (`PANO()` is shorter than the NSE
 call, §3.1); the helper win is a mis-scoring channel at the one site it
 would matter (`score()`'s ascending-order contract, §3.1); 6 net-new
-Imports incl. D-006-refused vctrs and an R-floor jump to 4.1 (§2); a
+Imports incl. D-006-refused vctrs (§2; the closure's R floors are neutral —
+the effective floor is already 4.1); a
 data-mask wrong-answer channel SE cannot produce plus `{{ }}` literacy
 demanded of exactly this package's power users (§3.2); and a peer group
 that is uniformly SE/formula (§1).

--- a/devel/m24-nse-evaluation.md
+++ b/devel/m24-nse-evaluation.md
@@ -81,7 +81,89 @@ Two aggravating precedents:
 
 ## §3 Ergonomics and ambiguity on real call sites
 
-(to follow — T3)
+### 3.1 Shipped vignette call sites, rewritten in hypothetical NSE form
+
+Site 1 — `introduction-to-ssm-analysis.Rmd:362` (the canonical call):
+
+```r
+# current SE                                   # hypothetical NSE
+ssm_analyze(jz2017, scales = PANO())           ssm_analyze(jz2017, scales = c(PA, BC, DE, FG, HI, JK, LM, NO))
+```
+
+The instrument helper is *shorter than the NSE form*: the main ergonomic
+argument for NSE ("stop typing quoted names") was already solved in 1.0.0 by
+`PANO()`-style helpers, which every vignette teaches.
+
+Site 2 — `intermediate-ssm-analysis.Rmd:66-68, 97-100` (measures/grouping):
+
+```r
+# current SE                                   # hypothetical NSE
+ssm_analyze(jz2017, scales = PANO(),           ssm_analyze(jz2017, scales = PANO(),
+  measures = c("NARPD", "ASPD"),                 measures = c(NARPD, ASPD),
+  grouping = "Gender")                           grouping = Gender)
+ssm_analyze(jz2017, scales = PANO(),           # NSE cannot express measures = 10:12
+  grouping = "Gender", measures = 10:12)       #   without all_of()/positional helpers
+```
+
+Saving: four quote characters per call. Cost: the vignette's own
+`measures = 10:12` numeric-index idiom now needs tidyselect position
+semantics or a dual interface (§3.2's ambiguity).
+
+Site 3 — `using-instruments.Rmd:83,108-110` (long item selections):
+
+```r
+# current SE                                   # hypothetical NSE
+ipsatize(raw_iipsc, items = 1:32)              ipsatize(raw_iipsc, items = starts_with("IIP"))
+score(raw_iipsc, items = 1:32, iipsc)          score(raw_iipsc, items = num_range("IIP", 1:32), iipsc)
+```
+
+This is NSE's best case — but it is *worse than useless here*: `score()`'s
+contract requires items **in ascending instrument order**
+(using-instruments.Rmd:105); `starts_with()` returns data-frame column
+order, silently mis-scoring shuffled items that `items = 1:32`-style
+explicit indexing forces the user to confront. The one site where
+tidyselect helpers shine is the one site whose statistical contract they
+undermine.
+
+### 3.2 Runnable ambiguity spikes
+
+Run 2026-07-16, R 4.x, tidyselect 1.2.1 / rlang (session library); output
+verbatim.
+
+Spike A — data-mask collision (env variable shadowed by a same-named
+column). The user's `sel` holds the intended scale names, but the data
+happen to contain a column named `sel`:
+
+```r
+library(tidyselect); library(rlang)
+df  <- data.frame(PA = 1, BC = 2, sel = 3)
+sel <- c("PA", "BC")
+eval_select(expr(sel), df)          # sel
+                                    #   3    <- silently selects COLUMN sel
+eval_select(expr(all_of(sel)), df)  # PA BC
+                                    #  1  2   <- correct, but only via all_of()
+```
+
+A wrong-columns silent selection feeding an SSM fit is a *statistical*
+wrong-answer channel that the SE interface cannot produce (`data[sel]` uses
+the env variable, always).
+
+Spike B — programming against an NSE API requires embracing. A toy NSE
+front-end and a user's perfectly natural wrapper around it:
+
+```r
+toy_nse       <- function(data, scales) names(eval_select(enquo(scales), data))
+wrap_naive    <- function(data, v) toy_nse(data, v)
+wrap_embraced <- function(data, v) toy_nse(data, {{ v }})
+d2 <- data.frame(PA = 1, BC = 2, DE = 3)
+toy_nse(d2, c(PA, BC))         # [1] "PA" "BC"
+wrap_naive(d2, c(PA, BC))      # ERROR: object 'PA' not found
+wrap_embraced(d2, c(PA, BC))   # [1] "PA" "BC"
+```
+
+Every user who loops SSM analyses over scale sets or wraps `ssm_analyze()`
+in a lab utility — the package's research audience does exactly this — must
+learn `{{ }}`. The current SE interface makes the naive wrapper just work.
 
 ## §4 Synthesis and verdict
 


### PR DESCRIPTION
Docs-only decision milestone (cairn M24). Evaluates tidyverse-style NSE for the user-facing API on four evidence strata (prior-art survey, dependency delta, ergonomics + runnable ambiguity spikes, back-compat vs the v1.0.0 removal); verdict NO — recorded as D-014 (full rejection with re-trigger clause) plus a DESIGN.md Dependency-policy doctrine line. Deliverable: devel/m24-nse-evaluation.md. No changes under R/, src/, or tests/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)