### PR TITLE
M39: Legible radial axis labels over data layers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Depends:
 Imports: 
     boot (>= 1.3-18),
     ggplot2 (>= 4.0.0),
+    grid,
     htmlTable (>= 1.13.3),
     parallel,
     Rcpp,

--- a/NEWS.md
+++ b/NEWS.md
@@ -448,6 +448,14 @@ plotting layer has been rebuilt on a real ggplot2 coordinate system.
   estimable (scales with an inestimable interval are drawn as a point only and
   named).
 
+* The amplitude axis labels are now drawn over a translucent backdrop, so they
+  stay readable where a data layer falls behind them. The amplitude axis is
+  drawn on top of the plotted data, which kept the labels visible but not
+  legible: a label crossing a dark marker, an arrowhead, or a dense scatter had
+  too little contrast against it to read. The backdrop is deliberately
+  translucent rather than opaque, so it restores contrast without hiding the
+  data it covers.
+
 ## Documentation
 
 * New vignette, "Evaluating Circumplex Structure": how to test whether an

--- a/R/coord_circumplex.R
+++ b/R/coord_circumplex.R
@@ -171,6 +171,119 @@ ssm_r_axis_angle <- function(breaks) {
   min(mids[gaps > max(gaps) - 1e-9])             # widest gap, smallest midpoint
 }
 
+# Semi-opaque plates drawn behind the amplitude tick labels (M39).
+#
+# The radial axis is a FOREGROUND guide: `CoordRadial$render_fg` emits it after
+# the geom layers, so its labels are already painted on top of the data. The
+# defect this fixes is therefore contrast, not draw order -- grey label text over
+# a dark arrowhead or a dense scatter stays on top and still cannot be read. The
+# plate is deliberately semi-transparent rather than opaque so it restores
+# contrast without erasing the data it covers.
+#
+# It is built FROM the label text grob rather than from computed positions.
+# `CoordRadial` places the radial axis through an unexported `rotate_r_axis()`,
+# so reproducing the placement would mean either reaching into ggplot2 internals
+# or re-deriving arithmetic that drifts silently and leaves the plate beside the
+# label instead of behind it. Sizing with `stringWidth()`/`stringHeight()` at the
+# text's own x/y/just hands the geometry to grid at draw time, making the plate
+# exact by construction (M39-D1).
+label_backdrop <- function(txt, pad = 1) {
+  labels <- as.character(txt$label)
+  # A blank label (M38 appends the rim break with one) would otherwise get a
+  # stray floating plate with nothing on it.
+  keep <- !is.na(labels) & labels != ""
+  if (!any(keep)) {
+    return(NULL)
+  }
+  n <- length(labels)
+  # x/just may arrive scalar for a vector of labels; recycle before subsetting
+  # so every plate is anchored exactly like the label it sits behind.
+  recycle <- function(u) if (length(u) == 1L && n > 1L) rep(u, n) else u
+  labels <- labels[keep]
+  x <- recycle(txt$x)[keep]
+  y <- recycle(txt$y)[keep]
+  # `%||%` is not used here: it only reached base R in 4.4 and this package
+  # declares R (>= 4.1), so it is not guaranteed available (D-021).
+  or_else <- function(value, default) if (is.null(value)) default else value
+  hj <- rep_len(or_else(txt$hjust, 0.5), n)[keep]
+  vj <- rep_len(or_else(txt$vjust, 0.5), n)[keep]
+  # The labels are ROTATED -- the radial axis sits at an angle, and each label
+  # is turned about its own anchor to stay readable. `rectGrob()` has no
+  # rotation, so a plate sharing the text's x/y is still drawn axis-aligned and
+  # slides off the label it is meant to back (caught by rendering, not by any
+  # structural check -- see the M39 work log). Each plate therefore gets its own
+  # viewport centred on that label's anchor: a viewport rotates about its own
+  # centre, so centring it on the anchor reproduces exactly the rotate-about-
+  # the-justification-point behaviour `textGrob()` applies to the label.
+  rot <- rep_len(or_else(txt$rot, 0), n)[keep]
+  # Inherit the label's font so stringWidth/stringHeight measure the text as it
+  # will actually be drawn rather than at the device default.
+  font <- list(
+    fontsize = txt$gp$fontsize, fontfamily = txt$gp$fontfamily,
+    fontface = txt$gp$font, cex = txt$gp$cex,
+    # White at 75% alpha, written as a literal rather than built with
+    # grDevices::adjustcolor() so the package gains no second dependency for a
+    # constant (the minimal-deps doctrine, D-006/D-014). BF = round(0.75 * 255).
+    fill = "#FFFFFFBF", col = NA
+  )
+  gp <- do.call(grid::gpar, font[!vapply(font, is.null, logical(1))])
+  plates <- lapply(seq_along(labels), function(i) {
+    # Padding widens the plate symmetrically, which would move it off the label
+    # unless the justification is centred: a plate `2 * pad` wider but pinned at
+    # the same edge sits off to one side. Shifting by `pad * (2 * just - 1)`
+    # re-centres it for any justification.
+    grid::rectGrob(
+      x = grid::unit(0.5, "npc") + grid::unit(pad * (2 * hj[[i]] - 1), "pt"),
+      y = grid::unit(0.5, "npc") + grid::unit(pad * (2 * vj[[i]] - 1), "pt"),
+      width = grid::stringWidth(labels[[i]]) + grid::unit(2 * pad, "pt"),
+      height = grid::stringHeight(labels[[i]]) + grid::unit(2 * pad, "pt"),
+      hjust = hj[[i]], vjust = vj[[i]],
+      gp = gp,
+      vp = grid::viewport(x = x[i], y = y[i], angle = rot[[i]])
+    )
+  })
+  do.call(grid::grobTree, c(plates, list(name = "circumplex-label-backdrop")))
+}
+
+# Walk a rendered foreground tree and put a backdrop behind the amplitude labels.
+#
+# The amplitude label grob is identified by its LABELS matching the radial view
+# scale's, not by position: M32 found these grobs nested in unnamed gTrees, so an
+# index path into them is not stable across ggplot2 versions, and the theta
+# (spoke) labels -- which M39 deliberately leaves alone -- sit in a sibling
+# subtree. A match failure therefore draws no plate at all, which is visible and
+# fenced, rather than silently styling the wrong text.
+add_label_backdrop <- function(grob, labels) {
+  # The view scale can carry a break the guide never draws -- an amax past the
+  # last generated break leaves an out-of-range break whose label is NA, dropped
+  # on the way to a grob -- so compare against the labels that can actually be
+  # rendered, not the raw break set.
+  labels <- as.character(labels)
+  labels <- labels[!is.na(labels)]
+  if (inherits(grob, "text")) {
+    if (identical(as.character(grob$label), labels)) {
+      backdrop <- label_backdrop(grob)
+      if (!is.null(backdrop)) {
+        # Keep the wrapper's name so the parent's childrenOrder still resolves.
+        return(grid::grobTree(backdrop, grob, name = grob$name))
+      }
+    }
+    return(grob)
+  }
+  # gtables hold their children in `grobs`, gTrees in `children`; assign back by
+  # index in both cases so the existing names (and childrenOrder) survive.
+  if (inherits(grob, "gtable")) {
+    for (i in seq_along(grob$grobs)) {
+      grob$grobs[[i]] <- add_label_backdrop(grob$grobs[[i]], labels)
+    }
+    return(grob)
+  }
+  for (i in seq_along(grob$children)) {
+    grob$children[[i]] <- add_label_backdrop(grob$children[[i]], labels)
+  }
+  grob
+}
+
 #' @rdname circumplex-ggproto
 #' @format NULL
 #' @usage NULL
@@ -213,5 +326,15 @@ CoordCircumplex <- ggplot2::ggproto(
     params$r <- rim_view_scale(params$r, r_max)
     params$r.major <- params$r$map(params$r$get_breaks())
     params
+  },
+
+  # Let the parent draw the foreground exactly as it does -- the radial axis is
+  # already painted above the geom layers there -- then slip a backdrop behind
+  # the amplitude labels so data underneath cannot swallow them (M39).
+  render_fg = function(self, panel_params, theme) {
+    fg <- ggplot2::ggproto_parent(
+      ggplot2::CoordRadial, self
+    )$render_fg(panel_params, theme)
+    add_label_backdrop(fg, panel_params$r$get_labels())
   }
 )

