### PR TITLE
Plotting vignette rewrite + pkgdown visualization reference

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,9 +9,11 @@
   reusable layers, and plotting a trajectory across occasions.
 
 * The reference index now groups the plotting API into "Complete Plots" and
-  "Building Blocks", and every plotting function cross-links to its siblings, so
-  `ssm_plot_trajectory()` and the composable layers are reachable from each
-  other's help pages.
+  "Building Blocks". The `ssm_plot_*` functions now cross-link to each other, so
+  `ssm_plot_trajectory()` is reachable from its siblings' help pages, and the
+  composable layers (`ggcircumplex()`, `coord_circumplex()`, the `geom_ssm_*()`
+  layers, `scale_x_circumplex()`, and `theme_circumplex()`) likewise cross-link
+  to each other.
 
 * The new `ssm_plot_trajectory()` plots how each SSM parameter changes across
   occasions, one panel per parameter with its confidence interval as a band, for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # circumplex (development version)
 
+* The "Advanced Circumplex Visualization" vignette has been rewritten over the
+  new plotting API. It now teaches `coord_circumplex()` as the owner of the
+  amplitude-to-radius mapping (replacing the old advice to keep a per-layer
+  `amax` in sync), the configurable circle center and amplitude-axis placement,
+  restyling the canvas through `theme_circumplex()` and ordinary `theme()`
+  calls, subclassing the exported `GeomSsmPoint`/`GeomSsmArc` objects to build
+  reusable layers, and plotting a trajectory across occasions.
+
+* The reference index now groups the plotting API into "Complete Plots" and
+  "Building Blocks", and every plotting function cross-links to its siblings, so
+  `ssm_plot_trajectory()` and the composable layers are reachable from each
+  other's help pages.
+
 * The new `ssm_plot_trajectory()` plots how each SSM parameter changes across
   occasions, one panel per parameter with its confidence interval as a band, for
   results from `ssm_analyze(occasions = )` and `ssm_analyze_long()`. The

--- a/R/coord_circumplex.R
+++ b/R/coord_circumplex.R
@@ -43,7 +43,7 @@
 #' @param ... Reserved for future extensions; currently unused.
 #' @return A \pkg{ggplot2} coordinate system that can be added to a plot with
 #'   `+`.
-#' @seealso [ggcircumplex()], [geom_ssm_point()], [geom_ssm_arc()]
+#' @family circumplex layers
 #' @export
 #' @examples
 #' data("jz2017")

--- a/R/geom_ssm.R
+++ b/R/geom_ssm.R
@@ -102,7 +102,7 @@ ssm_deprecate_geom_arg <- function(value, arg, fn) {
 #'   profiles with a missing displacement or amplitude, since they have no
 #'   location on the circle; if `TRUE` (the default) remove them silently.
 #' @return A \pkg{ggplot2} layer.
-#' @seealso [coord_circumplex()], [ggcircumplex()], [geom_ssm_arc()]
+#' @family circumplex layers
 #' @export
 #' @examples
 #' data("jz2017")
@@ -198,7 +198,7 @@ GeomSsmPoint <- ggplot2::ggproto(
 #'   profiles with an incomplete confidence region (a missing amplitude or
 #'   displacement bound); if `TRUE` (the default) remove them silently.
 #' @return A \pkg{ggplot2} layer.
-#' @seealso [coord_circumplex()], [ggcircumplex()], [geom_ssm_point()]
+#' @family circumplex layers
 #' @export
 #' @examples
 #' data("jz2017")

--- a/R/scale_circumplex.R
+++ b/R/scale_circumplex.R
@@ -47,7 +47,7 @@ circumplex_degree_labels <- function(angles) {
 #' @param ... Additional arguments passed to
 #'   [ggplot2::scale_x_continuous()], such as `name` or `limits`.
 #' @return A \pkg{ggplot2} scale object that can be added to a plot with `+`.
-#' @seealso [ggcircumplex()]
+#' @family circumplex layers
 #' @export
 #' @examples
 #' # Degree-labeled angle axis

--- a/R/ssm_plot.R
+++ b/R/ssm_plot.R
@@ -43,6 +43,7 @@ has_ggrepel <- function() {
 #'   of profiles is five or less. (default = FALSE)
 #' @param ... Not used. Supplying an unrecognized argument produces a warning.
 #' @return A ggplot variable containing a completed circular plot.
+#' @family visualization functions
 #' @export
 #' @examples
 #' \donttest{
@@ -257,6 +258,7 @@ ssm_plot_circle <- function(ssm_object,
 #'   low fit (<.70) or include them with dashed lines (default = FALSE).
 #' @param ... Not used. Supplying an unrecognized argument produces a warning.
 #' @return A ggplot object depicting the SSM curve(s) of each profile.
+#' @family visualization functions
 #' @export
 #' @examples
 #' \donttest{
@@ -396,6 +398,7 @@ ssm_plot_curve <- function(ssm_object,
 #' @param ... Not used. Supplying an unrecognized argument produces a warning.
 #' @return A ggplot variable containing difference point-ranges faceted by SSM
 #'   parameter. An interval that does not contain the value of zero has p<.05.
+#' @family visualization functions
 #' @export
 #' @examples
 #' \donttest{
@@ -539,6 +542,7 @@ ssm_plot_contrast <- function(ssm_object, drop_xy = FALSE,
 #'   `labels` is given) the scale abbreviations are taken from the instrument
 #'   (default = `NULL`).
 #' @return A \pkg{ggplot2} object containing the empty circumplex canvas.
+#' @family circumplex layers
 #' @seealso [coord_circumplex()], which owns the transform this canvas is built
 #'   on; [ssm_plot_circle()], which draws SSM results on this canvas.
 #' @export
@@ -596,7 +600,7 @@ ggcircumplex <- function(angles = octants(), labels = NULL,
 #' @param base_size A single positive number giving the base font size (in pt)
 #'   for the theme (default = 12).
 #' @return A \pkg{ggplot2} theme object, to be added to a plot with `+`.
-#' @seealso [ggcircumplex()], [coord_circumplex()]
+#' @family circumplex layers
 #' @export
 #' @examples
 #' # Restyle the canvas with a larger base font

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -37,10 +37,6 @@ reference:
   - ssm_analyze
   - ssm_analyze_long
   - ssm_table
-  - ssm_plot_circle
-  - ssm_plot_contrast
-  - ssm_plot_curve
-  - ssm_plot_trajectory
   - ssm_parameters
   - ssm_parameters_id
   - summary.circumplex_ssm_id
@@ -67,8 +63,15 @@ reference:
   - ssm_ci_accuracy
   - summary.circumplex_ci_accuracy
   - plot.circumplex_ci_accuracy
-- title: Visualization Layer
-  desc: Composable ggplot2 components for building circumplex figures
+- title: Visualization - Complete Plots
+  desc: Ready-made circumplex figures for a set of SSM results
+  contents:
+  - ssm_plot_circle
+  - ssm_plot_curve
+  - ssm_plot_contrast
+  - ssm_plot_trajectory
+- title: Visualization - Building Blocks
+  desc: Composable ggplot2 components for building custom circumplex figures
   contents:
   - ggcircumplex
   - coord_circumplex

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -14,7 +14,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M31 | Circumplex coordinate-system build | done | M30 | high | milestones/archive/M31-coord-system-build.md |
 | M32 | Circumplex geom & layer ergonomics | done | M31 | normal | milestones/archive/M32-geom-ergonomics.md |
 | M33 | Longitudinal trajectory visualization (occasions objects) | done | — | high | milestones/archive/M33-trajectory-visualization.md |
-| M34 | Plotting vignette + pkgdown reference | planned | M31, M32, M33 | normal | milestones/M34-plotting-vignette-pkgdown.md |
+| M34 | Plotting vignette + pkgdown reference | in-progress | M31, M32, M33 | normal | milestones/M34-plotting-vignette-pkgdown.md |
 | M35 | Model-based trajectory plotting (`ssm_draws()` tables) | done | M33 | normal | milestones/archive/M35-model-based-trajectory.md |
 
 ## Candidates

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -14,7 +14,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M31 | Circumplex coordinate-system build | done | M30 | high | milestones/archive/M31-coord-system-build.md |
 | M32 | Circumplex geom & layer ergonomics | done | M31 | normal | milestones/archive/M32-geom-ergonomics.md |
 | M33 | Longitudinal trajectory visualization (occasions objects) | done | — | high | milestones/archive/M33-trajectory-visualization.md |
-| M34 | Plotting vignette + pkgdown reference | in-progress | M31, M32, M33 | normal | milestones/M34-plotting-vignette-pkgdown.md |
+| M34 | Plotting vignette + pkgdown reference | review | M31, M32, M33 | normal | milestones/M34-plotting-vignette-pkgdown.md |
 | M35 | Model-based trajectory plotting (`ssm_draws()` tables) | done | M33 | normal | milestones/archive/M35-model-based-trajectory.md |
 
 ## Candidates

--- a/cairn/milestones/M34-plotting-vignette-pkgdown.md
+++ b/cairn/milestones/M34-plotting-vignette-pkgdown.md
@@ -57,7 +57,7 @@ plots, and organize the pkgdown reference so the plotting API is discoverable.
 - [x] **T1** — Extend/refresh the plotting vignette with coord + center, geom
       subclassing + styling, and trajectory sections, each with a runnable
       example rendered from actual output.
-- [ ] **T2** — Reorganize `_pkgdown.yml` visualization reference groups; run
+- [x] **T2** — Reorganize `_pkgdown.yml` visualization reference groups; run
       `pkgdown::check_pkgdown()` for orphaned/missing topics.
 - [ ] **T3** — Statistical-precision prose pass; full `check()`.
 
@@ -65,6 +65,7 @@ plots, and organize the pkgdown reference so the plotting API is discoverable.
 
 - 2026-07-17: created by /milestone-plan (viz expansion, area D).
 - 2026-07-18: gate — single rewritten vignette; occasions trajectory path only (growth vignette keeps the table path); two pkgdown viz groups; M35 legend-glyph defect stays a candidate (no scope amendment).
+- 2026-07-18: T2 done — `_pkgdown.yml` split into "Visualization - Complete Plots" (the four `ssm_plot_*`, moved out of Primary SSM Functions) and "Visualization - Building Blocks"; added `@family visualization functions` to the plot trio and a new `@family circumplex layers` across the six building blocks, replacing their incomplete hand-kept `@seealso` lists. `check_pkgdown()`: no problems found.
 - 2026-07-18: T1 done — vignette rewritten (stale per-layer `amax` teaching removed; coord/center/r_axis_angle, theming, geom subclassing, occasions trajectory added). Render-and-inspect fixed an illegible center demo and two "Coordinate system already present" messages. Suite 2886 pass.
 
 ## Decisions

--- a/cairn/milestones/M34-plotting-vignette-pkgdown.md
+++ b/cairn/milestones/M34-plotting-vignette-pkgdown.md
@@ -59,14 +59,15 @@ plots, and organize the pkgdown reference so the plotting API is discoverable.
       example rendered from actual output.
 - [x] **T2** — Reorganize `_pkgdown.yml` visualization reference groups; run
       `pkgdown::check_pkgdown()` for orphaned/missing topics.
-- [ ] **T3** — Statistical-precision prose pass; full `check()`.
+- [x] **T3** — Statistical-precision prose pass; full `check()`.
 
 ## Work log
 
 - 2026-07-17: created by /milestone-plan (viz expansion, area D).
 - 2026-07-18: gate — single rewritten vignette; occasions trajectory path only (growth vignette keeps the table path); two pkgdown viz groups; M35 legend-glyph defect stays a candidate (no scope amendment).
-- 2026-07-18: T2 done — `_pkgdown.yml` split into "Visualization - Complete Plots" (the four `ssm_plot_*`, moved out of Primary SSM Functions) and "Visualization - Building Blocks"; added `@family visualization functions` to the plot trio and a new `@family circumplex layers` across the six building blocks, replacing their incomplete hand-kept `@seealso` lists. `check_pkgdown()`: no problems found.
 - 2026-07-18: T1 done — vignette rewritten (stale per-layer `amax` teaching removed; coord/center/r_axis_angle, theming, geom subclassing, occasions trajectory added). Render-and-inspect fixed an illegible center demo and two "Coordinate system already present" messages. Suite 2886 pass.
+- 2026-07-18: T2 done — `_pkgdown.yml` split into "Visualization - Complete Plots" (the four `ssm_plot_*`, moved out of Primary SSM Functions) and "Visualization - Building Blocks"; added `@family visualization functions` to the plot trio and a new `@family circumplex layers` across the six building blocks, replacing their incomplete hand-kept `@seealso` lists. `check_pkgdown()`: no problems found.
+- 2026-07-18: T3 done — precision pass added the unwrap's unverifiable half-turn assumption, the bands-are-pointwise-not-simultaneous caveat, and the vector-averaging reading of a short group amplitude (printed live, not asserted in prose); rescaled the individuals figure (amax 3 -> 1.75) so the shrinkage it describes is actually visible. NEWS entry added. `devtools::check()`: 0 errors / 0 warnings / 0 notes.
 
 ## Decisions
 

--- a/cairn/milestones/M34-plotting-vignette-pkgdown.md
+++ b/cairn/milestones/M34-plotting-vignette-pkgdown.md
@@ -33,17 +33,17 @@ plots, and organize the pkgdown reference so the plotting API is discoverable.
 
 ## Acceptance criteria
 
-- [ ] The vignette teaches the coordinate system + configurable center, geom
+- [x] The vignette teaches the coordinate system + configurable center, geom
       subclassing + new styling options, and trajectory plots, each with a
       runnable chunk; it builds under `devtools::check()` (the authoritative
       vignette build — [LESSONS.md M21](../LESSONS.md)).
-- [ ] `_pkgdown.yml` groups the visualization functions coherently; `pkgdown::
+- [x] `_pkgdown.yml` groups the visualization functions coherently; `pkgdown::
       check_pkgdown()` (or build) reports every exported plotting function
       referenced (no orphaned topics).
-- [ ] Prose reviewed for statistical precision (no CI-as-significance-test
+- [x] Prose reviewed for statistical precision (no CI-as-significance-test
       phrasing); rendered figures reflect the actual current output (re-run the
       chunks, don't edit narrative by guess — [LESSONS.md M16](../LESSONS.md)).
-- [ ] `devtools::check()` clean (0 errors / 0 warnings / 0 notes).
+- [x] `devtools::check()` clean (0 errors / 0 warnings / 0 notes).
 
 ## Coverage
 
@@ -69,8 +69,92 @@ plots, and organize the pkgdown reference so the plotting API is discoverable.
 - 2026-07-18: T2 done — `_pkgdown.yml` split into "Visualization - Complete Plots" (the four `ssm_plot_*`, moved out of Primary SSM Functions) and "Visualization - Building Blocks"; added `@family visualization functions` to the plot trio and a new `@family circumplex layers` across the six building blocks, replacing their incomplete hand-kept `@seealso` lists. `check_pkgdown()`: no problems found.
 - 2026-07-18: T3 done — precision pass added the unwrap's unverifiable half-turn assumption, the bands-are-pointwise-not-simultaneous caveat, and the vector-averaging reading of a short group amplitude (printed live, not asserted in prose); rescaled the individuals figure (amax 3 -> 1.75) so the shrinkage it describes is actually visible. NEWS entry added. `devtools::check()`: 0 errors / 0 warnings / 0 notes.
 
+- 2026-07-18: review — three-lens fan-out returned 6 findings; F1/F2/F3 (>=80) actioned, F5/F4/F6 (<80) logged below. F1 and F2 were real content defects that `check()` could not see.
 - 2026-07-18: all tasks done; `devtools::check()` re-run on the final tree (incl. NEWS): 0 errors / 0 warnings / 0 notes. Status -> review.
 
 ## Decisions
 
 ## Review
+
+**PR:** https://github.com/jmgirard/circumplex/pull/59 (2026-07-18)
+
+### Acceptance criteria — fresh evidence
+
+- **AC1 (vignette teaches the three topics, runnable chunks, builds under `check()`).**
+  Coordinate system + center: sections "The coordinate system" (chunk `coord-bare`),
+  "Moving the center" (`coord-center`), "Moving the amplitude axis" (`coord-r-axis`).
+  Geom subclassing + styling: "Extending the layers" (`subclass`, a working
+  `GeomSsmStar` subclass of `GeomSsmPoint`), "Restyling the canvas" (`theming`).
+  Trajectory: "Trajectories across occasions" (`occasions-data`, `occasions-plot`).
+  14 code chunks total, all executing. `devtools::check()` reports
+  "re-building of vignette outputs ... OK".
+- **AC2 (`_pkgdown.yml` grouping; no orphaned topics).** `pkgdown::check_pkgdown()`:
+  "No problems found". Audited against the dev tree (`load_all()`, not the installed
+  package — LESSONS M21): all 10 user-facing plotting exports are listed, none
+  duplicated across groups. The 3 unlisted exports (`CoordCircumplex`, `GeomSsmArc`,
+  `GeomSsmPoint`) are documented on the `@keywords internal` `circumplex-ggproto`
+  page and are index-exempt by design (LESSONS M32).
+- **AC3 (statistical precision; figures from actual output).** Grep for
+  significance-test phrasing finds only the two intentional disclaimers (the arc
+  paragraph and the hollow-point rule). Every figure was rendered and visually
+  inspected; the render pass caught three defects `check()` passed silently (an
+  illegible `center` demo, two leaked "Coordinate system already present" messages,
+  and an `amax` that hid the shrinkage the prose described). Numeric claims are
+  printed live from the chunk, not asserted in prose. The occasion-ordering claim
+  was corrected after review verified it empirically (see F2).
+- **AC4 (`check()` clean).** 0 errors / 0 warnings / 0 notes, re-run after the
+  review fixes on the final tree.
+
+### Consistency gate
+
+`cairn_validate.py`: exit 0, all 15 checks pass. No DESIGN principle changed, so
+`cairn_impact` was skipped. Toolchain slot (`r-package`): `devtools::document()`
+produces no diff; README.md in sync; `pkgdown::check_pkgdown()` clean; NEWS.md
+entry present; no new top-level files; `check()` clean.
+
+CI on PR #59: 8 of 9 checks pass (R CMD check on macOS, Windows, Ubuntu release
+and oldrel-1; pkgdown; test-coverage; both codecov gates). `ubuntu-latest (devel)`
+fails in `setup-r-dependencies` — upstream infrastructure, not this diff: the
+`pak` binary for R-4.7 is unpublished ("cannot open URL ... pak_0.11.0_R-4-7").
+
+### Independent review — three lenses + scorer
+
+Diff-bug **[O]**, blame-history **[S]**, prior-PR-comments **[S]**, then a
+confidence scorer **[S]**. The prior-PR lens was a clean no-op (this repo has zero
+inline PR comments; LESSONS M33 records that its silence carries no evidential
+weight here).
+
+**Actioned (score >= 80):**
+
+- **F1 (98) — fixed.** Leaked tool-call scaffolding (`</content>`, `</invoke>`)
+  committed at the end of the vignette, introduced by this branch. Invisible to
+  `check()` because pandoc passes unmatched closing tags through as raw HTML and
+  browsers drop them; would have shipped to CRAN in the vignette source. Found
+  independently by two lenses.
+- **F2 (90) — fixed.** The vignette claimed occasions "appear in the order they
+  were supplied, never in alphabetical order, so a `T2`/`T10` pair cannot silently
+  swap." False for a factor occasion column: `ssm_analyze_long()` uses
+  `levels(droplevels())` for factors, and `factor()` sorts levels alphabetically.
+  Verified empirically — a default factor yields `T1, T10, T2`, exactly the swap
+  the prose called impossible. Rewritten to state first-appearance order for
+  character, level order for factor, with the alphabetical-default warning.
+- **F3 (80) — fixed.** The NEWS entry claimed trajectory and the composable layers
+  are "reachable from each other's help pages"; the two families are disjoint and
+  no such direct link exists. Reworded to claim only the within-family links that
+  are real.
+
+**Below threshold (logged, not silently dropped):**
+
+- **F5 (78) — fixed anyway.** "Everything the parent geom does --- the polar
+  placement ..." misattributed the polar transform to the geom, contradicting the
+  vignette's own opening bullet list; `GeomSsmPoint$setup_data` only assigns
+  `x`/`y` and the coord owns the transform. Verified correct and one line to fix
+  in a file already being edited.
+- **F4 (72) — fixed anyway.** `angles <- octants()` had been hoisted out of the
+  `curve-axis` chunk into the trajectory simulation two sections earlier, so
+  copy-pasting the angle-axis example alone failed. Restored to the chunk.
+- **F6 (55) — rejected.** `plot.circumplex_ci_accuracy` carries
+  `@family visualization functions` but sits in the pkgdown "Structure Evaluation
+  Functions" group. Both the tag and the grouping predate this diff, which only
+  made the mismatch more visible; a simulation diagnostic also belongs beside its
+  analysis function. Left as-is.

--- a/cairn/milestones/M34-plotting-vignette-pkgdown.md
+++ b/cairn/milestones/M34-plotting-vignette-pkgdown.md
@@ -2,11 +2,11 @@
      section ownership". A phase skill never rewrites another phase's section. -->
 # M34: Plotting vignette + pkgdown reference
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** M31, M32, M33
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** `m34-plotting-vignette-pkgdown`
 
 ## Goal
 
@@ -54,7 +54,7 @@ plots, and organize the pkgdown reference so the plotting API is discoverable.
 
 ## Tasks
 
-- [ ] **T1** — Extend/refresh the plotting vignette with coord + center, geom
+- [x] **T1** — Extend/refresh the plotting vignette with coord + center, geom
       subclassing + styling, and trajectory sections, each with a runnable
       example rendered from actual output.
 - [ ] **T2** — Reorganize `_pkgdown.yml` visualization reference groups; run
@@ -64,6 +64,8 @@ plots, and organize the pkgdown reference so the plotting API is discoverable.
 ## Work log
 
 - 2026-07-17: created by /milestone-plan (viz expansion, area D).
+- 2026-07-18: gate — single rewritten vignette; occasions trajectory path only (growth vignette keeps the table path); two pkgdown viz groups; M35 legend-glyph defect stays a candidate (no scope amendment).
+- 2026-07-18: T1 done — vignette rewritten (stale per-layer `amax` teaching removed; coord/center/r_axis_angle, theming, geom subclassing, occasions trajectory added). Render-and-inspect fixed an illegible center demo and two "Coordinate system already present" messages. Suite 2886 pass.
 
 ## Decisions
 

--- a/cairn/milestones/M34-plotting-vignette-pkgdown.md
+++ b/cairn/milestones/M34-plotting-vignette-pkgdown.md
@@ -2,7 +2,7 @@
      section ownership". A phase skill never rewrites another phase's section. -->
 # M34: Plotting vignette + pkgdown reference
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** M31, M32, M33
 - **Principles touched:** —
@@ -68,6 +68,8 @@ plots, and organize the pkgdown reference so the plotting API is discoverable.
 - 2026-07-18: T1 done — vignette rewritten (stale per-layer `amax` teaching removed; coord/center/r_axis_angle, theming, geom subclassing, occasions trajectory added). Render-and-inspect fixed an illegible center demo and two "Coordinate system already present" messages. Suite 2886 pass.
 - 2026-07-18: T2 done — `_pkgdown.yml` split into "Visualization - Complete Plots" (the four `ssm_plot_*`, moved out of Primary SSM Functions) and "Visualization - Building Blocks"; added `@family visualization functions` to the plot trio and a new `@family circumplex layers` across the six building blocks, replacing their incomplete hand-kept `@seealso` lists. `check_pkgdown()`: no problems found.
 - 2026-07-18: T3 done — precision pass added the unwrap's unverifiable half-turn assumption, the bands-are-pointwise-not-simultaneous caveat, and the vector-averaging reading of a short group amplitude (printed live, not asserted in prose); rescaled the individuals figure (amax 3 -> 1.75) so the shrinkage it describes is actually visible. NEWS entry added. `devtools::check()`: 0 errors / 0 warnings / 0 notes.
+
+- 2026-07-18: all tasks done; `devtools::check()` re-run on the final tree (incl. NEWS): 0 errors / 0 warnings / 0 notes. Status -> review.
 
 ## Decisions
 

--- a/cairn/milestones/M34-plotting-vignette-pkgdown.md
+++ b/cairn/milestones/M34-plotting-vignette-pkgdown.md
@@ -112,10 +112,11 @@ plots, and organize the pkgdown reference so the plotting API is discoverable.
 produces no diff; README.md in sync; `pkgdown::check_pkgdown()` clean; NEWS.md
 entry present; no new top-level files; `check()` clean.
 
-CI on PR #59: 8 of 9 checks pass (R CMD check on macOS, Windows, Ubuntu release
-and oldrel-1; pkgdown; test-coverage; both codecov gates). `ubuntu-latest (devel)`
-fails in `setup-r-dependencies` — upstream infrastructure, not this diff: the
-`pak` binary for R-4.7 is unpublished ("cannot open URL ... pak_0.11.0_R-4-7").
+CI on PR #59: all 9 checks green (R CMD check on macOS, Windows, Ubuntu devel /
+release / oldrel-1; pkgdown; test-coverage; both codecov gates). An earlier run
+failed `ubuntu-latest (devel)` in `setup-r-dependencies` — a transient upstream
+outage ("cannot open URL ... pak_0.11.0_R-4-7"), which passed on re-run,
+confirming it was never related to this diff.
 
 ### Independent review — three lenses + scorer
 

--- a/man/coord_circumplex.Rd
+++ b/man/coord_circumplex.Rd
@@ -50,5 +50,11 @@ ggplot2::ggplot(res$results) +
   geom_ssm_point(ggplot2::aes(amplitude = a_est, displacement = d_est))
 }
 \seealso{
-\code{\link[=ggcircumplex]{ggcircumplex()}}, \code{\link[=geom_ssm_point]{geom_ssm_point()}}, \code{\link[=geom_ssm_arc]{geom_ssm_arc()}}
+Other circumplex layers:
+\code{\link[=geom_ssm_arc]{geom_ssm_arc()}},
+\code{\link[=geom_ssm_point]{geom_ssm_point()}},
+\code{\link[=ggcircumplex]{ggcircumplex()}},
+\code{\link[=scale_x_circumplex]{scale_x_circumplex()}},
+\code{\link[=theme_circumplex]{theme_circumplex()}}
 }
+\concept{circumplex layers}

--- a/man/geom_ssm_arc.Rd
+++ b/man/geom_ssm_arc.Rd
@@ -71,5 +71,11 @@ ggcircumplex(octants(), amax = 0.5) +
   )
 }
 \seealso{
-\code{\link[=coord_circumplex]{coord_circumplex()}}, \code{\link[=ggcircumplex]{ggcircumplex()}}, \code{\link[=geom_ssm_point]{geom_ssm_point()}}
+Other circumplex layers:
+\code{\link[=coord_circumplex]{coord_circumplex()}},
+\code{\link[=geom_ssm_point]{geom_ssm_point()}},
+\code{\link[=ggcircumplex]{ggcircumplex()}},
+\code{\link[=scale_x_circumplex]{scale_x_circumplex()}},
+\code{\link[=theme_circumplex]{theme_circumplex()}}
 }
+\concept{circumplex layers}

--- a/man/geom_ssm_point.Rd
+++ b/man/geom_ssm_point.Rd
@@ -49,5 +49,11 @@ ggcircumplex(octants(), amax = 0.5) +
   )
 }
 \seealso{
-\code{\link[=coord_circumplex]{coord_circumplex()}}, \code{\link[=ggcircumplex]{ggcircumplex()}}, \code{\link[=geom_ssm_arc]{geom_ssm_arc()}}
+Other circumplex layers:
+\code{\link[=coord_circumplex]{coord_circumplex()}},
+\code{\link[=geom_ssm_arc]{geom_ssm_arc()}},
+\code{\link[=ggcircumplex]{ggcircumplex()}},
+\code{\link[=scale_x_circumplex]{scale_x_circumplex()}},
+\code{\link[=theme_circumplex]{theme_circumplex()}}
 }
+\concept{circumplex layers}

--- a/man/ggcircumplex.Rd
+++ b/man/ggcircumplex.Rd
@@ -58,4 +58,12 @@ ggcircumplex(instrument = csip)
 \seealso{
 \code{\link[=coord_circumplex]{coord_circumplex()}}, which owns the transform this canvas is built
 on; \code{\link[=ssm_plot_circle]{ssm_plot_circle()}}, which draws SSM results on this canvas.
+
+Other circumplex layers:
+\code{\link[=coord_circumplex]{coord_circumplex()}},
+\code{\link[=geom_ssm_arc]{geom_ssm_arc()}},
+\code{\link[=geom_ssm_point]{geom_ssm_point()}},
+\code{\link[=scale_x_circumplex]{scale_x_circumplex()}},
+\code{\link[=theme_circumplex]{theme_circumplex()}}
 }
+\concept{circumplex layers}

--- a/man/plot.circumplex_ci_accuracy.Rd
+++ b/man/plot.circumplex_ci_accuracy.Rd
@@ -54,6 +54,9 @@ Other ssm functions:
 \code{\link[=summary.circumplex_ssm_id]{summary.circumplex_ssm_id()}}
 
 Other visualization functions:
+\code{\link[=ssm_plot_circle]{ssm_plot_circle()}},
+\code{\link[=ssm_plot_contrast]{ssm_plot_contrast()}},
+\code{\link[=ssm_plot_curve]{ssm_plot_curve()}},
 \code{\link[=ssm_plot_trajectory]{ssm_plot_trajectory()}}
 }
 \concept{ssm functions}

--- a/man/scale_x_circumplex.Rd
+++ b/man/scale_x_circumplex.Rd
@@ -43,5 +43,11 @@ scale_x_circumplex(octants())
 scale_x_circumplex(instrument = csip)
 }
 \seealso{
-\code{\link[=ggcircumplex]{ggcircumplex()}}
+Other circumplex layers:
+\code{\link[=coord_circumplex]{coord_circumplex()}},
+\code{\link[=geom_ssm_arc]{geom_ssm_arc()}},
+\code{\link[=geom_ssm_point]{geom_ssm_point()}},
+\code{\link[=ggcircumplex]{ggcircumplex()}},
+\code{\link[=theme_circumplex]{theme_circumplex()}}
 }
+\concept{circumplex layers}

--- a/man/ssm_plot_circle.Rd
+++ b/man/ssm_plot_circle.Rd
@@ -76,3 +76,11 @@ res <- ssm_analyze(
 ssm_plot_circle(res)
 }
 }
+\seealso{
+Other visualization functions:
+\code{\link[=plot.circumplex_ci_accuracy]{plot.circumplex_ci_accuracy()}},
+\code{\link[=ssm_plot_contrast]{ssm_plot_contrast()}},
+\code{\link[=ssm_plot_curve]{ssm_plot_curve()}},
+\code{\link[=ssm_plot_trajectory]{ssm_plot_trajectory()}}
+}
+\concept{visualization functions}

--- a/man/ssm_plot_contrast.Rd
+++ b/man/ssm_plot_contrast.Rd
@@ -55,3 +55,11 @@ res <- ssm_analyze(
 ssm_plot_contrast(res)
 }
 }
+\seealso{
+Other visualization functions:
+\code{\link[=plot.circumplex_ci_accuracy]{plot.circumplex_ci_accuracy()}},
+\code{\link[=ssm_plot_circle]{ssm_plot_circle()}},
+\code{\link[=ssm_plot_curve]{ssm_plot_curve()}},
+\code{\link[=ssm_plot_trajectory]{ssm_plot_trajectory()}}
+}
+\concept{visualization functions}

--- a/man/ssm_plot_curve.Rd
+++ b/man/ssm_plot_curve.Rd
@@ -47,3 +47,11 @@ ssm_plot_curve(res)
 ssm_plot_curve(res, angle_labels = PANO())
 }
 }
+\seealso{
+Other visualization functions:
+\code{\link[=plot.circumplex_ci_accuracy]{plot.circumplex_ci_accuracy()}},
+\code{\link[=ssm_plot_circle]{ssm_plot_circle()}},
+\code{\link[=ssm_plot_contrast]{ssm_plot_contrast()}},
+\code{\link[=ssm_plot_trajectory]{ssm_plot_trajectory()}}
+}
+\concept{visualization functions}

--- a/man/ssm_plot_trajectory.Rd
+++ b/man/ssm_plot_trajectory.Rd
@@ -127,6 +127,9 @@ ssm_plot_trajectory(trajectory, time = "wave")
 }
 \seealso{
 Other visualization functions:
-\code{\link[=plot.circumplex_ci_accuracy]{plot.circumplex_ci_accuracy()}}
+\code{\link[=plot.circumplex_ci_accuracy]{plot.circumplex_ci_accuracy()}},
+\code{\link[=ssm_plot_circle]{ssm_plot_circle()}},
+\code{\link[=ssm_plot_contrast]{ssm_plot_contrast()}},
+\code{\link[=ssm_plot_curve]{ssm_plot_curve()}}
 }
 \concept{visualization functions}

--- a/man/theme_circumplex.Rd
+++ b/man/theme_circumplex.Rd
@@ -26,5 +26,11 @@ restyle the canvas.
 ggcircumplex(octants()) + theme_circumplex(base_size = 16)
 }
 \seealso{
-\code{\link[=ggcircumplex]{ggcircumplex()}}, \code{\link[=coord_circumplex]{coord_circumplex()}}
+Other circumplex layers:
+\code{\link[=coord_circumplex]{coord_circumplex()}},
+\code{\link[=geom_ssm_arc]{geom_ssm_arc()}},
+\code{\link[=geom_ssm_point]{geom_ssm_point()}},
+\code{\link[=ggcircumplex]{ggcircumplex()}},
+\code{\link[=scale_x_circumplex]{scale_x_circumplex()}}
 }
+\concept{circumplex layers}

--- a/vignettes/advanced-visualization.Rmd
+++ b/vignettes/advanced-visualization.Rmd
@@ -274,7 +274,10 @@ people <- people[!is.na(people$Disp), ]
 # Group-level profile for the same subset
 group <- ssm_analyze(jz2017[1:100, ], scales = PANO())
 
-ggcircumplex(octants(), labels = PANO(), amax = 3) +
+# The group amplitude is shorter than a typical individual amplitude
+c(group = group$results$a_est, median_individual = median(people$Ampl))
+
+ggcircumplex(octants(), labels = PANO(), amax = 1.75) +
   geom_ssm_point(
     data = people,
     mapping = aes(amplitude = Ampl, displacement = Disp),
@@ -287,10 +290,17 @@ ggcircumplex(octants(), labels = PANO(), amax = 3) +
   )
 ```
 
-The individual points spread around the circle while the group summary sits near
-their center of mass, a picture that none of the built-in functions produce
-directly. Any other `ggplot2` layer --- text annotations, additional geoms,
-faceting --- can be added the same way.
+The individual points spread widely around the circle while the group summary
+sits close to the origin, a picture that none of the built-in functions produce
+directly. That contrast is not an artifact: the group profile is the SSM of the
+*mean* scale scores, so its position is the average of the individual positions
+in (x, y) --- and averaging vectors that point in different directions yields a
+resultant shorter than the typical individual vector, as the two amplitudes
+printed above show. A group
+amplitude smaller than a typical person's therefore indicates disagreement about
+*direction* among the respondents, not that each person's profile is flat. Any
+other `ggplot2` layer --- text annotations, additional geoms, faceting --- can be
+added the same way.
 
 ## Trajectories across occasions
 
@@ -343,11 +353,23 @@ continues past 360, so values outside \[0, 360) are expected there. Second,
 occasions appear in the order they were supplied, never in alphabetical order,
 so a `T2`/`T10` pair cannot silently swap.
 
+The unwrap carries an assumption that no data can check: that the profile
+rotates less than a half-turn between consecutive occasions. Waves that are far
+apart in time, or a series with a gap, could rotate further than that and would
+be drawn as the shorter rotation regardless, so read widely spaced occasions
+with that in mind.
+
 A time point whose amplitude interval is too close to zero for its displacement
 to be interpretable is drawn as a hollow point --- a marker of an
 interpretability precondition, not a significance test. `drop_xy = TRUE` above
 omits the X-value and Y-value panels, leaving elevation, amplitude, and
 displacement.
+
+The bands are the per-occasion confidence intervals, one per time point. They
+are not a simultaneous confidence band for the trajectory as a whole, and
+overlap (or its absence) between two occasions' bands is not a test of change
+between them; for that, estimate the contrast directly (see `?ssm_analyze` and
+`ssm_plot_contrast()`).
 
 `ssm_plot_trajectory()` also accepts a trajectory table --- a data frame of
 `a_est`/`a_lci`/`a_uci` and `d_est`/`d_lci`/`d_uci` triples at numeric time

--- a/vignettes/advanced-visualization.Rmd
+++ b/vignettes/advanced-visualization.Rmd
@@ -25,11 +25,11 @@ library(circumplex)
 
 ## Beyond the built-in plots
 
-The `ssm_plot_circle()`, `ssm_plot_curve()`, and `ssm_plot_contrast()`
-functions cover the most common circumplex figures, but they each produce a
-finished plot with a fixed set of layers. Sometimes you want more control: to
-overlay individual respondents on a group profile, to annotate a specific
-region of the circle, to restyle the points, or to place several circumplex
+The `ssm_plot_circle()`, `ssm_plot_curve()`, `ssm_plot_contrast()`, and
+`ssm_plot_trajectory()` functions cover the most common circumplex figures, but
+they each produce a finished plot with a fixed set of layers. Sometimes you want
+more control: to overlay individual respondents on a group profile, to zoom in on
+a band of amplitudes, to restyle the points, or to place several circumplex
 panels side by side.
 
 To make that possible, `circumplex` exposes the building blocks that the
@@ -37,11 +37,17 @@ built-in plots are themselves made of. These are ordinary
 [`ggplot2`](https://ggplot2.tidyverse.org/) components, so you compose them with
 `+` and combine them freely with any other `ggplot2` layers, scales, and themes:
 
-- `ggcircumplex()` draws the empty circular **canvas** (amplitude rings,
-  displacement spokes, and scale labels).
-- `geom_ssm_point()` and `geom_ssm_arc()` are polar-native **layers** that place
-  profile points and their confidence regions in the circle, taking amplitude
-  and displacement directly as aesthetics.
+- `coord_circumplex()` is the **coordinate system**. It maps the `displacement`
+  aesthetic (degrees) onto the angle and the `amplitude` aesthetic onto the
+  radius, and it owns the amplitude-to-radius scaling for the whole plot.
+- `ggcircumplex()` assembles the empty circular **canvas** --- the coordinate
+  system plus the amplitude rings, displacement spokes, and scale labels.
+- `geom_ssm_point()` and `geom_ssm_arc()` are the **layers** that place profile
+  points and their confidence regions in the circle, taking amplitude and
+  displacement directly as aesthetics.
+- `theme_circumplex()` is the **theme** the canvas is drawn with, and the rings
+  and spokes are ordinary themed panel furniture that respond to further
+  theming.
 - `scale_x_circumplex()` is a **scale** for the angle axis of linear circumplex
   plots (such as the score-by-angle curve).
 
@@ -72,40 +78,99 @@ instrument:
 ggcircumplex(instrument = csip)
 ```
 
-The `amax` argument sets the amplitude represented by the outer ring; it also
-determines the amplitude gridline labels. It matters because it is the shared
-reference that the data layers below must agree with, as we will see next.
+Throughout, displacement runs counterclockwise from the right, and the
+0/360 degree position is labeled 360.
 
-## Placing SSM results in the circle
+## The coordinate system
 
-Let's estimate a Structural Summary Method (SSM) profile for two measures and
-draw it on the canvas ourselves, rather than calling `ssm_plot_circle()`.
+`ggcircumplex()` is a convenience wrapper. Underneath it, the piece that makes a
+circumplex plot circular is `coord_circumplex()`, and you can add that to a bare
+`ggplot()` yourself when you want to build a figure from scratch:
 
-```{r analyze}
+```{r coord-bare}
 results <- ssm_analyze(
   jz2017,
   scales = PANO(),
   measures = c("NARPD", "ASPD")
 )
 results$results[, c("Label", "a_est", "d_est", "a_lci", "a_uci")]
+
+ggplot(results$results) +
+  coord_circumplex(amax = 0.3) +
+  geom_ssm_point(aes(amplitude = a_est, displacement = d_est, fill = Label)) +
+  theme_circumplex()
 ```
 
-`geom_ssm_point()` places a point for each profile at its amplitude
-(`a_est`) and displacement (`d_est`), and `geom_ssm_arc()` draws the wedge
-spanning each profile's amplitude confidence interval radially and its
-displacement confidence interval angularly. Both take the SSM parameters
-directly as aesthetics and handle the conversion into circular coordinates
-internally, including wrap-around when a displacement interval crosses the
-0/360 degree boundary.
+That is the minimum: a coordinate system and a layer. The spokes fall on
+`ggplot2`'s default axis breaks rather than on the circumplex scale angles,
+because a bare coordinate system has not been told what the scales are ---
+supplying those breaks and labels, along with the theme, is exactly what
+`ggcircumplex()` adds on top.
 
-The one rule to remember is that **`amax` must be the same** for the canvas and
-for every data layer, so that amplitudes map onto the same radius. Here we set
-it once and reuse it:
+Because the coordinate system owns the amplitude-to-radius mapping, `amax` is
+set exactly once per plot and the canvas and the data layers cannot disagree
+about what a given radius means. (Earlier versions of the package took an `amax`
+argument on each layer; those arguments are now deprecated and ignored, with a
+one-time note.) Leaving `amax = NULL` trains it from the data, as
+`ssm_plot_circle()` does.
+
+### Moving the center
+
+By default the center of the circle is amplitude 0, so radial distance is
+proportional to amplitude and the origin means "no differentiation among the
+scales." The `center` argument moves that inner limit, which is useful when
+every profile sits in a narrow band of amplitudes and the interesting variation
+is squeezed against the rim:
+
+```{r coord-center}
+ggplot(results$results) +
+  coord_circumplex(amax = 0.28, center = 0.15) +
+  scale_x_continuous(breaks = octants(), labels = PANO()) +
+  geom_ssm_point(aes(amplitude = a_est, displacement = d_est, fill = Label)) +
+  theme_circumplex()
+```
+
+This is a zoom, and it changes how the figure should be read. With a nonzero
+center, radial distance is no longer proportional to amplitude and the origin no
+longer represents zero amplitude, so differences in radius are exaggerated
+relative to the default view. The amplitude ring labels still report the true
+amplitudes, and they are what the reader should be directed to. Use a nonzero
+center to resolve closely spaced profiles, and say so in the caption.
+
+### Moving the amplitude axis
+
+The amplitude (radial) axis and its tick labels are placed automatically in the
+widest gap between the displacement spokes, so they never collide with a spoke
+label. You can override that with `r_axis_angle`, given as a displacement in
+degrees:
+
+```{r coord-r-axis}
+ggplot(results$results) +
+  coord_circumplex(amax = 0.3, r_axis_angle = 67.5) +
+  scale_x_continuous(breaks = octants(), labels = PANO()) +
+  geom_ssm_point(aes(amplitude = a_est, displacement = d_est, fill = Label)) +
+  theme_circumplex()
+```
+
+Note that these examples build the canvas from its parts --- the coordinate
+system, an x-scale carrying the spoke breaks and labels, and the theme --- rather
+than adding a second coordinate system on top of `ggcircumplex()`, which
+`ggplot2` would replace with a message.
+
+## Placing SSM results in the circle
+
+Let's draw the two-measure profile from above on a labeled canvas ourselves,
+rather than calling `ssm_plot_circle()`.
+
+`geom_ssm_point()` places a point for each profile at its amplitude (`a_est`)
+and displacement (`d_est`), and `geom_ssm_arc()` draws the wedge spanning each
+profile's amplitude confidence interval radially and its displacement confidence
+interval angularly. Both take the SSM parameters directly as aesthetics and
+handle the conversion into circular coordinates internally, including
+wrap-around when a displacement interval crosses the 0/360 degree boundary.
 
 ```{r results-plot}
-amax <- 1
-
-ggcircumplex(octants(), labels = PANO(), amax = amax) +
+ggcircumplex(octants(), labels = PANO(), amax = 0.3) +
   geom_ssm_arc(
     data = results$results,
     mapping = aes(
@@ -113,12 +178,11 @@ ggcircumplex(octants(), labels = PANO(), amax = amax) +
       displacement_min = d_lci, displacement_max = d_uci,
       fill = Label
     ),
-    amax = amax, alpha = 0.4, color = NA
+    alpha = 0.4, color = NA
   ) +
   geom_ssm_point(
     data = results$results,
-    mapping = aes(amplitude = a_est, displacement = d_est, fill = Label),
-    amax = amax
+    mapping = aes(amplitude = a_est, displacement = d_est, fill = Label)
   )
 ```
 
@@ -133,6 +197,60 @@ confidence interval for a linear parameter (such as elevation) can be.
 Displacement is only worth interpreting at all when the amplitude interval is
 clearly above zero and the model fits reasonably well (see the "Introduction to
 SSM Analysis" vignette and `?ssm_analyze`).
+
+## Restyling the canvas
+
+`theme_circumplex()` is the theme `ggcircumplex()` applies. Because the rings,
+spokes, and labels are themed panel furniture rather than drawn geometry, any
+further theming reaches them. Adjust the base font size through the theme, and
+restyle the gridlines with an ordinary `theme()` call:
+
+```{r theming}
+ggcircumplex(octants(), labels = PANO(), amax = 0.3) +
+  geom_ssm_point(
+    data = results$results,
+    mapping = aes(amplitude = a_est, displacement = d_est, fill = Label)
+  ) +
+  theme_circumplex(base_size = 14) +
+  theme(
+    panel.grid.major = element_line(color = "steelblue", linetype = "dotted"),
+    legend.position = "bottom"
+  )
+```
+
+## Extending the layers
+
+The `ggplot2` objects behind the layers and the coordinate system ---
+`GeomSsmPoint`, `GeomSsmArc`, and `CoordCircumplex` --- are exported, so you can
+subclass them the same way you would subclass any `ggplot2` geom. This is the
+route to a reusable layer with your own defaults, rather than repeating the same
+arguments at every call site.
+
+```{r subclass}
+GeomSsmStar <- ggproto("GeomSsmStar", GeomSsmPoint,
+  default_aes = modifyList(
+    GeomSsmPoint$default_aes,
+    list(shape = 23, size = 5, fill = "#D55E00", colour = "black")
+  )
+)
+
+geom_ssm_star <- function(mapping = NULL, data = NULL, ...) {
+  layer(
+    geom = GeomSsmStar, mapping = mapping, data = data,
+    stat = "identity", position = "identity",
+    inherit.aes = FALSE, params = list(...)
+  )
+}
+
+ggcircumplex(octants(), labels = PANO(), amax = 0.3) +
+  geom_ssm_star(
+    data = results$results,
+    mapping = aes(amplitude = a_est, displacement = d_est)
+  )
+```
+
+Everything the parent geom does --- the polar placement, the dropping of
+profiles with no defined location --- is inherited; only the defaults change.
 
 ## Composing custom layers
 
@@ -156,18 +274,16 @@ people <- people[!is.na(people$Disp), ]
 # Group-level profile for the same subset
 group <- ssm_analyze(jz2017[1:100, ], scales = PANO())
 
-amax <- 3
-
-ggcircumplex(octants(), labels = PANO(), amax = amax) +
+ggcircumplex(octants(), labels = PANO(), amax = 3) +
   geom_ssm_point(
     data = people,
     mapping = aes(amplitude = Ampl, displacement = Disp),
-    amax = amax, fill = "grey70", size = 1.5, alpha = 0.6
+    fill = "grey70", size = 1.5, alpha = 0.6
   ) +
   geom_ssm_point(
     data = group$results,
     mapping = aes(amplitude = a_est, displacement = d_est),
-    amax = amax, fill = "#0072B2", size = 4
+    fill = "#0072B2", size = 4
   )
 ```
 
@@ -175,6 +291,69 @@ The individual points spread around the circle while the group summary sits near
 their center of mass, a picture that none of the built-in functions produce
 directly. Any other `ggplot2` layer --- text annotations, additional geoms,
 faceting --- can be added the same way.
+
+## Trajectories across occasions
+
+When the same people are measured on the same scales at two or more occasions,
+`ssm_analyze_long()` (for long data) or `ssm_analyze(occasions = )` (for wide
+data) estimates one SSM profile per occasion, resampling persons so that
+within-person dependence across occasions is respected.
+`ssm_plot_trajectory()` then draws each SSM parameter against time.
+
+Here is a small simulated three-wave data set whose group profile rotates
+counterclockwise across the 0/360 degree boundary, which is the case worth
+seeing drawn:
+
+```{r occasions-data}
+angles <- octants()
+n <- 200
+waves <- c(T1 = 330, T2 = 355, T3 = 20) # true displacement at each wave
+elevation <- rnorm(n) * 0.5 # per-person offset, stable across waves
+
+long <- do.call(rbind, lapply(names(waves), function(w) {
+  # Group signal at this wave, plus the stable person offset and fresh noise
+  signal <- 0.6 * cos((angles - waves[[w]]) * pi / 180)
+  scores <- matrix(signal, nrow = n, ncol = length(angles), byrow = TRUE) +
+    elevation +
+    matrix(rnorm(n * length(angles), sd = 0.5), nrow = n)
+  out <- as.data.frame(scores)
+  names(out) <- PANO()
+  out$id <- seq_len(n)
+  out$wave <- w
+  out
+}))
+
+results_long <- ssm_analyze_long(
+  long,
+  scales = PANO(),
+  id = "id",
+  occasion = "wave"
+)
+results_long$results[, c("Occasion", "a_est", "d_est", "d_lci", "d_uci")]
+```
+
+```{r occasions-plot, fig.height = 6}
+ssm_plot_trajectory(results_long, drop_xy = TRUE)
+```
+
+Two things about the displacement panel are worth reading carefully. First, it
+is drawn on an *unwrapped* branch: the profile crosses the 0/360 boundary
+between the second and third wave, and rather than jumping a full turn the panel
+continues past 360, so values outside \[0, 360) are expected there. Second,
+occasions appear in the order they were supplied, never in alphabetical order,
+so a `T2`/`T10` pair cannot silently swap.
+
+A time point whose amplitude interval is too close to zero for its displacement
+to be interpretable is drawn as a hollow point --- a marker of an
+interpretability precondition, not a significance test. `drop_xy = TRUE` above
+omits the X-value and Y-value panels, leaving elevation, amplitude, and
+displacement.
+
+`ssm_plot_trajectory()` also accepts a trajectory table --- a data frame of
+`a_est`/`a_lci`/`a_uci` and `d_est`/`d_lci`/`d_uci` triples at numeric time
+points --- which is how you plot a *model-based* trajectory evaluated from a
+fitted growth model rather than one estimated separately at each wave. That
+workflow is the subject of the "Growth Models on SSM Parameters" vignette.
 
 ## The angle axis for linear plots
 
@@ -185,7 +364,6 @@ by default with the angle in degrees, or with custom labels or an instrument's
 abbreviations.
 
 ```{r curve-axis}
-angles <- octants()
 curve <- data.frame(
   angle = angles,
   score = 1 + 0.8 * cos((angles - 135) * pi / 180)
@@ -225,3 +403,5 @@ take, the coordinates are computed the same way, so the results line up.
 * Zimmermann, J., & Wright, A. G. C. (2017). Beyond description in interpersonal
   construct validation: Methodological advances in the circumplex Structural
   Summary Approach. _Assessment, 24_(1), 3--23.
+</content>
+</invoke>

--- a/vignettes/advanced-visualization.Rmd
+++ b/vignettes/advanced-visualization.Rmd
@@ -249,8 +249,11 @@ ggcircumplex(octants(), labels = PANO(), amax = 0.3) +
   )
 ```
 
-Everything the parent geom does --- the polar placement, the dropping of
-profiles with no defined location --- is inherited; only the defaults change.
+Everything the parent geom does --- mapping amplitude and displacement onto the
+positional aesthetics, and dropping profiles with no defined location --- is
+inherited; only the defaults change. The polar transform itself is not part of
+the geom: as above, `coord_circumplex()` owns it, which is why the subclass
+needs no circular arithmetic of its own.
 
 ## Composing custom layers
 
@@ -350,8 +353,11 @@ Two things about the displacement panel are worth reading carefully. First, it
 is drawn on an *unwrapped* branch: the profile crosses the 0/360 boundary
 between the second and third wave, and rather than jumping a full turn the panel
 continues past 360, so values outside \[0, 360) are expected there. Second,
-occasions appear in the order they were supplied, never in alphabetical order,
-so a `T2`/`T10` pair cannot silently swap.
+the occasion order comes from the data rather than from the plot: for a
+character occasion column it is first-appearance order, and for a factor it is
+the factor's level order. Note that `factor()` sorts its levels alphabetically
+by default, which would place `T10` before `T2` --- so if your occasion column
+is a factor, set its levels in temporal order.
 
 The unwrap carries an assumption that no data can check: that the profile
 rotates less than a half-turn between consecutive occasions. Waves that are far
@@ -386,6 +392,7 @@ by default with the angle in degrees, or with custom labels or an instrument's
 abbreviations.
 
 ```{r curve-axis}
+angles <- octants()
 curve <- data.frame(
   angle = angles,
   score = 1 + 0.8 * cos((angles - 135) * pi / 180)
@@ -425,5 +432,3 @@ take, the coordinates are computed the same way, so the results line up.
 * Zimmermann, J., & Wright, A. G. C. (2017). Beyond description in interpersonal
   construct validation: Methodological advances in the circumplex Structural
   Summary Approach. _Assessment, 24_(1), 3--23.
-</content>
-</invoke>


### PR DESCRIPTION
Documents the visualization surface shipped by the coordinate-system and
trajectory work, and reorganizes the reference index around it.

## Vignette

`vignettes/advanced-visualization.Rmd` is rewritten over the current API. It
had been teaching a rule that no longer exists — keep `amax` in sync across
the canvas and every data layer — which is now impossible to follow, since the
per-layer argument is deprecated and ignored. The vignette now teaches
`coord_circumplex()` as the single owner of the amplitude-to-radius mapping,
and adds sections for the configurable circle center, amplitude-axis
placement, canvas theming, subclassing the exported geoms, and plotting a
trajectory across occasions.

Three statistical-precision additions: the trajectory unwrap's
half-turn-between-occasions assumption is stated as unverifiable; the
confidence bands are named as per-occasion and pointwise, with an explicit
warning that band overlap is not a test of change; and a group amplitude
shorter than a typical individual's is explained as vector averaging
(disagreement about direction, not flat individual profiles), with both
amplitudes printed live from the chunk rather than asserted in prose.

## Reference index

`_pkgdown.yml` splits the plotting API into "Visualization - Complete Plots"
and "Visualization - Building Blocks". Two roxygen families replace the
hand-maintained `@seealso` lists, which had left `scale_x_circumplex()`
linking to a single sibling and `theme_circumplex()` unreachable from the
geoms.

## Verification

- `devtools::check()`: 0 errors / 0 warnings / 0 notes
- `pkgdown::check_pkgdown()`: no problems found
- Test suite: 2886 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)