--- a/R/coord_circumplex.R
+++ b/R/coord_circumplex.R
@@ -188,7 +188,12 @@ ssm_r_axis_angle <- function(breaks) {
 # text's own x/y/just hands the geometry to grid at draw time, making the plate
 # exact by construction (M39-D1).
 label_backdrop <- function(txt, pad = 1) {
-  labels <- as.character(txt$label)
+  # Keep the label in its ORIGINAL form, not as.character(): a plotmath
+  # expression deparses to its source text, and measuring that string sizes the
+  # plate to `"beta[max]"` rather than to the rendered glyph. Only the
+  # blank/NA test below needs the character form.
+  raw <- txt$label
+  labels <- as.character(raw)
   # A blank label (M38 appends the rim break with one) would otherwise get a
   # stray floating plate with nothing on it.
   keep <- !is.na(labels) & labels != ""
@@ -199,7 +204,7 @@ label_backdrop <- function(txt, pad = 1) {
   # x/just may arrive scalar for a vector of labels; recycle before subsetting
   # so every plate is anchored exactly like the label it sits behind.
   recycle <- function(u) if (length(u) == 1L && n > 1L) rep(u, n) else u
-  labels <- labels[keep]
+  idx <- which(keep)
   x <- recycle(txt$x)[keep]
   y <- recycle(txt$y)[keep]
   # `%||%` is not used here: it only reached base R in 4.4 and this package
@@ -216,8 +221,8 @@ label_backdrop <- function(txt, pad = 1) {
   # centre, so centring it on the anchor reproduces exactly the rotate-about-
   # the-justification-point behaviour `textGrob()` applies to the label.
   rot <- rep_len(or_else(txt$rot, 0), n)[keep]
-  # Inherit the label's font so stringWidth/stringHeight measure the text as it
-  # will actually be drawn rather than at the device default.
+  # Inherit the label's font so the measurement below sizes the text as it will
+  # actually be drawn rather than at the device default.
   font <- list(
     fontsize = txt$gp$fontsize, fontfamily = txt$gp$fontfamily,
     fontface = txt$gp$font, cex = txt$gp$cex,
@@ -227,7 +232,15 @@ label_backdrop <- function(txt, pad = 1) {
     fill = "#FFFFFFBF", col = NA
   )
   gp <- do.call(grid::gpar, font[!vapply(font, is.null, logical(1))])
-  plates <- lapply(seq_along(labels), function(i) {
+  plates <- lapply(seq_along(idx), function(i) {
+    # Measure the label as a GROB, not as a string. `stringWidth()` takes a
+    # character vector, so a plotmath label would be measured as its deparsed
+    # source (`"gamma^2"`, seven characters) instead of the one glyph actually
+    # drawn -- a plate several times too wide, and vertically offset because the
+    # superscript changes the rendered height. `grobWidth()`/`grobHeight()` on a
+    # text grob built from the label itself measures what the device will draw,
+    # for plain strings and expressions alike.
+    one <- grid::textGrob(raw[[idx[[i]]]], gp = gp)
     # Padding widens the plate symmetrically, which would move it off the label
     # unless the justification is centred: a plate `2 * pad` wider but pinned at
     # the same edge sits off to one side. Shifting by `pad * (2 * just - 1)`
@@ -235,8 +248,8 @@ label_backdrop <- function(txt, pad = 1) {
     grid::rectGrob(
       x = grid::unit(0.5, "npc") + grid::unit(pad * (2 * hj[[i]] - 1), "pt"),
       y = grid::unit(0.5, "npc") + grid::unit(pad * (2 * vj[[i]] - 1), "pt"),
-      width = grid::stringWidth(labels[[i]]) + grid::unit(2 * pad, "pt"),
-      height = grid::stringHeight(labels[[i]]) + grid::unit(2 * pad, "pt"),
+      width = grid::grobWidth(one) + grid::unit(2 * pad, "pt"),
+      height = grid::grobHeight(one) + grid::unit(2 * pad, "pt"),
       hjust = hj[[i]], vjust = vj[[i]],
       gp = gp,
       vp = grid::viewport(x = x[i], y = y[i], angle = rot[[i]])
@@ -247,13 +260,19 @@ label_backdrop <- function(txt, pad = 1) {
 
 # Walk a rendered foreground tree and put a backdrop behind the amplitude labels.
 #
-# The amplitude label grob is identified by its LABELS matching the radial view
-# scale's, not by position: M32 found these grobs nested in unnamed gTrees, so an
-# index path into them is not stable across ggplot2 versions, and the theta
-# (spoke) labels -- which M39 deliberately leaves alone -- sit in a sibling
-# subtree. A match failure therefore draws no plate at all, which is visible and
-# fenced, rather than silently styling the wrong text.
-add_label_backdrop <- function(grob, labels) {
+# Two conditions must BOTH hold before a text grob is plated, because either one
+# alone is unsafe. The grob must sit inside the radial axis's own gtable (named
+# "axis"), and its labels must match the radial view scale's. Position alone is
+# not enough -- M32 found these grobs nested in unnamed gTrees, so an index path
+# into them is not stable across ggplot2 versions. Labels alone are not enough
+# either: the theta (spoke) labels, which M39 deliberately leaves alone, live in
+# a sibling subtree that is traversed FIRST, so a caller whose spoke labels
+# happen to read like amplitudes (`scale_x_continuous(labels = c("0.0", ...))`)
+# would otherwise have them silently plated too. Requiring the axis subtree
+# scopes the walk to the guide M39 owns; requiring the labels keeps it from
+# plating anything else that guide might contain. A match failure draws no plate
+# at all, which is visible and fenced, rather than styling the wrong text.
+add_label_backdrop <- function(grob, labels, in_axis = FALSE) {
   # The view scale can carry a break the guide never draws -- an amax past the
   # last generated break leaves an out-of-range break whose label is NA, dropped
   # on the way to a grob -- so compare against the labels that can actually be
@@ -261,7 +280,7 @@ add_label_backdrop <- function(grob, labels) {
   labels <- as.character(labels)
   labels <- labels[!is.na(labels)]
   if (inherits(grob, "text")) {
-    if (identical(as.character(grob$label), labels)) {
+    if (in_axis && identical(as.character(grob$label), labels)) {
       backdrop <- label_backdrop(grob)
       if (!is.null(backdrop)) {
         # Keep the wrapper's name so the parent's childrenOrder still resolves.
@@ -271,15 +290,19 @@ add_label_backdrop <- function(grob, labels) {
     return(grob)
   }
   # gtables hold their children in `grobs`, gTrees in `children`; assign back by
-  # index in both cases so the existing names (and childrenOrder) survive.
+  # index in both cases so the existing names (and childrenOrder) survive. The
+  # gtable branch must come first: a gtable IS a gTree, but carries no
+  # `children`, so testing gTree first would silently descend into nothing.
+  # Entering the guide's "axis" gtable is what arms plating for its subtree.
   if (inherits(grob, "gtable")) {
+    in_axis <- in_axis || identical(grob$name, "axis")
     for (i in seq_along(grob$grobs)) {
-      grob$grobs[[i]] <- add_label_backdrop(grob$grobs[[i]], labels)
+      grob$grobs[[i]] <- add_label_backdrop(grob$grobs[[i]], labels, in_axis)
     }
     return(grob)
   }
   for (i in seq_along(grob$children)) {
-    grob$children[[i]] <- add_label_backdrop(grob$children[[i]], labels)
+    grob$children[[i]] <- add_label_backdrop(grob$children[[i]], labels, in_axis)
   }
   grob
 }

--- a/cairn/DECISIONS.md
+++ b/cairn/DECISIONS.md
@@ -600,3 +600,27 @@ note names it for the CRAN reviewer. Re-pinning an R floor is a dependency
 change under the tracking-rules gate -- **user-approved 2026-07-18** at the M7
 T2 gate. D-014/D-019 reinforced, neither superseded.
 
+
+### D-022 (2026-07-19): `grid` joins Imports for grob-level label backdrops (M39)
+
+**Context:** M39 draws a translucent plate behind each amplitude axis label so
+the label stays readable where a data layer falls behind it. There is no theme
+route to this: `element_text()` in ggplot2 4.0.3 has no `fill`, and ggplot2
+ships no text-with-background element (checked at the M39 T1 gate). The plate
+must therefore be a grob, which needs `unit()`, `gpar()`, `rectGrob()`,
+`textGrob()`, `grobWidth()`/`grobHeight()`, `viewport()`, and `grobTree()` --
+all in `grid`, which the package used nowhere before.
+**Decision:** declare `grid` in `Imports` and call it as `grid::`.
+**Consequences:** no user is affected and no install burden is added. `grid` is
+a base R package shipping with every R installation, it cannot raise the R
+floor, and ggplot2 -- already an Import -- depends on it, so it was loaded in
+every session that used this package's plotting layer already. This records an
+existing reality rather than adding a constraint, exactly as D-021 did for the
+R floor. **No second dependency was taken for convenience:** the plate's fill is
+written as the literal `#FFFFFFBF` rather than built with
+`grDevices::adjustcolor()`, keeping `grDevices` out of `Imports` for what is
+only a constant (D-006/D-014 minimal deps reinforced, neither superseded).
+Adding a dependency is a question-gate item under the tracking rules --
+**user-approved 2026-07-19** at the M39 T3 gate. This entry was written at
+review: the gate was held but the D-entry was missed at the time, and review's
+history lens caught the omission (M39 finding F1).

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38 | high | milestones/M7-v2-release-prep.md |
-| M39 | Legible radial axis labels over data layers | in-progress | — | normal | milestones/M39-radial-label-legibility.md |
+| M39 | Legible radial axis labels over data layers | review | — | normal | milestones/M39-radial-label-legibility.md |
 | M38 | Guaranteed rim ring for the circumplex canvas | done | — | normal | milestones/archive/M38-rim-ring-guarantee.md |
 | M36 | Visualization polish — certification legend key + non-finite guards | done | — | normal | milestones/archive/M36-viz-polish-legend-guards.md |
 | M37 | On-circle movement paths across occasions | done | M31, M32, M33 | normal | milestones/archive/M37-on-circle-movement-paths.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38 | high | milestones/M7-v2-release-prep.md |
-| M39 | Legible radial axis labels over data layers | planned | — | normal | milestones/M39-radial-label-legibility.md |
+| M39 | Legible radial axis labels over data layers | in-progress | — | normal | milestones/M39-radial-label-legibility.md |
 | M38 | Guaranteed rim ring for the circumplex canvas | done | — | normal | milestones/archive/M38-rim-ring-guarantee.md |
 | M36 | Visualization polish — certification legend key + non-finite guards | done | — | normal | milestones/archive/M36-viz-polish-legend-guards.md |
 | M37 | On-circle movement paths across occasions | done | M31, M32, M33 | normal | milestones/archive/M37-on-circle-movement-paths.md |

--- a/cairn/milestones/M39-radial-label-legibility.md
+++ b/cairn/milestones/M39-radial-label-legibility.md
@@ -1,6 +1,6 @@
 # M39: Legible radial axis labels over data layers
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Principles touched:** —
@@ -34,10 +34,13 @@ they stay readable where they fall over dark or dense geom layers.
 - Any change to break generation, the rim ring, or `ssm_r_axis_angle()`'s
   placement rule — M38 and M32 own those and their fences must stay green.
 
-**Merge gate:** M7 is at T4 with a v2.0.0 CRAN submission pending. This
-milestone may be *built* on its branch at any time, but must not merge to
-master until that submission is handed off, so the submitted tarball and
-master do not diverge mid-review. Review confirms before merging.
+**Merge gate (amended 2026-07-19 — the original clause is inverted):** M39's
+change is documented in **v2.0.0's** NEWS at Jeff's gate choice, which claims it
+as part of that release. So M39 must merge **before** `submit_cran()` runs, not
+after, or the submitted tarball would omit the code its own NEWS describes. The
+tarball is not yet submitted and M7 stays `blocked` in the meantime, so there is
+no conflict to resolve — the ordering is simply M39 merges, then M7 unblocks and
+ships. Review confirms M39 is merged ahead of the release handoff.
 
 ## Acceptance criteria
 
@@ -99,7 +102,7 @@ master do not diverge mid-review. Review confirms before merging.
 - [x] **T5** — Re-render `occasions-path`, `occasions-path-wrapper`, and
       `individuals`; inspect each and record the result. Regenerate any canvas
       baselines that legitimately moved, and state which and why.
-- [ ] **T6** — `document()`, `test()`, `check(manual = TRUE)`; NEWS entry;
+- [x] **T6** — `document()`, `test()`, `check(manual = TRUE)`; NEWS entry;
       `_pkgdown.yml` row if anything was exported.
 
 ## Work log
@@ -116,6 +119,10 @@ master do not diverge mid-review. Review confirms before merging.
 
 - 2026-07-19: T4 done. New baseline `amplitude-labels-over-dark-marks` puts heavy dark markers and a large arrowhead exactly where the amplitude labels fall, which no existing canvas baseline did — every one of them draws its labels over empty panel, so none could have seen a contrast defect (the M38 lesson, applied rather than rediscovered). **Teeth proven by mutation, not assumed:** with `label_backdrop()` stubbed to `NULL` the baseline fails; the artifact that mutated run wrote was deleted rather than accepted.
 - 2026-07-19: T5 done. **17 canvas baselines legitimately moved and were accepted; 12 did not, and the split is exactly the canvas/non-canvas boundary** — everything unmoved is a curve plot, a contrast panel plot, a trajectory plot, or the ladder plot, none of which draw a radial axis (verified by reading each test's plotting call, e.g. `single group mean ssm with labels` is `ssm_plot_curve()` and `group-constrast correlation ssm` is `ssm_plot_contrast()`, not circle plots as their names suggest). All three reported vignette figures re-rendered and inspected: `0.6` now reads over the arrowhead in `occasions-path`, `0.50` over the marker in `occasions-path-wrapper` (sampled `srgb(210,210,210)` behind the final glyph — exactly 75% white over the dark arrow, so the plate is compositing as designed), and `0.0`/`0.5` over the scatter in `individuals`. Full `devtools::test()` clean afterwards: 0 failures, the only warnings the 4 pre-existing `test-ci_accuracy.R` Hessian diagnostics. Stray PNGs the render scripts had dropped in the repo root were removed and the scripts repointed at the scratchpad (the M31 `Rplots.pdf` failure class).
+
+- 2026-07-19: T6 done. `devtools::check(manual = TRUE)`: **Status OK, 0 errors / 0 warnings / 0 notes** (5m13s), with both steps this repo has learned to verify by name rather than infer from the summary line confirmed present in the log — `checking PDF version of manual ... OK` (the class win-builder caught in M7, invisible under `--no-manual`) and `checking re-building of vignette outputs ... OK` (38s, exercising the knit that `devtools::test()` never touches). `document()` no diff; `pkgdown::check_pkgdown()` no problems; no `_pkgdown.yml` row needed since nothing new is exported (both new functions are internal). NEWS entry added to the **v2.0.0 Visualization section** at Jeff's gate choice, which carries a consequence recorded rather than absorbed silently: documenting the change in that release means the submitted tarball must contain it, so M39's merge gate is **inverted** — M39 merges before `submit_cran()`, not after. Jeff confirmed the tarball is unsubmitted and M7 stays `blocked` meanwhile, so the sequence is simply M39 merges, then M7 unblocks and ships; the ordering is cross-referenced in M7's work log so a session reading it alone still sees the predecessor.
+
+- 2026-07-19: status in-progress→review (/milestone-implement). All six tasks done; branch is 2 commits over 22 files. `check(manual = TRUE)` 0/0/0 on the tip. Acceptance-criterion boxes deliberately left unticked for `/milestone-review` to tick against fresh evidence (AC fencing). **One thing review should weigh rather than take on trust:** the T2 fence as first written passed an implementation that rendered visibly wrong (plates unrotated, sliding off their labels), so the structural assertions alone were not sufficient evidence — the rotation, per-label anchor, and font-inheritance assertions were added afterwards specifically to close that gap, and the render-and-inspect evidence in T5 is doing real work here, not decorating it.
 
 ## Decisions
 

--- a/cairn/milestones/M39-radial-label-legibility.md
+++ b/cairn/milestones/M39-radial-label-legibility.md
@@ -4,7 +4,7 @@
 - **Priority:** normal
 - **Depends on:** —
 - **Principles touched:** —
-- **Branch/PR:** `m39-radial-label-legibility` / —
+- **Branch/PR:** `m39-radial-label-legibility` / [PR #65](https://github.com/jmgirard/circumplex/pull/65)
 
 ## Goal
 
@@ -44,28 +44,28 @@ ships. Review confirms M39 is merged ahead of the release handoff.
 
 ## Acceptance criteria
 
-- [ ] The radial axis tick labels render with a backdrop grob behind them,
+- [x] The radial axis tick labels render with a backdrop grob behind them,
       asserted structurally (the property — that a backdrop is emitted, one per
       labelled break, positioned with the labels), not by eyeballing a render.
       M32 established that label overlap itself cannot be fenced at grob level
       because the label grobs are nested unnamed gTrees; fence what is
       constructible instead.
-- [ ] A new vdiffr baseline covers a radial label falling over a dark mark —
+- [x] A new vdiffr baseline covers a radial label falling over a dark mark —
       a case the existing 14 canvas baselines do not contain. Verified to have
       teeth: it must differ from what the pre-change code renders.
-- [ ] Existing radial-axis fences still pass unchanged:
+- [x] Existing radial-axis fences still pass unchanged:
       `test-coord_circumplex.R`'s `ssm_r_axis_angle()` unit tests and the two
       `r_axis_inside` placement tests (`:218-253`), and the
       `test-ggproto-classes.R:53` field-copy fence.
-- [ ] The three reported figures re-rendered and read legibly; any baseline
+- [x] The three reported figures re-rendered and read legibly; any baseline
       that moved is accounted for as intended (M38: a clean vdiffr run is
       evidence only after checking the baselines exercise the changed path).
-- [ ] `devtools::document()` no diff; `devtools::test()` clean;
+- [x] `devtools::document()` no diff; `devtools::test()` clean;
       `devtools::check(manual = TRUE)` 0 errors / 0 warnings / 0 notes, with
       `checking PDF version of manual ... OK` and
       `checking re-building of vignette outputs ... OK` confirmed present in
       the log by name (M7: never read `Status: OK` as coverage).
-- [ ] `NEWS.md` carries a user-visible entry; if anything new is exported, a
+- [x] `NEWS.md` carries a user-visible entry; if anything new is exported, a
       `_pkgdown.yml` row in the same commit.
 
 ## Coverage
@@ -152,4 +152,45 @@ does not fire. Appearance is white at 75% alpha with 1pt padding — legible
 without erasing the data beneath. Jeff approved mechanism, API shape, and
 appearance at the T3 gate.
 
+- 2026-07-19: review — four findings from three lenses, all scored >= 80, all fixed on the branch and re-verified fresh (not by trusting the reviewers' own reproductions). **F1** (grid without a D-entry): D-022 written. **F2** (spoke labels plated when they read like amplitudes): plating now requires the grob be inside the guide's own `axis` gtable AND match the labels — reproduction went 2 backdrop groups -> 1. **F3** (plotmath sized to deparsed source): measured with `grobWidth`/`grobHeight` on the label grob — plotmath widths now glyph-scale (7.57/18.53/9.07/6.36/5.88pt vs the scorer's 54.5pt-for-7.1pt), byte-identical for plain labels so all 17 baselines still match. **F4** (fence missed plate extent/offset, caught only by skip_on_ci vdiffr): three structural regression tests added — fixed-size plate now fails 15, dropped re-centring fails 10, previously zero each. Post-fix: full `devtools::test()` clean (0 failures, 4 pre-existing Hessian warnings), `document()` no diff, `check(manual = TRUE)` 0/0/0 with both named steps present, `cairn_validate` 15/15, PR #65 CI 9/9 green. AC1-AC6 boxes ticked against this evidence.
+
 ## Review
+
+Reviewed 2026-07-19. PR [#65](https://github.com/jmgirard/circumplex/pull/65).
+
+### Acceptance-criterion evidence
+
+- **AC1 — backdrop rendered, asserted structurally.** `test-coord_circumplex.R`'s four M39 T2 tests pass with 51 assertions: a backdrop gTree exists carrying one `rect` per non-blank label, each plate rotated to the label's own `rot`, anchored at its own label rather than all at one point, inheriting the label font, and filled `#FFFFFF` at less than full opacity with `col = NA`. Fenced by mutation rather than inspection — suppressing the backdrop fails 6, dropping the rotation fails 10.
+- **AC2 — collision baseline with teeth.** New vdiffr baseline `amplitude-labels-over-dark-marks` puts heavy dark markers and an arrowhead where the labels fall; no pre-existing canvas baseline drew labels over anything. Teeth re-proven **fresh at review**, not inherited: stubbing `label_backdrop()` to `NULL` fails it, and dropping the plate rotation fails it.
+- **AC3 — pre-existing fences unchanged.** All fences the criterion names by path pass untouched: `ssm_r_axis_angle()` unit tests (9 assertions), both `r_axis_inside` placement tests (2 and 4), and `test-ggproto-classes.R`'s field-copy fence (7). Whole file: 0 failed, 0 error.
+- **AC4 — figures legible, baselines accounted for.** All three reported figures re-rendered and read: `0.6` over the arrowhead, `0.50` over the marker (pixel behind the final glyph sampled `srgb(210,210,210)` — exactly 75% white over the dark arrow, so the plate composites as designed), `0.0`/`0.5` over the scatter. 17 canvas baselines moved, 12 did not, and the split is exactly the canvas/non-canvas boundary — every unmoved one is a curve, contrast-panel, trajectory, or ladder plot with no radial axis, verified by reading each test's plotting call rather than inferring from its name. The history lens independently diffed all 17 line-by-line: **pure additions of `<rect>` elements, zero removed lines**, nothing else moved.
+- **AC5 — checks clean.** `devtools::check(manual = TRUE)`: **Status OK, 0/0/0** (5m30s), with `checking PDF version of manual ... OK` and `checking re-building of vignette outputs ... OK` confirmed present by name, never inferred from the summary line (M7's lesson). `document()` no diff. Full suite clean.
+- **AC6 — NEWS + pkgdown.** NEWS entry present in the v2.0.0 Visualization section; `check_pkgdown()` no problems; no `_pkgdown.yml` row needed since nothing is exported. No milestone numbers leak into user-facing text (grep over NEWS, README, cran-comments).
+
+### Consistency gate
+
+`cairn_validate` exit 0, all 15 checks PASS. 47 advisory `work-log format` warnings, every one on a hard-wrapped pre-M39 entry in M7's log — history, advisory by design, untouched. No principle changed (`Principles touched: —`), so the impact report is a clean skip. Toolchain slot: `document()` no diff; `NAMESPACE`/`man/` clean; `check_pkgdown()` passes; one added file, a snapshot under `tests/`, needing no `.Rbuildignore` entry; full check clean. PR #65 CI: **9/9 green** across macOS/Windows/Ubuntu (release, devel, oldrel-1), pkgdown, and both codecov gates.
+
+### Independent review — three lenses
+
+- **[O] diff-bug (Opus):** 3 findings plus one unnumbered note. Verified the shift formula, traversal safety, and matching robustness empirically (32 `center`x`amax` combinations; zero label ink off-plate across nine `r_axis_angle` values) before reporting.
+- **[S] blame-history (Sonnet):** 1 finding. No silent undoing: `render_fg` is purely additive (zero `-` lines in `R/coord_circumplex.R`), M38-D1's blank rim label is respected and fenced, and M32's "match by content, not index" lesson is honoured.
+- **[S] prior-PR-comments (Sonnet):** no prior-PR evidence — all merged PRs touching these files carry zero inline review comments. Clean no-op, zero findings, as LESSONS records is permanent for this repo.
+
+### Findings actioned (all four scored >= 80)
+
+**F1 (90) — `grid` added to Imports with no D-entry.** `DESCRIPTION` gained `grid`, but `cairn/DECISIONS.md` was untouched by the branch and its only `grid` string is inside the word "r-gridlines". The tracking rules require dependency changes to take a question gate **and** a D-entry; the gate was held at T3 but the entry was never written, and a work-log narration is not the required artifact. Every prior dependency change has one, including D-021, which was argued into an entry despite the constraint already being transitively true.
+**Fixed:** D-022 written, recording `grid` as base R, already transitively loaded via ggplot2, adding no install burden and unable to raise the R floor — and noting that `grDevices` was deliberately NOT taken for a colour constant.
+
+**F2 (85) — spoke labels could be plated, which Scope puts explicitly Out.** `add_label_backdrop()` matched on label-vector equality alone and did not stop at the first hit, so any foreground text grob whose labels equalled the radial labels got plates. Reproduced by both the reviewer and the scorer: `scale_x_continuous(labels = c("0.0", ..., "0.8"))` produced **two** backdrop groups, one behind the spoke labels. The code comment claimed the design fails visibly "rather than silently styling the wrong text" — here it silently styled the wrong text.
+**Fixed:** plating now requires **both** that the grob sits inside the guide's own `axis` gtable **and** that its labels match. Short-circuiting on first match would have been wrong — the theta guide is traversed first, so it would have selected the wrong grob. **Verified against the reproduction: 2 backdrop groups -> 1.**
+
+**F3 (88) — plotmath labels got plates sized to deparsed source text.** `as.character(txt$label)` deparses an expression, so `stringWidth()` measured the string `"gamma^2"` rather than the single rendered glyph. Reviewer measured ~4x oversize; the scorer independently measured **54.5pt of plate for a 7.1pt glyph**, and the base glyph of `gamma^2` fell outside its own plate vertically. Introduced by this diff — before it there was no plate.
+**Fixed:** the label is kept in its original form and measured with `grobWidth()`/`grobHeight()` on a text grob built from the label itself, which measures what the device draws for plain strings and expressions alike. **Verified: plate widths for the plotmath reproduction are now 7.57 / 18.53 / 9.07 / 6.36 / 5.88 pt** — glyph-scale, with the subscript and superscript cases correctly wider. Byte-identical for plain labels (all 17 baselines still match).
+
+**F4 (88) — the fence constrained rotation and anchor but not plate extent or padding offset.** Review mutation-verified that a plate hardcoded to 30x30pt, and one with the `pad * (2 * just - 1)` re-centring dropped, both **passed every structural test** and failed only the two vdiffr baselines — which both carry `skip_on_ci()`, so on CI those regressions went green. The same gap as the milestone's own headline lesson, one level down.
+**Fixed:** three regression tests added asserting the size units derive from a grob measurement (a constant-size plate cannot satisfy them) and that the anchors carry the padding term. **Mutation-verified: fixed-size plate now fails 15 structural assertions, dropped re-centring fails 10** — previously zero each.
+
+### Findings logged, not actioned
+
+- **Unnumbered minor (diff lens, below the bar and not scored) — helper inconsistency.** `label_backdrop()` recycles `x`/`y` with a hand-rolled `recycle()` handling only length-1 and length-n, while `hjust`/`vjust`/`rot` use `rep_len()`. A text grob with, say, 3 x-values for 6 labels is legal under grid recycling and would be subset by a length-6 logical. The reviewer could construct no path reaching it and flagged it only because two helpers in one function disagree. Left as-is: no reachable defect, and the ggplot2 axis guide always emits either a scalar or a full-length vector.

--- a/cairn/milestones/M39-radial-label-legibility.md
+++ b/cairn/milestones/M39-radial-label-legibility.md
@@ -1,10 +1,10 @@
 # M39: Legible radial axis labels over data layers
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** `m39-radial-label-legibility` / —
 
 ## Goal
 
@@ -76,7 +76,7 @@ master do not diverge mid-review. Review confirms before merging.
 
 ## Tasks
 
-- [ ] **T1** — Choose the backdrop mechanism and record why in the milestone's
+- [x] **T1** — Choose the backdrop mechanism and record why in the milestone's
       Decisions section. Two candidates are known: (a) post-process the grob
       tree returned by `CoordRadial$render_fg` to wrap the label grobs — direct,
       but walks the nested unnamed gTrees M32 found fragile; (b) compute the
@@ -85,18 +85,18 @@ master do not diverge mid-review. Review confirms before merging.
       ([coord_circumplex.R:202-215](R/coord_circumplex.R:202)), and draw the
       backdrops in a `render_fg` override before delegating — avoids grob
       spelunking entirely. Prefer (b) unless it proves unworkable.
-- [ ] **T2** — Write the structural fence first (test-first), asserting the
+- [x] **T2** — Write the structural fence first (test-first), asserting the
       backdrop property against the chosen mechanism. It must fail against
       current `main`.
-- [ ] **T3** — Implement the backdrop in `CoordCircumplex`
+- [x] **T3** — Implement the backdrop in `CoordCircumplex`
       ([R/coord_circumplex.R:178-217](R/coord_circumplex.R:178)). Decide whether
       to expose an escape hatch; exposing one is a new CRAN API commitment, so
       it takes the question gate and a D-entry rather than a unilateral call.
       *(RB tripwire: irreversible-api — only if an argument is exported.)*
-- [ ] **T4** — Add the collision vdiffr baseline; prove it has teeth by running
+- [x] **T4** — Add the collision vdiffr baseline; prove it has teeth by running
       it against the pre-change renderer (M38's lesson: baselines that never
       exercise the changed path report green regardless).
-- [ ] **T5** — Re-render `occasions-path`, `occasions-path-wrapper`, and
+- [x] **T5** — Re-render `occasions-path`, `occasions-path-wrapper`, and
       `individuals`; inspect each and record the result. Regenerate any canvas
       baselines that legitimately moved, and state which and why.
 - [ ] **T6** — `document()`, `test()`, `check(manual = TRUE)`; NEWS entry;
@@ -107,6 +107,42 @@ master do not diverge mid-review. Review confirms before merging.
 - 2026-07-19: created by /milestone-plan. Promoted from the ROADMAP candidate added 2026-07-18 out of M38's T6 render-and-inspect sweep. **The candidate row's diagnosis was wrong and was corrected at this gate:** it recorded the amplitude labels as "panel furniture drawn beneath the geom layers" and offered "drawing the radial guide above the layers" as a remedy. They are already drawn above. Three confirmations, on all three reported figures: the panel's children print in draw order with the axis gTree **last** (`grill` → geom layers → axis gTree); `CoordCircumplex$setup_panel_params` always assigns a *numeric* `r_axis_inside` (`R/coord_circumplex.R:202-207`), which defeats the `isFALSE(self$r_axis_inside)` early return in ggplot2 4.0.3's `CoordRadial$render_fg` and routes the r-axis guides into the foreground, while `render_bg` draws only `guide_grid()`; and recolouring `axis.text.y` red renders every reported label fully legible **on top of** the mark that had hidden it. The defect is contrast — grey30 text over dark arrowheads/markers (`occasions-path`, `occasions-path-wrapper`) and over a pale busy scatter (`individuals`) — so a backdrop is the only live remedy of the two the row proposed. Jeff accepted the correction and chose the package-level backdrop over a vignette-only `r_axis_angle` retune, radial labels only, and the property-fence-plus-new-baseline acceptance bar.
 - 2026-07-19: sequencing recorded rather than expressed as a dependency. M39 is technically independent of M7, so `Depends on:` stays `—` and the milestone is buildable now; the constraint is on *merge* only, while M7's v2.0.0 submission is in flight (see Scope → Merge gate).
 
+- 2026-07-19: started (/milestone-implement). Branch `m39-radial-label-legibility` cut from master at `894207a5`. Status planned→in-progress; the slot was freed by parking M7 as `blocked` on its external `submit_cran()` handoff (Jeff's gate choice) rather than by overriding the `at most one in-progress` check.
+
+- 2026-07-19: T1 done. Mechanism chosen and gated (see M39-D1): wrap the located label text grobs rather than compute label positions. Investigation that produced the reversal — the parent's foreground tree is `theta guide / zeroGrob / zeroGrob / r-axis gTree / border`, with the r-axis text nested `absoluteGrob → gtable "axis" → titleGrob → text`; `CoordRadial` positions it through the unexported `rotate_r_axis()`, so matching it needs `ggplot2:::` (a CRAN problem and a private-API dependency) or re-derived arithmetic that drifts silently. Also confirmed there is no theme route: `element_text()` in ggplot2 4.0.3 has no `fill`, and ggplot2 ships no text-with-background element. Jeff's gate answers: mechanism (a′), **no exported argument** (so the plan's `(RB tripwire: irreversible-api)` does not fire and no escalation was needed), semi-transparent white.
+- 2026-07-19: T2 done. Fence added to `test-coord_circumplex.R`, written before the implementation and confirmed to fail against it (10 failures + 1 error with no backdrop present).
+- 2026-07-19: T3 done, but **the first implementation was wrong in a way the T2 fence passed**, and that is the entry's point. The plates were given the labels' x/y and drawn as one vectorized `rectGrob`, on the assumption that a sibling of the text grob inherits its placement. It does not: the labels carry `rot = 67.5`, because the radial axis sits at an angle and each label is turned about its own anchor to stay readable, and `rectGrob()` has no rotation. The plates rendered axis-aligned and slid off their labels — **every structural assertion still passed**, and only rendering the canvas with the plates coloured bright red exposed it (the M33/M38 render-and-inspect lesson, and M36's "it works is not it is the mechanism"). Fixed by giving each label its own plate in a `viewport(x, y, angle = rot)`: a viewport rotates about its own centre, so centring it on the label's anchor reproduces exactly what `textGrob()` does. The fence was then **strengthened to catch the bug it had missed** — it now asserts the per-plate rotation equals the text's `rot`, that each plate is anchored at its own label rather than all at one point, and that the label font is inherited so `stringWidth()` measures the text as drawn. Mutation-verified across five mutations: rotation dropped **10 failures** (the bug that previously passed silently), shared anchor 1, font not inherited 5, opaque plate 5, backdrop suppressed 6.
+- 2026-07-19: T3 — two portability defects caught before commit, neither visible in a passing `load_all()` test run. `%||%` only reached base R in 4.4 while this package declares R (>= 4.1) (D-021) and rlang's is not imported, so it was replaced with a local helper; and `grDevices::adjustcolor()` would have added an undeclared second dependency, so the fill is written as the literal `#FFFFFFBF` rather than gaining one for a constant (D-006/D-014 minimal deps). `grid` **is** now in Imports — base R, ships with every install, already a ggplot2 dependency — user-approved at the T3 gate. `document()` produces no `man/`/`NAMESPACE` diff (both new functions are internal); the `cpm_gradient` link warning it emits was verified pre-existing on clean master.
+
+- 2026-07-19: T4 done. New baseline `amplitude-labels-over-dark-marks` puts heavy dark markers and a large arrowhead exactly where the amplitude labels fall, which no existing canvas baseline did — every one of them draws its labels over empty panel, so none could have seen a contrast defect (the M38 lesson, applied rather than rediscovered). **Teeth proven by mutation, not assumed:** with `label_backdrop()` stubbed to `NULL` the baseline fails; the artifact that mutated run wrote was deleted rather than accepted.
+- 2026-07-19: T5 done. **17 canvas baselines legitimately moved and were accepted; 12 did not, and the split is exactly the canvas/non-canvas boundary** — everything unmoved is a curve plot, a contrast panel plot, a trajectory plot, or the ladder plot, none of which draw a radial axis (verified by reading each test's plotting call, e.g. `single group mean ssm with labels` is `ssm_plot_curve()` and `group-constrast correlation ssm` is `ssm_plot_contrast()`, not circle plots as their names suggest). All three reported vignette figures re-rendered and inspected: `0.6` now reads over the arrowhead in `occasions-path`, `0.50` over the marker in `occasions-path-wrapper` (sampled `srgb(210,210,210)` behind the final glyph — exactly 75% white over the dark arrow, so the plate is compositing as designed), and `0.0`/`0.5` over the scatter in `individuals`. Full `devtools::test()` clean afterwards: 0 failures, the only warnings the 4 pre-existing `test-ci_accuracy.R` Hessian diagnostics. Stray PNGs the render scripts had dropped in the repo root were removed and the scripts repointed at the scratchpad (the M31 `Rplots.pdf` failure class).
+
 ## Decisions
+
+### M39-D1 (2026-07-19): the label backdrop wraps the label grobs; it does not compute label positions
+
+**Context:** the amplitude labels are illegible where they fall over dark or
+dense layers. They are already drawn above the data (the radial axis is a
+foreground guide), so this is a contrast problem and the remedy is a plate
+behind each label. Two ways to place that plate: compute the positions from
+`params$r.major` + `params$axis_rotation`, or derive them from the label grobs.
+**Decision:** derive them from the grobs. `CoordRadial` places the radial axis
+through an unexported `rotate_r_axis()`; matching it means either `ggplot2:::`
+— a CRAN check problem and a dependency on private API that can break on any
+ggplot2 release — or re-deriving arithmetic that drifts silently and leaves the
+plate beside the label rather than behind it. Sizing each plate with
+`stringWidth()`/`stringHeight()` and anchoring it at the label's own
+x/y/just/rot hands the geometry to grid at draw time, so it is exact by
+construction.
+**Consequences:** the residual risk moves from silent misplacement to failure
+to *find* the label subtree, which draws no plate at all — visible, and fenced.
+The labels are located by matching the radial view scale's label set rather than
+by index, since M32 established these grobs are nested in unnamed gTrees and the
+theta labels sit in a sibling subtree that M39 leaves alone. **No argument is
+exported**, so nothing enters the CRAN API surface and adding a control later
+stays purely additive; the plan's `(RB tripwire: irreversible-api)` therefore
+does not fire. Appearance is white at 75% alpha with 1pt padding — legible
+without erasing the data beneath. Jeff approved mechanism, API shape, and
+appearance at the T3 gate.
 
 ## Review

--- a/cairn/milestones/M7-v2-release-prep.md
+++ b/cairn/milestones/M7-v2-release-prep.md
@@ -159,6 +159,8 @@ complete and validated (D-008).
 
 - 2026-07-19: status in-progress→**blocked** (/milestone-implement M39, at Jeff's gate choice). Blocker: T4/AC4 is the `submit_cran()` handoff, an action only Jeff can take, so M7 waits on something outside any session. Parking it is a status correction, not a deprioritization — it frees cairn's single `in-progress` slot for M39 and keeps `at most one in-progress` green. **Nothing about the release changed:** T1–T3 stay done, AC4 stays unticked, the milestone stays unarchived, and M7 returns to `in-progress` the moment T4 is picked up. M39 additionally carries a merge gate forbidding it to reach master until this submission is handed off.
 
+- 2026-07-19: **ordering constraint added by M39, no status change — M7 stays `blocked`.** M39 (amplitude-label backdrop) documents its change in *this* release's NEWS at Jeff's gate choice, so the v2.0.0 tarball must contain it: **M39 merges before T4 runs `submit_cran()`**, or the submission would omit code its own NEWS describes. Jeff confirmed the tarball is not yet submitted and that M7 should stay parked meanwhile, so nothing is in conflict — the sequence is M39 merges, then M7 unblocks and ships. Recorded here because a later session reading M7 alone would otherwise not know T4 has a predecessor.
+
 ## Decisions
 
 ## Review

--- a/tests/testthat/_snaps/coord_circumplex/amplitude-labels-over-dark-marks.svg
+++ b/tests/testthat/_snaps/coord_circumplex/amplitude-labels-over-dark-marks.svg
@@ -41,39 +41,30 @@
 <polyline points='360.00,297.44 365.32,302.76 370.63,308.07 375.95,313.39 381.27,318.71 386.59,324.02 391.90,329.34 397.22,334.66 402.54,339.98 407.85,345.29 413.17,350.61 418.49,355.93 423.81,361.24 429.12,366.56 434.44,371.88 439.76,377.20 445.07,382.51 450.39,387.83 455.71,393.15 461.03,398.46 466.34,403.78 471.66,409.10 476.98,414.42 482.29,419.73 487.61,425.05 492.93,430.37 498.25,435.68 503.56,441.00 508.88,446.32 514.20,451.64 ' style='stroke-width: 1.16; stroke: #CCCCCC; stroke-linecap: butt;' />
 <polyline points='360.00,297.44 367.52,297.44 375.04,297.44 382.56,297.44 390.08,297.44 397.60,297.44 405.12,297.44 412.64,297.44 420.16,297.44 427.68,297.44 435.20,297.44 442.72,297.44 450.23,297.44 457.75,297.44 465.27,297.44 472.79,297.44 480.31,297.44 487.83,297.44 495.35,297.44 502.87,297.44 510.39,297.44 517.91,297.44 525.43,297.44 532.95,297.44 540.47,297.44 547.99,297.44 555.51,297.44 563.03,297.44 570.55,297.44 578.07,297.44 ' style='stroke-width: 1.16; stroke: #CCCCCC; stroke-linecap: butt;' />
 <polyline points='360.00,297.44 365.32,292.12 370.63,286.80 375.95,281.49 381.27,276.17 386.59,270.85 391.90,265.54 397.22,260.22 402.54,254.90 407.85,249.58 413.17,244.27 418.49,238.95 423.81,233.63 429.12,228.32 434.44,223.00 439.76,217.68 445.07,212.36 450.39,207.05 455.71,201.73 461.03,196.41 466.34,191.10 471.66,185.78 476.98,180.46 482.29,175.14 487.61,169.83 492.93,164.51 498.25,159.19 503.56,153.88 508.88,148.56 514.20,143.24 ' style='stroke-width: 1.16; stroke: #CCCCCC; stroke-linecap: butt;' />
-<polygon points='237.80,140.07 231.34,145.30 225.11,150.80 219.11,156.55 213.36,162.55 207.86,168.78 202.63,175.24 210.21,181.12 217.79,187.01 225.36,192.89 229.84,187.37 234.54,182.03 239.46,176.90 244.60,171.98 249.93,167.28 255.45,162.80 249.57,155.22 243.68,147.65 ' style='stroke-width: 1.07; stroke: #666666; stroke-linecap: butt; stroke-linejoin: miter; fill: #FC8D62; fill-opacity: 0.40;' />
-<polygon points='164.32,259.91 163.04,267.35 162.04,274.83 161.33,282.35 160.90,289.89 160.76,297.44 160.90,304.99 161.33,312.53 162.04,320.04 163.04,327.53 164.32,334.97 173.75,333.16 183.17,331.36 192.59,329.55 191.39,322.47 190.48,315.35 189.88,308.20 189.58,301.03 189.58,293.85 189.88,286.68 190.48,279.53 191.39,272.41 192.59,265.33 183.17,263.52 173.75,261.71 ' style='stroke-width: 1.07; stroke: #666666; stroke-linecap: butt; stroke-linejoin: miter; fill: #8DA0CB; fill-opacity: 0.40;' />
-<polygon points='191.93,404.44 195.94,410.49 200.16,416.39 204.60,422.13 209.24,427.70 214.08,433.10 219.11,438.32 224.34,443.36 229.74,448.20 235.31,452.84 241.05,457.28 246.95,461.50 253.00,465.51 258.15,457.42 263.30,449.33 268.45,441.23 262.26,437.10 256.25,432.69 250.44,428.03 244.84,423.12 239.46,417.97 234.31,412.59 229.40,406.99 224.74,401.19 220.34,395.18 216.21,388.98 208.11,394.14 200.02,399.29 ' style='stroke-width: 1.07; stroke: #666666; stroke-linecap: butt; stroke-linejoin: miter; fill: #E78AC3; fill-opacity: 0.40;' />
-<polygon points='315.15,491.57 322.53,493.13 329.96,494.40 337.43,495.40 344.94,496.11 352.46,496.54 360.00,496.68 367.54,496.54 375.06,496.11 382.57,495.40 390.04,494.40 397.47,493.13 404.85,491.57 402.69,482.22 400.53,472.87 398.37,463.53 391.48,464.97 384.54,466.13 377.56,466.99 370.55,467.57 363.52,467.86 356.48,467.86 349.45,467.57 342.44,466.99 335.46,466.13 328.52,464.97 321.63,463.53 319.47,472.87 317.31,482.22 ' style='stroke-width: 1.07; stroke: #666666; stroke-linecap: butt; stroke-linejoin: miter; fill: #A6D854; fill-opacity: 0.40;' />
-<polygon points='467.00,465.51 473.05,461.50 478.95,457.28 484.69,452.84 490.26,448.20 495.66,443.36 500.89,438.32 505.92,433.10 510.76,427.70 515.40,422.13 519.84,416.39 524.06,410.49 528.07,404.44 519.98,399.29 511.89,394.14 503.79,388.98 499.66,395.18 495.26,401.19 490.60,406.99 485.69,412.59 480.54,417.97 475.16,423.12 469.56,428.03 463.75,432.69 457.74,437.10 451.55,441.23 456.70,449.33 461.85,457.42 ' style='stroke-width: 1.07; stroke: #666666; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD92F; fill-opacity: 0.40;' />
-<polygon points='555.68,334.97 556.96,327.53 557.96,320.04 558.67,312.53 559.10,304.99 559.24,297.44 559.10,289.89 558.67,282.35 557.96,274.83 556.96,267.35 555.68,259.91 546.25,261.71 536.83,263.52 527.41,265.33 528.61,272.41 529.52,279.53 530.12,286.68 530.42,293.85 530.42,301.03 530.12,308.20 529.52,315.35 528.61,322.47 527.41,329.55 536.83,331.36 546.25,333.16 ' style='stroke-width: 1.07; stroke: #666666; stroke-linecap: butt; stroke-linejoin: miter; fill: #E5C494; fill-opacity: 0.40;' />
-<polygon points='517.37,175.24 512.14,168.78 506.64,162.55 500.89,156.55 494.89,150.80 488.66,145.30 482.20,140.07 476.32,147.65 470.43,155.22 464.55,162.80 470.07,167.28 475.40,171.98 480.54,176.90 485.46,182.03 490.16,187.37 494.64,192.89 502.21,187.01 509.79,181.12 ' style='stroke-width: 1.07; stroke: #666666; stroke-linecap: butt; stroke-linejoin: miter; fill: #B3B3B3; fill-opacity: 0.40;' />
-<circle cx='360.00' cy='112.87' r='3.59' style='stroke-width: 0.77; fill: #66C2A5;' />
-<circle cx='229.49' cy='166.93' r='3.59' style='stroke-width: 0.77; fill: #FC8D62;' />
-<circle cx='175.43' cy='297.44' r='3.59' style='stroke-width: 0.77; fill: #8DA0CB;' />
-<circle cx='229.49' cy='427.95' r='3.59' style='stroke-width: 0.77; fill: #E78AC3;' />
-<circle cx='360.00' cy='482.01' r='3.59' style='stroke-width: 0.77; fill: #A6D854;' />
-<circle cx='490.51' cy='427.95' r='3.59' style='stroke-width: 0.77; fill: #FFD92F;' />
-<circle cx='544.57' cy='297.44' r='3.59' style='stroke-width: 0.77; fill: #E5C494;' />
-<circle cx='490.51' cy='166.93' r='3.59' style='stroke-width: 0.77; fill: #B3B3B3;' />
-<text x='360.00' y='73.99' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='12.81px' lengthAdjust='spacingAndGlyphs'>PA</text>
-<text x='203.95' y='140.41' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>BC</text>
-<text x='136.55' y='300.74' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>DE</text>
-<text x='203.95' y='461.08' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.33px' lengthAdjust='spacingAndGlyphs'>FG</text>
-<text x='360.00' y='527.49' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='9.60px' lengthAdjust='spacingAndGlyphs'>HI</text>
-<text x='516.36' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='11.21px' lengthAdjust='spacingAndGlyphs'>JK</text>
-<text x='583.45' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>LM</text>
-<text x='515.89' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.41px' lengthAdjust='spacingAndGlyphs'>NO</text>
-<rect x='359.92' y='298.65' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
-<rect x='410.29' y='277.79' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
-<rect x='460.65' y='256.93' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
-<rect x='511.02' y='236.06' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
-<rect x='561.39' y='215.20' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
-<text x='360.92' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.00</text>
-<text x='411.28' y='285.39' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.25</text>
-<text x='461.65' y='264.53' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.50</text>
-<text x='512.02' y='243.67' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.75</text>
-<text x='562.38' y='222.80' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>1.00</text>
-<text x='87.42' y='15.89' style='font-size: 14.40px; font-family: sans;' textLength='159.30px' lengthAdjust='spacingAndGlyphs'>cpm circle plot no legend</text>
+<circle cx='410.37' cy='276.58' r='9.99' style='stroke-width: 0.77; fill: #1A1A1A;' />
+<circle cx='460.73' cy='255.71' r='9.99' style='stroke-width: 0.77; fill: #1A1A1A;' />
+<circle cx='511.10' cy='234.85' r='9.99' style='stroke-width: 0.77; fill: #1A1A1A;' />
+<circle cx='561.47' cy='213.99' r='9.99' style='stroke-width: 0.77; fill: #1A1A1A;' />
+<polyline points='410.37,276.58 417.56,273.60 424.76,270.62 431.95,267.63 439.15,264.65 446.34,261.67 453.54,258.69 460.73,255.71 469.13,252.24 477.52,248.76 485.92,245.28 494.31,241.80 502.71,238.33 511.10,234.85 521.17,230.68 531.25,226.51 541.32,222.33 551.39,218.16 561.47,213.99 ' style='stroke-width: 2.99; stroke-linecap: butt;' />
+<polygon points='548.32,231.12 561.47,213.99 540.05,211.17 ' style='stroke-width: 2.99; stroke-linecap: butt; fill: #000000;' />
+<text x='360.00' y='73.99' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.52px' lengthAdjust='spacingAndGlyphs'>90°</text>
+<text x='204.91' y='140.41' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>135°</text>
+<text x='136.55' y='300.74' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>180°</text>
+<text x='204.91' y='461.08' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>225°</text>
+<text x='360.00' y='527.49' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>270°</text>
+<text x='515.09' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>315°</text>
+<text x='583.45' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>360°</text>
+<text x='515.87' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.52px' lengthAdjust='spacingAndGlyphs'>45°</text>
+<rect x='359.92' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='410.29' y='277.79' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='460.65' y='256.93' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='511.02' y='236.06' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='561.39' y='215.20' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<text x='360.92' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='411.28' y='285.39' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='461.65' y='264.53' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='512.02' y='243.67' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='562.38' y='222.80' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='87.42' y='15.89' style='font-size: 14.40px; font-family: sans;' textLength='211.33px' lengthAdjust='spacingAndGlyphs'>amplitude labels over dark marks</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/coord_circumplex/rim-ring-at-an-unround-amax.svg
+++ b/tests/testthat/_snaps/coord_circumplex/rim-ring-at-an-unround-amax.svg
@@ -49,6 +49,10 @@
 <text x='516.36' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='11.21px' lengthAdjust='spacingAndGlyphs'>JK</text>
 <text x='583.45' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>LM</text>
 <text x='515.89' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.41px' lengthAdjust='spacingAndGlyphs'>NO</text>
+<rect x='359.92' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='417.48' y='274.81' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='475.04' y='250.97' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='532.61' y='227.12' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='360.92' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='418.48' y='282.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='476.04' y='258.57' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>1.0</text>

--- a/tests/testthat/_snaps/cpm_plot/cpm-circle-plot.svg
+++ b/tests/testthat/_snaps/cpm_plot/cpm-circle-plot.svg
@@ -64,6 +64,11 @@
 <text x='485.57' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='11.21px' lengthAdjust='spacingAndGlyphs'>JK</text>
 <text x='552.66' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>LM</text>
 <text x='485.10' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.41px' lengthAdjust='spacingAndGlyphs'>NO</text>
+<rect x='329.13' y='298.65' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='379.50' y='277.79' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='429.87' y='256.93' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='480.23' y='236.06' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='530.60' y='215.20' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='330.13' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.00</text>
 <text x='380.50' y='285.39' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.25</text>
 <text x='430.86' y='264.53' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.50</text>

--- a/tests/testthat/_snaps/fit_structure_api/structure-config-no-legend.svg
+++ b/tests/testthat/_snaps/fit_structure_api/structure-config-no-legend.svg
@@ -57,6 +57,11 @@
 <text x='427.89' y='517.45' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.41px' lengthAdjust='spacingAndGlyphs'>NO</text>
 <text x='569.08' y='379.65' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='12.81px' lengthAdjust='spacingAndGlyphs'>PA</text>
 <text x='583.45' y='301.31' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>BC</text>
+<rect x='361.04' y='288.59' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='332.56' y='242.10' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='304.07' y='195.62' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='275.59' y='149.14' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='247.10' y='102.65' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='362.04' y='296.19' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.00</text>
 <text x='333.55' y='249.71' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.25</text>
 <text x='305.07' y='203.22' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.50</text>

--- a/tests/testthat/_snaps/fit_structure_api/structure-config-plot.svg
+++ b/tests/testthat/_snaps/fit_structure_api/structure-config-plot.svg
@@ -57,6 +57,11 @@
 <text x='397.11' y='517.45' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.41px' lengthAdjust='spacingAndGlyphs'>NO</text>
 <text x='538.29' y='379.65' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='12.81px' lengthAdjust='spacingAndGlyphs'>PA</text>
 <text x='552.66' y='301.31' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>BC</text>
+<rect x='330.26' y='288.59' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='301.77' y='242.10' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='273.29' y='195.62' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='244.80' y='149.14' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='216.32' y='102.65' width='20.68' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='331.25' y='296.19' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.00</text>
 <text x='302.77' y='249.71' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.25</text>
 <text x='274.28' y='203.22' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.50</text>

--- a/tests/testthat/_snaps/geom_ssm/ggcircumplex-with-ssm-geoms.svg
+++ b/tests/testthat/_snaps/geom_ssm/ggcircumplex-with-ssm-geoms.svg
@@ -52,6 +52,12 @@
 <text x='515.09' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>315°</text>
 <text x='583.45' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>360°</text>
 <text x='515.87' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.52px' lengthAdjust='spacingAndGlyphs'>45°</text>
+<rect x='359.92' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='400.21' y='281.96' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='440.51' y='265.27' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='480.80' y='248.58' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='521.09' y='231.89' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='561.39' y='215.20' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='360.92' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='401.21' y='289.56' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
 <text x='441.50' y='272.87' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.2</text>

--- a/tests/testthat/_snaps/geom_ssm_path/ssm-path-across-the-seam.svg
+++ b/tests/testthat/_snaps/geom_ssm_path/ssm-path-across-the-seam.svg
@@ -56,6 +56,13 @@
 <text x='515.09' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>315°</text>
 <text x='583.45' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>360°</text>
 <text x='515.87' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.52px' lengthAdjust='spacingAndGlyphs'>45°</text>
+<rect x='359.92' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='393.50' y='284.74' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='427.07' y='270.83' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='460.65' y='256.93' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='494.23' y='243.02' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='527.81' y='229.11' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='561.39' y='215.20' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='360.92' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='394.49' y='292.35' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
 <text x='428.07' y='278.44' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.2</text>

--- a/tests/testthat/_snaps/geom_ssm_path/ssm-path-with-a-gap.svg
+++ b/tests/testthat/_snaps/geom_ssm_path/ssm-path-with-a-gap.svg
@@ -52,6 +52,13 @@
 <text x='515.09' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>315°</text>
 <text x='583.45' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>360°</text>
 <text x='515.87' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.52px' lengthAdjust='spacingAndGlyphs'>45°</text>
+<rect x='359.92' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='393.50' y='284.74' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='427.07' y='270.83' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='460.65' y='256.93' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='494.23' y='243.02' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='527.81' y='229.11' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='561.39' y='215.20' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='360.92' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='394.49' y='292.35' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
 <text x='428.07' y='278.44' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.2</text>

--- a/tests/testthat/_snaps/ssm_plot/cross-zero-circle.svg
+++ b/tests/testthat/_snaps/ssm_plot/cross-zero-circle.svg
@@ -52,6 +52,12 @@
 <text x='515.09' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>315°</text>
 <text x='583.45' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>360°</text>
 <text x='515.87' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.52px' lengthAdjust='spacingAndGlyphs'>45°</text>
+<rect x='359.92' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='400.21' y='281.96' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='440.51' y='265.27' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='480.80' y='248.58' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='521.09' y='231.89' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='561.39' y='215.20' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='360.92' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='401.21' y='289.56' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
 <text x='441.50' y='272.87' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.2</text>

--- a/tests/testthat/_snaps/ssm_plot/ggcircumplex-instrument-canvas.svg
+++ b/tests/testthat/_snaps/ssm_plot/ggcircumplex-instrument-canvas.svg
@@ -50,6 +50,12 @@
 <text x='516.36' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='11.21px' lengthAdjust='spacingAndGlyphs'>JK</text>
 <text x='583.45' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>LM</text>
 <text x='515.89' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.41px' lengthAdjust='spacingAndGlyphs'>NO</text>
+<rect x='359.92' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='400.21' y='281.96' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='440.51' y='265.27' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='480.80' y='248.58' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='521.09' y='231.89' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='561.39' y='215.20' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='360.92' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='401.21' y='289.56' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
 <text x='441.50' y='272.87' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.2</text>

--- a/tests/testthat/_snaps/ssm_plot/ggcircumplex-octant-canvas.svg
+++ b/tests/testthat/_snaps/ssm_plot/ggcircumplex-octant-canvas.svg
@@ -50,6 +50,12 @@
 <text x='515.09' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>315°</text>
 <text x='583.45' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>360°</text>
 <text x='515.87' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.52px' lengthAdjust='spacingAndGlyphs'>45°</text>
+<rect x='359.92' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='400.21' y='281.96' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='440.51' y='265.27' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='480.80' y='248.58' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='521.09' y='231.89' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='561.39' y='215.20' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='360.92' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='401.21' y='289.56' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
 <text x='441.50' y='272.87' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.2</text>

--- a/tests/testthat/_snaps/ssm_plot/many-circle-plots.svg
+++ b/tests/testthat/_snaps/ssm_plot/many-circle-plots.svg
@@ -58,6 +58,12 @@
 <text x='470.83' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>315°</text>
 <text x='539.18' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>360°</text>
 <text x='471.61' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.52px' lengthAdjust='spacingAndGlyphs'>45°</text>
+<rect x='315.66' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='355.95' y='281.96' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='396.24' y='265.27' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='436.54' y='248.58' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='476.83' y='231.89' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='517.12' y='215.20' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='316.65' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='356.95' y='289.56' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
 <text x='397.24' y='272.87' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.2</text>

--- a/tests/testthat/_snaps/ssm_plot/many-circle-repel.svg
+++ b/tests/testthat/_snaps/ssm_plot/many-circle-repel.svg
@@ -66,6 +66,12 @@
 <text x='515.09' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>315°</text>
 <text x='583.45' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>360°</text>
 <text x='515.87' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.52px' lengthAdjust='spacingAndGlyphs'>45°</text>
+<rect x='359.92' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='400.21' y='281.96' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='440.51' y='265.27' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='480.80' y='248.58' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='521.09' y='231.89' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='561.39' y='215.20' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='360.92' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='401.21' y='289.56' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
 <text x='441.50' y='272.87' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.2</text>

--- a/tests/testthat/_snaps/ssm_plot/measure-contrast-circle-ssm.svg
+++ b/tests/testthat/_snaps/ssm_plot/measure-contrast-circle-ssm.svg
@@ -54,6 +54,12 @@
 <text x='470.50' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>315°</text>
 <text x='538.85' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>360°</text>
 <text x='471.28' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.52px' lengthAdjust='spacingAndGlyphs'>45°</text>
+<rect x='315.33' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='355.62' y='281.96' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='395.91' y='265.27' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='436.21' y='248.58' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='476.50' y='231.89' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='516.79' y='215.20' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='316.32' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='356.61' y='289.56' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
 <text x='396.91' y='272.87' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.2</text>

--- a/tests/testthat/_snaps/ssm_plot/single-group-correlation-ssm.svg
+++ b/tests/testthat/_snaps/ssm_plot/single-group-correlation-ssm.svg
@@ -52,6 +52,12 @@
 <text x='515.09' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>315°</text>
 <text x='583.45' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>360°</text>
 <text x='515.87' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.52px' lengthAdjust='spacingAndGlyphs'>45°</text>
+<rect x='359.92' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='400.21' y='281.96' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='440.51' y='265.27' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='480.80' y='248.58' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='521.09' y='231.89' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='561.39' y='215.20' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='360.92' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='401.21' y='289.56' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.1</text>
 <text x='441.50' y='272.87' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.2</text>

--- a/tests/testthat/_snaps/ssm_plot/single-group-mean-ssm-no-palette.svg
+++ b/tests/testthat/_snaps/ssm_plot/single-group-mean-ssm-no-palette.svg
@@ -52,6 +52,12 @@
 <text x='515.09' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>315°</text>
 <text x='583.45' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>360°</text>
 <text x='515.87' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.52px' lengthAdjust='spacingAndGlyphs'>45°</text>
+<rect x='359.92' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='400.21' y='281.96' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='440.51' y='265.27' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='480.80' y='248.58' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='521.09' y='231.89' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='561.39' y='215.20' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='360.92' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='401.21' y='289.56' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='441.50' y='272.87' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>1.0</text>

--- a/tests/testthat/_snaps/ssm_plot/single-group-mean-ssm.svg
+++ b/tests/testthat/_snaps/ssm_plot/single-group-mean-ssm.svg
@@ -52,6 +52,12 @@
 <text x='515.09' y='461.08' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>315°</text>
 <text x='583.45' y='300.74' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='19.86px' lengthAdjust='spacingAndGlyphs'>360°</text>
 <text x='515.87' y='140.41' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='14.52px' lengthAdjust='spacingAndGlyphs'>45°</text>
+<rect x='359.92' y='298.65' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='400.21' y='281.96' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='440.51' y='265.27' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='480.80' y='248.58' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='521.09' y='231.89' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
+<rect x='561.39' y='215.20' width='15.34' height='8.60' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF; fill-opacity: 0.75;' />
 <text x='360.92' y='306.25' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='401.21' y='289.56' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='441.50' y='272.87' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>1.0</text>

--- a/tests/testthat/test-coord_circumplex.R
+++ b/tests/testthat/test-coord_circumplex.R
@@ -396,3 +396,84 @@ test_that("an amplitude label over a dark mark stays legible (M39 T4)", {
       )
   )
 })
+
+test_that("plate extent and padding offset are fenced structurally (M39 F4)", {
+  # Review found the structural fence covered rotation and anchor but NOT size
+  # or offset: a plate hardcoded to 30x30pt, or one with the padding re-centring
+  # dropped, passed everything here and failed only the two vdiffr baselines --
+  # both `skip_on_ci()`, so on CI those regressions went green. Fence the extent
+  # and the offset directly so the guard does not depend on a skipped snapshot.
+  parts <- axis_label_parts(ggcircumplex(octants(), amax = 0.8))
+  for (plate in parts$backdrop$children) {
+    # Size derives from the measured label, not a constant: the unit is a sum
+    # carrying a grob-measurement term, so a fixed-size plate cannot satisfy it.
+    for (dim in list(plate$width, plate$height)) {
+      expect_true(inherits(dim, "unit"))
+      expect_match(
+        paste(as.character(dim), collapse = " "), "grobwidth|grobheight",
+        ignore.case = TRUE
+      )
+    }
+    # The anchor carries the padding correction that re-centres the wider plate
+    # on its label. hjust/vjust are 0/1 here, so the offsets are -1pt and +1pt;
+    # dropping the correction leaves a bare 0.5npc with no "pt" term.
+    expect_match(paste(as.character(plate$x), collapse = " "), "pt|points")
+    expect_match(paste(as.character(plate$y), collapse = " "), "pt|points")
+  }
+})
+
+test_that("spoke labels are never plated, even when they read like amplitudes (M39 F2)", {
+  # Review reproduction: the walk matched on label text alone, so a caller whose
+  # THETA labels happen to equal the amplitude labels got plates behind both --
+  # and the theta guide is traversed first. The spoke labels are explicitly Out
+  # of this milestone's scope, so this must plate the amplitude axis only.
+  p <- ggplot2::ggplot() +
+    coord_circumplex(amax = 0.8) +
+    ggplot2::geom_blank(
+      data = data.frame(.x = c(0, 360), .y = c(0, 0.8)),
+      mapping = ggplot2::aes(x = .data$.x, y = .data$.y), inherit.aes = FALSE
+    ) +
+    ggplot2::scale_x_continuous(
+      breaks = c(72, 144, 216, 288, 360),
+      labels = c("0.0", "0.2", "0.4", "0.6", "0.8")
+    )
+  panel <- ggplot2::ggplotGrob(p)
+  panel <- panel$grobs[[which(panel$layout$name == "panel")]]
+  n <- 0L
+  walk <- function(g) {
+    if (identical(g$name, "circumplex-label-backdrop")) n <<- n + 1L
+    kids <- if (inherits(g, "gtable")) g$grobs else g$children
+    for (k in kids) walk(k)
+  }
+  walk(panel)
+  # Exactly one backdrop group: the amplitude axis. Two would mean the spoke
+  # labels were plated too.
+  expect_equal(n, 1L)
+})
+
+test_that("a plotmath label is measured as drawn, not as its source text (M39 F3)", {
+  # Review found `as.character()` deparsed an expression, so the plate was sized
+  # to the string "gamma^2" rather than to the single rendered glyph -- several
+  # times too wide, and vertically offset by the superscript. The plate must be
+  # measured from the label itself.
+  p <- ggplot2::ggplot() +
+    coord_circumplex(amax = 0.8) +
+    ggplot2::geom_blank(
+      data = data.frame(.x = c(0, 360), .y = c(0, 0.8)),
+      mapping = ggplot2::aes(x = .data$.x, y = .data$.y), inherit.aes = FALSE
+    ) +
+    ggplot2::scale_x_continuous(breaks = octants()) +
+    ggplot2::scale_y_continuous(
+      breaks = c(0, 0.2, 0.4, 0.6, 0.8),
+      labels = parse(text = c("alpha", "beta[max]", "gamma^2", "delta", "epsilon"))
+    )
+  parts <- axis_label_parts(p)
+  expect_false(is.null(parts$backdrop))
+  # Measurement is grob-based, so plotmath is measured rendered rather than
+  # deparsed; a stringWidth() implementation would carry "strwidth" instead.
+  for (plate in parts$backdrop$children) {
+    w <- paste(as.character(plate$width), collapse = " ")
+    expect_match(w, "grobwidth", ignore.case = TRUE)
+    expect_false(grepl("strwidth", w, ignore.case = TRUE))
+  }
+})

--- a/tests/testthat/test-coord_circumplex.R
+++ b/tests/testthat/test-coord_circumplex.R
@@ -264,3 +264,135 @@ test_that("the rim ring renders on an unround amax", {
     ggcircumplex(octants(), labels = PANO(), amax = 1.75)
   )
 })
+
+# --- M39: the amplitude labels carry a backdrop so data cannot swallow them ---
+
+# Pull the panel's foreground grob (the last panel child; the radial axis is a
+# FOREGROUND guide, which is why the labels were already on top of the data and
+# the defect was contrast rather than draw order) and return the amplitude-axis
+# text grob alongside the backdrop drawn behind it. Located by name and by
+# label-set rather than by index: M32 established that these grobs are nested in
+# unnamed gTrees, so a positional path into them is not stable, and the theta
+# (spoke) labels sit in a sibling subtree that M39 deliberately leaves alone.
+axis_label_parts <- function(p) {
+  panel <- ggplot2::ggplotGrob(p)
+  panel <- panel$grobs[[which(panel$layout$name == "panel")]]
+  found <- list(text = NULL, backdrop = NULL)
+  walk <- function(g) {
+    if (inherits(g, "text") && !any(grepl("°", as.character(g$label)))) {
+      found$text <<- g
+    }
+    if (identical(g$name, "circumplex-label-backdrop")) found$backdrop <<- g
+    kids <- if (inherits(g, "gtable")) g$grobs else g$children
+    for (k in kids) walk(k)
+  }
+  walk(panel)
+  found
+}
+
+test_that("the amplitude labels are drawn over a backdrop (M39 T2)", {
+  parts <- axis_label_parts(ggcircumplex(octants(), amax = 0.8))
+
+  # The labels themselves are unchanged: still one vectorized text grob.
+  expect_false(is.null(parts$text))
+  expect_equal(as.character(parts$text$label), c("0.0", "0.2", "0.4", "0.6", "0.8"))
+
+  # A backdrop exists, carrying one plate per label rather than one for all.
+  expect_false(is.null(parts$backdrop))
+  expect_length(parts$backdrop$children, length(parts$text$label))
+  for (plate in parts$backdrop$children) expect_s3_class(plate, "rect")
+
+  # Semi-transparent fill and no border, so the data underneath stays visible.
+  for (plate in parts$backdrop$children) {
+    expect_identical(plate$gp$col, NA)
+    expect_match(plate$gp$fill, "^#FFFFFF", ignore.case = TRUE)
+    expect_false(identical(toupper(plate$gp$fill), "#FFFFFFFF")) # not opaque
+  }
+})
+
+test_that("each plate is rotated onto its own label (M39 T2)", {
+  # The regression this exists for: the radial axis sits at an angle and every
+  # label is turned about its own anchor to stay readable, but rectGrob has no
+  # rotation. A first implementation shared the labels' x/y and still drew the
+  # plates axis-aligned, so they slid off the text -- and every structural
+  # assertion above still passed. Only rendering exposed it. Fence the rotation
+  # and the per-label anchor directly so it cannot come back silently.
+  parts <- axis_label_parts(ggcircumplex(octants(), amax = 0.8))
+  rot <- parts$text$rot
+  expect_true(rot != 0) # precondition: the labels really are rotated here
+
+  anchors_x <- character(0)
+  for (plate in parts$backdrop$children) {
+    expect_false(is.null(plate$vp))
+    expect_equal(plate$vp$angle, rot)
+    anchors_x <- c(anchors_x, format(plate$vp$y))
+  }
+  # Each plate is anchored at its own label's position, not all at one point.
+  expect_equal(length(unique(anchors_x)), length(parts$text$label))
+
+  # The plates inherit the label font, so their size measures the text as drawn
+  # rather than at the device default.
+  for (plate in parts$backdrop$children) {
+    expect_equal(plate$gp$fontsize, parts$text$gp$fontsize)
+  }
+})
+
+test_that("the backdrop tracks a relocated axis (M39 T2)", {
+  # r_axis_angle (M32) moves the axis, which changes the label rotation; the
+  # plates must follow it rather than keep the default placement's angle.
+  p <- ggplot2::ggplot() +
+    coord_circumplex(amax = 0.8, r_axis_angle = 200) +
+    ggplot2::geom_blank(
+      data = data.frame(.x = c(0, 360), .y = c(0, 0.8)),
+      mapping = ggplot2::aes(x = .data$.x, y = .data$.y), inherit.aes = FALSE
+    ) +
+    ggplot2::scale_x_continuous(breaks = octants())
+  moved <- axis_label_parts(p)
+  expect_false(is.null(moved$backdrop))
+  expect_length(moved$backdrop$children, length(moved$text$label))
+  for (plate in moved$backdrop$children) {
+    expect_equal(plate$vp$angle, moved$text$rot)
+  }
+  # And that really is a different angle from the default placement.
+  default_rot <- axis_label_parts(ggcircumplex(octants(), amax = 0.8))$text$rot
+  expect_false(isTRUE(all.equal(moved$text$rot, default_rot)))
+})
+
+test_that("the rim's blank label gets no plate (M39 T2)", {
+  # M38 appends the rim break with a blank label. A plate behind an empty string
+  # would be a stray floating rectangle, so the count follows the non-empty
+  # labels, not the break count.
+  parts <- axis_label_parts(ggcircumplex(octants(), amax = 1.75))
+  labels <- as.character(parts$text$label)
+  # amax 1.75 is not a generated break, so M38 appends the rim with a blank
+  # label -- the precondition this test depends on, asserted rather than assumed.
+  expect_true(any(labels == ""))
+  expect_length(parts$backdrop$children, sum(labels != ""))
+})
+
+test_that("an amplitude label over a dark mark stays legible (M39 T4)", {
+  # The defect M39 fixes is a CONTRAST failure, and no existing canvas baseline
+  # could see it: every one of them draws the labels over empty panel. This
+  # baseline puts a large dark marker and a heavy arrowhead exactly where the
+  # amplitude labels fall -- the `advanced-visualization.Rmd` situation reduced
+  # to a fixture -- so the plates are the only thing keeping the labels
+  # readable, and removing them moves this image.
+  skip_on_ci()
+  # amax 0.8 puts labels at 0.2/0.4/0.6; the path runs straight through them.
+  marks <- data.frame(a = c(0.2, 0.4, 0.6, 0.8), d = rep(22.5, 4))
+  vdiffr::expect_doppelganger(
+    "amplitude labels over dark marks",
+    ggcircumplex(octants(), amax = 0.8) +
+      geom_ssm_point(
+        data = marks,
+        mapping = ggplot2::aes(amplitude = .data$a, displacement = .data$d),
+        fill = "grey10", size = 9
+      ) +
+      geom_ssm_path(
+        data = marks,
+        mapping = ggplot2::aes(amplitude = .data$a, displacement = .data$d),
+        arrow = grid::arrow(length = grid::unit(0.3, "inches"), type = "closed"),
+        linewidth = 1.4
+      )
+  )
+})


### PR DESCRIPTION
Amplitude (radial) axis labels now sit on a translucent white plate, so a label
crossing a dark marker, an arrowhead, or a dense scatter stays readable. Applies
to every circumplex canvas, users' own plots included. Nothing added to the API.

## The diagnosis was corrected during planning

The originating ROADMAP candidate recorded the labels as "panel furniture drawn
beneath the geom layers" and proposed "drawing the radial guide above the
layers". They are already drawn above — the radial axis is a foreground guide.
The defect is contrast, not draw order, so that proposed remedy was a no-op.

## Mechanism (M39-D1)

Built by wrapping the located label grobs rather than computing label positions:
`CoordRadial` places the axis through an unexported `rotate_r_axis()`, so
matching it would need `ggplot2:::` or arithmetic that drifts silently.

## A bug the first fence passed

The first implementation gave the plates the labels' x/y and drew them
axis-aligned. Labels carry `rot = 67.5`, and `rectGrob` has no rotation, so the
plates slid off — and every structural assertion still passed. Only rendering
exposed it. Each plate now sits in a viewport centred on its label's anchor with
a matching angle, and the fence was strengthened to assert rotation, per-label
anchor, and font inheritance. Mutation-checked: dropping the rotation now fails
10 assertions, previously zero.

## Verification

- `devtools::check(manual = TRUE)`: Status OK, 0/0/0, with
  `checking PDF version of manual ... OK` and
  `checking re-building of vignette outputs ... OK` confirmed by name
- `devtools::test()`: 0 failures
- 17 canvas vdiffr baselines regenerated + 1 new collision baseline; the 12
  unchanged are all non-canvas plots with no radial axis

`grid` added to Imports (base R, already a ggplot2 dependency).

**Merge order:** this must merge before v2.0.0 is submitted — its NEWS entry is
in the 2.0.0 section, so the submitted tarball must contain it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)