### PR TITLE
M40: Source notes for the two shelved primary sources

### DIFF
--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38 | high | milestones/M7-v2-release-prep.md |
-| M40 | Source notes for the two shelved primary sources | planned | — | normal | milestones/M40-reference-notes-shelved.md |
+| M40 | Source notes for the two shelved primary sources | in-progress | — | normal | milestones/M40-reference-notes-shelved.md |
 | M41 | Source notes for the seven unshelved relied-on sources | planned | M40 | normal | milestones/M41-reference-notes-unshelved.md |
 | M39 | Legible radial axis labels over data layers | done | — | normal | milestones/archive/M39-radial-label-legibility.md |
 | M38 | Guaranteed rim ring for the circumplex canvas | done | — | normal | milestones/archive/M38-rim-ring-guarantee.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38 | high | milestones/M7-v2-release-prep.md |
-| M40 | Source notes for the two shelved primary sources | in-progress | — | normal | milestones/M40-reference-notes-shelved.md |
+| M40 | Source notes for the two shelved primary sources | review | — | normal | milestones/M40-reference-notes-shelved.md |
 | M41 | Source notes for the seven unshelved relied-on sources | planned | M40 | normal | milestones/M41-reference-notes-unshelved.md |
 | M39 | Legible radial axis labels over data layers | done | — | normal | milestones/archive/M39-radial-label-legibility.md |
 | M38 | Guaranteed rim ring for the circumplex canvas | done | — | normal | milestones/archive/M38-rim-ring-guarantee.md |

--- a/cairn/milestones/M40-reference-notes-shelved.md
+++ b/cairn/milestones/M40-reference-notes-shelved.md
@@ -1,6 +1,6 @@
 # M40: Source notes for the two shelved primary sources
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Principles touched:** —
@@ -14,8 +14,8 @@ establishing the page conventions the remaining seven follow.
 
 ## Scope
 
-**In:** Source notes `cairn/references/grassi2010CircE.md` and
-`cairn/references/zimmermann2017Description.md`, authored from
+**In:** Source notes `cairn/references/grassi2010.md` and
+`cairn/references/zimmermann2017.md` (citekeys per M40-D1), authored from
 `skills/shared/templates/source-note.md` — extracted values carrying page or
 table anchors, a `Traces to` list naming specific files and lines, and a
 Provenance block. Both record `Extraction: verified 2026-07-19`, sourced to
@@ -33,10 +33,10 @@ slot is not applicable and AC7 fences that claim instead.
 
 ## Acceptance criteria
 
-- [ ] `cairn/references/grassi2010CircE.md` exists, carries every section the
+- [ ] `cairn/references/grassi2010.md` exists, carries every section the
       source-note template defines, and every extracted value carries a page
       or table anchor.
-- [ ] `cairn/references/zimmermann2017Description.md` likewise.
+- [ ] `cairn/references/zimmermann2017.md` likewise.
 - [ ] Both Provenance blocks carry an `Extraction:` status on a **single
       physical line** (a wrapped status silently loses its `— observed` stamp
       to the staleness guard), recording verification against the primary
@@ -79,15 +79,16 @@ slot is not applicable and AC7 fences that claim instead.
       track its low Prob (.130), not its R².
 - [x] T3. Write both Provenance blocks; verify each `Extraction:` status is
       one physical line.
-- [ ] T4. Rewrite `INDEX.md` — drop the deferral comment, add one line per
+- [x] T4. Rewrite `INDEX.md` — drop the deferral comment, add one line per
       committed page.
-- [ ] T5. Mutation-prove the references check, then run `cairn_validate`
+- [x] T5. Mutation-prove the references check, then run `cairn_validate`
       clean.
-- [ ] T6. Tail-byte check every written page; confirm `git diff devel/` is
+- [x] T6. Tail-byte check every written page; confirm `git diff devel/` is
       empty and no package file is touched.
 
 ## Work log
 
+- 2026-07-19: T4–T6 done; status → review. **T5 caught a real defect by mutation before it shipped.** The first `INDEX.md` used `[grassi2010](grassi2010.md)` as its entry, and `cairn_validate`'s `_INDEX_LINE` regex matches the first `[\w./-]+\.md` token after the bullet — so a bare citekey as link text is silently NOT a catalog entry, and BOTH pages read as unindexed while the file looked correct to a human. Entry text must be the filename (`[grassi2010.md](grassi2010.md)`); the trap is now documented in INDEX.md itself. Three mutations then proved the checks have teeth and all restored clean: dropping an INDEX entry FAILs, stripping a Provenance block FAILs, and blanking an `Extraction:` status fires the staleness WARN. Final state: `cairn_validate` 15/15 PASS with only M7's 47 pre-existing work-log-format advisories (unchanged from baseline); `git diff master...HEAD -- devel/` empty; the branch touches `cairn/` only; no leaked tool-call scaffolding in any written page.
 - 2026-07-19: T2+T3 done — `cairn/references/zimmermann2017.md`, both Provenance blocks written and each `Extraction:` status confirmed a single physical line (420 and 657 chars). Machine re-check reproduced the Note 3 matrices, both Table 4 rows, Table 4's note, the Study 2 thresholds, the Study 5 CircE indices and IIP-SC parameters, and all eight constants Eq. A6/A7/Eq. 3 derive (no-√2 variant misses all three f_a values). **Table 4's printed note independently confirms M7's Prob-not-R² correction.** Three items are outside a text layer and rest on Jeff's read alone, recorded as such rather than claimed: Figure 1A's octant angles, Figure 5's panel readings, and Eq. A7's √2 radicand + leading ½, which `pdftotext` silently drops — the M40 channel reproduced that artifact rather than resolving it, so the page logs Eq. A7 as still lacking two genuinely independent channels.
 - 2026-07-19: T1 done — `cairn/references/grassi2010.md`. The shelf changed mid-session: Jeff added seven PDFs and renamed the two originals to `author+year`, so `browne1992a.pdf` was identified as Browne & Cudeck (1992) SMR 21(2) 230–258 (not a second Browne solo paper) and `acton2002.pdf` as a bonus needing no page — the repo cites Acton & Revelle (2002) only as *others'* citation of prior work, which "consulted in passing owes nothing" excludes. Browne (1982) is still absent. Independent `pdftotext -layout` re-check reproduced EVERY fixture value: all 21 Table 1 correlations + N, the Table 2 model 1a row, the Table 3 fit row, all Appendix A full-precision estimates/SEs/fit measures, all seven communality indices and CIs after re-mapping the reordered block, all seven variance ratios, and the Listing 7 matrix + N. Three records confirmed on the page: A2's reordering note is printed verbatim ("variable names have been reordered to yield increasing polar angles"), A4's column really is ρ̂, and A6's retraction was right — p. 68 prints "Foreign Literature". New fact the fixtures never recorded: Appendix A's fit CIs are **90%** while its communality CIs are **95%**.
 - 2026-07-19: created by /milestone-plan. Scope split at the plan gate — the nine owed source notes are three different jobs (shelved+verified / transcribed-but-unshelved / cold reads), and only this group is workable today; M41 carries the other seven. Jeff's plan-gate decisions: leave the `devel/` transcriptions byte-untouched while M7's open work log cites them, and give Browne 1992 a full model specification in M41 rather than a reliance-scoped extract.

--- a/cairn/milestones/M40-reference-notes-shelved.md
+++ b/cairn/milestones/M40-reference-notes-shelved.md
@@ -72,12 +72,12 @@ slot is not applicable and AC7 fences that claim instead.
       communality index, not ζ; the symmetry belongs on ln v_ii). Record
       Appendix A's own variable order explicitly — flat row order invited a
       false mismatch at M7 T3.
-- [ ] T2. Author `zimmermann2017Description.md` from
+- [x] T2. Author `zimmermann2017.md` (citekey per M40-D1) from
       `devel/m4-zw-transcription.md` against the shelf PDF, carrying the Eq.
       A7 confirmation (√2 radicand **and** leading ½, both confirmed on the
       page 2026-07-19) and the Table 4 note that OCPD's withheld a/δ CIs
       track its low Prob (.130), not its R².
-- [ ] T3. Write both Provenance blocks; verify each `Extraction:` status is
+- [x] T3. Write both Provenance blocks; verify each `Extraction:` status is
       one physical line.
 - [ ] T4. Rewrite `INDEX.md` — drop the deferral comment, add one line per
       committed page.
@@ -88,6 +88,7 @@ slot is not applicable and AC7 fences that claim instead.
 
 ## Work log
 
+- 2026-07-19: T2+T3 done — `cairn/references/zimmermann2017.md`, both Provenance blocks written and each `Extraction:` status confirmed a single physical line (420 and 657 chars). Machine re-check reproduced the Note 3 matrices, both Table 4 rows, Table 4's note, the Study 2 thresholds, the Study 5 CircE indices and IIP-SC parameters, and all eight constants Eq. A6/A7/Eq. 3 derive (no-√2 variant misses all three f_a values). **Table 4's printed note independently confirms M7's Prob-not-R² correction.** Three items are outside a text layer and rest on Jeff's read alone, recorded as such rather than claimed: Figure 1A's octant angles, Figure 5's panel readings, and Eq. A7's √2 radicand + leading ½, which `pdftotext` silently drops — the M40 channel reproduced that artifact rather than resolving it, so the page logs Eq. A7 as still lacking two genuinely independent channels.
 - 2026-07-19: T1 done — `cairn/references/grassi2010.md`. The shelf changed mid-session: Jeff added seven PDFs and renamed the two originals to `author+year`, so `browne1992a.pdf` was identified as Browne & Cudeck (1992) SMR 21(2) 230–258 (not a second Browne solo paper) and `acton2002.pdf` as a bonus needing no page — the repo cites Acton & Revelle (2002) only as *others'* citation of prior work, which "consulted in passing owes nothing" excludes. Browne (1982) is still absent. Independent `pdftotext -layout` re-check reproduced EVERY fixture value: all 21 Table 1 correlations + N, the Table 2 model 1a row, the Table 3 fit row, all Appendix A full-precision estimates/SEs/fit measures, all seven communality indices and CIs after re-mapping the reordered block, all seven variance ratios, and the Listing 7 matrix + N. Three records confirmed on the page: A2's reordering note is printed verbatim ("variable names have been reordered to yield increasing polar angles"), A4's column really is ρ̂, and A6's retraction was right — p. 68 prints "Foreign Literature". New fact the fixtures never recorded: Appendix A's fit CIs are **90%** while its communality CIs are **95%**.
 - 2026-07-19: created by /milestone-plan. Scope split at the plan gate — the nine owed source notes are three different jobs (shelved+verified / transcribed-but-unshelved / cold reads), and only this group is workable today; M41 carries the other seven. Jeff's plan-gate decisions: leave the `devel/` transcriptions byte-untouched while M7's open work log cites them, and give Browne 1992 a full model specification in M41 rather than a reliance-scoped extract.
 

--- a/cairn/milestones/M40-reference-notes-shelved.md
+++ b/cairn/milestones/M40-reference-notes-shelved.md
@@ -1,10 +1,10 @@
 # M40: Source notes for the two shelved primary sources
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** `m40-reference-notes-shelved`
 
 ## Goal
 
@@ -64,7 +64,7 @@ slot is not applicable and AC7 fences that claim instead.
 
 ## Tasks
 
-- [ ] T1. Author `grassi2010CircE.md`: extract values from the provenance
+- [x] T1. Author `grassi2010.md` (citekey per M40-D1): extract values from the provenance
       headers in `tests/testthat/helper-cpm-oracles.R` and
       `tests/testthat/test-cpm_oracles.R` against the shelf PDF, preserving
       the M7 A3/A4/A5 corrections (unconstrained m = 1 fit measures come from
@@ -88,8 +88,13 @@ slot is not applicable and AC7 fences that claim instead.
 
 ## Work log
 
+- 2026-07-19: T1 done — `cairn/references/grassi2010.md`. The shelf changed mid-session: Jeff added seven PDFs and renamed the two originals to `author+year`, so `browne1992a.pdf` was identified as Browne & Cudeck (1992) SMR 21(2) 230–258 (not a second Browne solo paper) and `acton2002.pdf` as a bonus needing no page — the repo cites Acton & Revelle (2002) only as *others'* citation of prior work, which "consulted in passing owes nothing" excludes. Browne (1982) is still absent. Independent `pdftotext -layout` re-check reproduced EVERY fixture value: all 21 Table 1 correlations + N, the Table 2 model 1a row, the Table 3 fit row, all Appendix A full-precision estimates/SEs/fit measures, all seven communality indices and CIs after re-mapping the reordered block, all seven variance ratios, and the Listing 7 matrix + N. Three records confirmed on the page: A2's reordering note is printed verbatim ("variable names have been reordered to yield increasing polar angles"), A4's column really is ρ̂, and A6's retraction was right — p. 68 prints "Foreign Literature". New fact the fixtures never recorded: Appendix A's fit CIs are **90%** while its communality CIs are **95%**.
 - 2026-07-19: created by /milestone-plan. Scope split at the plan gate — the nine owed source notes are three different jobs (shelved+verified / transcribed-but-unshelved / cold reads), and only this group is workable today; M41 carries the other seven. Jeff's plan-gate decisions: leave the `devel/` transcriptions byte-untouched while M7's open work log cites them, and give Browne 1992 a full model specification in M41 rather than a reliance-scoped extract.
 
 ## Decisions
+
+- **M40-D1 (2026-07-19): citekeys follow the shelf's `author+year` filenames.** The pages are `grassi2010.md` and `zimmermann2017.md`, superseding the plan's `grassi2010CircE`/`zimmermann2017Description` — Jeff replaced the shelf mid-session with a consistently named nine-file set, and a citekey that disagrees with the file it points at is a permanent trap. Binds M41's seven pages too.
+- **M40-D2 (2026-07-19): an `Extraction:` status claims only what actually ran.** These two pages record verification because *both* channels exist — Jeff's M7 AC3 human re-read against the primary source, and an independent M40 `pdftotext -layout` re-check of every recorded value. A page with only one channel says so; a page with neither is `unverified`. Authoring a source note is itself a fresh transcription step, so inheriting an attestation of the *old* record without re-checking would have overclaimed.
+- **M40-D3 (2026-07-19): the Browne & Cudeck edition mismatch folds into M41's scope, not a candidate row.** `sources/browne1992a.pdf` is the 1992 *Sociological Methods & Research* 21(2), 230–258 article, while `R/ssm_ci_oop.R:415` cites the 1993 Bollen & Long chapter; resolving it edits package code, which M40 excludes. Noted here because Grassi p. 58 cites the **1992** version too, which is evidence toward correcting the shipped citation rather than hunting the chapter.
 
 ## Review

--- a/cairn/milestones/M40-reference-notes-shelved.md
+++ b/cairn/milestones/M40-reference-notes-shelved.md
@@ -33,23 +33,23 @@ slot is not applicable and AC7 fences that claim instead.
 
 ## Acceptance criteria
 
-- [ ] `cairn/references/grassi2010.md` exists, carries every section the
+- [x] `cairn/references/grassi2010.md` exists, carries every section the
       source-note template defines, and every extracted value carries a page
       or table anchor.
-- [ ] `cairn/references/zimmermann2017.md` likewise.
-- [ ] Both Provenance blocks carry an `Extraction:` status on a **single
+- [x] `cairn/references/zimmermann2017.md` likewise.
+- [x] Both Provenance blocks carry an `Extraction:` status on a **single
       physical line** (a wrapped status silently loses its `— observed` stamp
       to the staleness guard), recording verification against the primary
       source and traceable to M7's AC3 attestation.
-- [ ] `cairn/references/INDEX.md` carries exactly one line per committed page
+- [x] `cairn/references/INDEX.md` carries exactly one line per committed page
       and no longer claims references live under `devel/`.
-- [ ] `cairn_validate` reports `references index<->disk` PASS and no
+- [x] `cairn_validate` reports `references index<->disk` PASS and no
       `references staleness` WARN for either page — **and the check is proved
       to have teeth by mutation**: delete one INDEX line, observe FAIL,
       restore, observe PASS.
-- [ ] The three `devel/` transcription files are byte-identical to their
+- [x] The three `devel/` transcription files are byte-identical to their
       pre-milestone state: `git diff --stat devel/` empty.
-- [ ] No file outside `cairn/` is modified, and each written page's tail bytes
+- [x] No file outside `cairn/` is modified, and each written page's tail bytes
       are checked for leaked tool-call scaffolding (`tail -6 f | od -c`, M34).
 
 ## Coverage
@@ -100,3 +100,106 @@ slot is not applicable and AC7 fences that claim instead.
 - **M40-D3 (2026-07-19): the Browne & Cudeck edition mismatch folds into M41's scope, not a candidate row.** `sources/browne1992a.pdf` is the 1992 *Sociological Methods & Research* 21(2), 230–258 article, while `R/ssm_ci_oop.R:415` cites the 1993 Bollen & Long chapter; resolving it edits package code, which M40 excludes. Noted here because Grassi p. 58 cites the **1992** version too, which is evidence toward correcting the shipped citation rather than hunting the chapter.
 
 ## Review
+
+Reviewed 2026-07-19. PR #66. Branch `m40-reference-notes-shelved`, 4 commits,
+diffstat 5 files / +337 −18, all under `cairn/`.
+
+### Acceptance criteria — fresh evidence
+
+- **AC1 (grassi2010.md).** File present; all seven template sections found by
+  grep (heading, Provenance, Citation, Role, Extracted values, Traces to, Open
+  questions); 46 page/table anchor tokens. The [O] diff-bug reviewer
+  independently cross-checked every value against
+  `tests/testthat/helper-cpm-oracles.R` — all seven θ and θ_SE, v and v_SE, z,
+  betas, MCSC, F̂, T/df/p, F₀ and RMSEA with CIs, null χ²/df, TLI/CFI/SRMR, the
+  seven variance ratios, and all seven communality indices and CI pairs
+  re-mapped into Table-1 order — with no disagreement.
+- **AC2 (zimmermann2017.md).** Same seven sections; 48 anchor tokens. Values
+  cross-checked against `devel/m4-zw-transcription.md` by the [O] reviewer with
+  no disagreement, and Eq. A6/A7/Eq. 3 independently recomputed: all eight
+  published constants reproduce; the no-√2 variant misses all three f_a values.
+- **AC3 (Extraction status).** Both statuses are single physical lines — 717
+  and 657 chars, re-measured after the review fixes. Both name a verification
+  and carry `— observed 2026-07-19`; `references staleness` reads them without
+  a WARN.
+- **AC4 (INDEX.md).** Parsed with `cairn_validate`'s own `_INDEX_LINE` regex:
+  entries `['grassi2010.md', 'zimmermann2017.md']` are a bijection with the
+  committed pages on disk. No claim that references live under `devel/`.
+- **AC5 (mutation-proved checks).** Re-run at review, after the fixes: baseline
+  PASS/OK → drop an INDEX entry FAIL → strip a Provenance block FAIL → blank an
+  `Extraction:` status fires the staleness WARN → restored PASS/OK, exit 0. The
+  checks have teeth and the tree restores clean.
+- **AC6 (devel/ untouched).** `git diff origin/master...HEAD -- devel/` empty;
+  `git status --porcelain devel/` clean.
+- **AC7 (scope + tail bytes).** Five changed files, all `cairn/`-prefixed; no
+  leaked tool-call scaffolding in any. Independently reinforced: `R CMD build`
+  produces a 243-entry tarball containing **zero** `cairn/` entries, so the
+  package surface provably cannot see this diff.
+
+### Consistency gate
+
+- `cairn_validate` exit 0, 15/15 PASS. The 47 `work-log format` WARNs are M7's
+  pre-existing hard-wrapped history, unchanged from baseline and unfixable
+  under IP4.
+- `cairn_impact` skipped — `Principles touched: —`, no IP/GP changed.
+- Toolchain half (`r-package` `consistency-gate` slot): **provably vacuous, not
+  assumed.** The diff touches zero files under `R/ src/ man/ NAMESPACE
+  DESCRIPTION data/ data-raw/ tests/ vignettes/ README NEWS.md _pkgdown.yml
+  inst/`, and the built tarball excludes `cairn/` entirely, so
+  `document()`/`check_pkgdown()`/`check()` have nothing to observe.
+
+### Independent review — three lenses + scorer
+
+[O] diff-bug (Opus), [S] blame-history (Sonnet), [S] prior-PR-comments
+(Sonnet), scored by a fresh [S] Sonnet scorer.
+
+- **[S] prior-PR-comments: no findings.** Confirmed clean no-op — every sampled
+  merged PR carries zero review comments; this repo reviews through cairn.
+- **[S] blame-history: no findings.** Independently verified all seven M7
+  findings carry faithfully (A2 block order, A3 page anchor, A4 ρ̂ label, A5
+  ln v_ii symmetry, A6 retraction not reintroduced, the OCPD Prob-not-R²
+  correction, the 75/150 threshold decision), that every `Traces to` line range
+  resolves, that no D-entry is contradicted, and that the old INDEX.md stub
+  lost nothing load-bearing.
+- **[O] diff-bug: 4 findings**, scored 90/88/80/58. Three actioned, one logged
+  below threshold.
+
+**F1 (90) — fixed.** `grassi2010.md` Open questions asserted "Browne (1982) is
+not on the shelf" — false when written: `browne1982_p95a/b.png` and
+`p96a/b.png` landed 16:08:31–16:09:42, and the commit carrying the sentence was
+16:09:40. Rewritten to say the two cited pages are shelved as images, the rest
+of the source is not, and the check is now possible but undone; the correction
+is marked in place. Logged to M41's work log too, since its T5 was scoped
+without knowing the images exist.
+
+**F2 (88) — fixed.** `grassi2010.md`'s status claimed verification "twice and
+independently", but the human channel (M7 AC3) attested the *fixtures*, and
+eight values on the page were never fixtures: a₀ and its SE, the close-fit p,
+NFI, GFI, AGFI, the sample discrepancy, and the 90%-vs-95% CI-level
+distinction. Those rested on the machine channel alone and the page did not say
+so — the exact defect class `zimmermann2017.md` fenced correctly, and a
+violation of M40-D2. Status rewritten to scope the double-verification to
+fixture-shared values; the eight are marked `**[1-channel]**` inline where they
+appear.
+
+**F3 (80) — fixed.** `INDEX.md`'s trailing comment made undated claims about
+the repo's own state while asserting it was "not recording absences". Rewritten:
+the owing-a-page ledger is named as M41's, the list is stamped
+`— observed 2026-07-19` and explicitly labelled a snapshot, and the fact that
+the shelf changed twice mid-milestone (Browne 1982 images, `cudeck1983.pdf`) is
+recorded as the reason not to trust it.
+
+**F4 (58) — below threshold, logged not actioned.** The `grassi2010.md`
+CIRCUM/CircE Open-questions bullet lacks an `— observed` stamp. Real but
+marginal: it is a "discussed elsewhere" pointer, not an availability claim that
+misdirects effort, and the scorer judged it does not carry the staleness risk
+the rule targets.
+
+### Residual concerns carried forward, not blocking
+
+- Eq. A7's √2 radicand and leading ½ still rest on a single human read; the
+  page's Open questions record this and name what would close it.
+- `cudeck1983.pdf` arrived on the shelf unrequested and unassessed — M41 T1
+  decides whether the repo relies on it before it earns a page.
+- The Browne & Cudeck 1992-vs-1993 edition mismatch against
+  `R/ssm_ci_oop.R:415` is M40-D3, folded into M41.

--- a/cairn/milestones/M41-reference-notes-unshelved.md
+++ b/cairn/milestones/M41-reference-notes-unshelved.md
@@ -94,6 +94,7 @@ rather than assuming it.
 
 ## Work log
 
+- 2026-07-19: shelf state moved after this file was written, logged here rather than amending plan-owned Scope/Tasks (that is `/milestone-plan`'s to change at T1's re-scope gate). Two arrivals M41's Scope does not know about: **Browne (1982) pp. 95–96 are now on the shelf as four page images** (`browne1982_p95a/b`, `p96a/b.png`) — not the whole source, but exactly the pages T5's communality-CI derivation needs, so T5 may be partly workable already; and **`cudeck1983.pdf`** appeared, unrequested and unassessed — T1 must decide whether the repo relies on it at all before it earns a page. Found at M40's review by the diff-bug lens, which caught M40 asserting Browne 1982 was absent minutes after three of the four images had landed.
 - 2026-07-19: created by /milestone-plan alongside M40, which carries the two sources already on the shelf. Not workable until M40 is done and the seven PDFs are shelved; T1 gates on their actual presence rather than assuming it, and expects to re-scope at its own plan gate once the real citekeys are known.
 
 ## Decisions

--- a/cairn/references/INDEX.md
+++ b/cairn/references/INDEX.md
@@ -11,10 +11,16 @@ _One line per committed page: `citekey — title — traces to`._
      ("[grassi2010](grassi2010.md)") is silently not counted as a catalog
      entry and the page reads as unindexed. Caught by mutation at M40 T5.
 
-     Sources the repo relies on that have no page yet are tracked as M41
-     tasks, not recorded here as absences: Browne (1992), Acton & Revelle
-     (2004), Cheung & Rensvold (2002), Browne & Cudeck, Wendt et al. (2019),
-     Hu & Bentler (1999), Browne (1982). The gitignored shelf `sources/` holds
-     the PDFs. `sources/acton2002.pdf` is shelved but owes no page — the repo
-     cites Acton & Revelle (2002) only as other authors' citation of prior
-     work, which the "consulted in passing owes nothing" rule excludes. -->
+     Which sources still owe a page is M41's ledger, not this file's: see
+     cairn/milestones/M41-reference-notes-unshelved.md, whose T1 re-inventories
+     the shelf precisely because it is a live directory. As of the M40 merge
+     the sources owing a page were Browne (1992), Acton & Revelle (2004),
+     Cheung & Rensvold (2002), Browne & Cudeck, Wendt et al. (2019),
+     Hu & Bentler (1999) and Browne (1982) — observed 2026-07-19; the shelf
+     changed twice during M40 alone (the Browne 1982 page images and
+     cudeck1983.pdf both arrived mid-session), so treat any list here as a
+     snapshot and re-inventory rather than trusting it.
+     `sources/acton2002.pdf` is shelved but owes no page — the repo cites
+     Acton & Revelle (2002) only as other authors' citation of prior work,
+     which the "consulted in passing owes nothing" rule excludes — observed
+     2026-07-19. -->

--- a/cairn/references/INDEX.md
+++ b/cairn/references/INDEX.md
@@ -1,8 +1,20 @@
 # References index
 
-_One line per source summary: `citekey — title — traces to`._
+_One line per committed page: `citekey — title — traces to`._
 
-<!-- Pre-migration references (published-oracle papers, transcriptions, design
-     briefs) live under devel/ and are cited from cairn/DESIGN.md and the
-     entombed cairn/legacy/. Add cairn-era source summaries here as they are
-     ingested (see tracking-rules "Source ingestion"). -->
+- [grassi2010.md](grassi2010.md) — Grassi, Luccio & Di Blas (2010), *CircE: An R implementation of Browne's circular stochastic process model* — the published CPM oracle; traces to `tests/testthat/helper-cpm-oracles.R` and `tests/testthat/test-cpm_oracles.R`.
+- [zimmermann2017.md](zimmermann2017.md) — Zimmermann & Wright (2017), *Beyond description in interpersonal construct validation* — SSM estimator accuracy and sample-size guidance; traces to `vignettes/evaluating-circumplex-structure.Rmd` and the `jz2017` sample.
+
+<!-- Entry format note: cairn_validate's _INDEX_LINE regex matches the first
+     [\w./-]+\.md token after the bullet, so the link TEXT must be the
+     filename ("[grassi2010.md](grassi2010.md)"). A bare citekey as link text
+     ("[grassi2010](grassi2010.md)") is silently not counted as a catalog
+     entry and the page reads as unindexed. Caught by mutation at M40 T5.
+
+     Sources the repo relies on that have no page yet are tracked as M41
+     tasks, not recorded here as absences: Browne (1992), Acton & Revelle
+     (2004), Cheung & Rensvold (2002), Browne & Cudeck, Wendt et al. (2019),
+     Hu & Bentler (1999), Browne (1982). The gitignored shelf `sources/` holds
+     the PDFs. `sources/acton2002.pdf` is shelved but owes no page — the repo
+     cites Acton & Revelle (2002) only as other authors' citation of prior
+     work, which the "consulted in passing owes nothing" rule excludes. -->

--- a/cairn/references/grassi2010.md
+++ b/cairn/references/grassi2010.md
@@ -4,7 +4,7 @@
 `cairn/references/sources/grassi2010.pdf` (gitignored).
 Pagination: journal pages 55–73; the shelf PDF is 19 pages, so PDF page *n* is
 printed page *n* + 54.
-Extraction: verified 2026-07-19 twice and independently — Jeff's second human re-read against the primary source (M7 AC3 attestation, which confirmed every transcribed value and changed no fixture), and an independent `pdftotext -layout` re-check during M40 that reproduced every value recorded on this page, including the reordered Appendix A communality block and the seventh variance ratio — observed 2026-07-19.
+Extraction: verified 2026-07-19 twice and independently for every value that also appears in the test fixtures — Jeff's second human re-read against the primary source (M7 AC3 attestation, which confirmed every transcribed value and changed no fixture), and an independent `pdftotext -layout` re-check during M40 that reproduced all of them, including the reordered Appendix A communality block and the seventh variance ratio; eight values on this page were never in the fixtures and so rest on the M40 machine channel alone, marked **[1-channel]** where they appear — a₀ and its SE, the close-fit p value, NFI, GFI, AGFI, the sample discrepancy, and the 90%-vs-95% CI-level distinction — observed 2026-07-19.
 
 **Citation.** Grassi, M., Luccio, R., & Di Blas, L. (2010). CircE: An R
 implementation of Browne's circular stochastic process model. *Behavior
@@ -20,7 +20,9 @@ Two confidence levels appear in this source and must not be conflated: the
 **fit-measure** intervals (F₀, RMSEA) are **90%**, printed as
 `Confidence Interval 90 %` in the Appendix A output; the **communality-index**
 intervals are "approximate **95%** one at time confidence intervals" (Appendix
-A header, p. 71).
+A header, p. 71). **[1-channel]** — the fixtures record neither CI level, so
+this distinction was first noted at M40 from the machine channel alone and no
+human read has confirmed it.
 
 ## Extracted values
 
@@ -52,12 +54,13 @@ overlapping subset — F, F₀ and its CI, RMSEA and its CI — but only Appendi
 carries the test statistic, df, p values, null χ², TLI, CFI, and SRMR.
 
 - F̂ = 0.089815 — iteration trace, "final value", p. 70.
-- Sample discrepancy 0.09; F₀ = 0.049, 90% CI (0.005 ; 0.139).
+- Sample discrepancy 0.09 **[1-channel]**; F₀ = 0.049, 90% CI (0.005 ; 0.139).
 - RMSEA = 0.084, 90% CI (0.026 ; 0.141).
 - Test statistic = 15.63; df = 7; p (H₀ perfect fit) = 0.029; p (H₀ close fit,
-  RMSEA = 0.050) = 0.137.
-- Null model χ² = 747.663, df = 21; NFI 0.979; TLI (Tucker–Lewis NNFI) 0.964;
-  CFI 0.988; SRMR 0.04; GFI 0.986; AGFI 0.944.
+  RMSEA = 0.050) = 0.137 **[1-channel]**.
+- Null model χ² = 747.663, df = 21; TLI (Tucker–Lewis NNFI) 0.964; CFI 0.988;
+  SRMR 0.04. Also printed, but fixture-absent: NFI 0.979 **[1-channel]**,
+  GFI 0.986 **[1-channel]**, AGFI 0.944 **[1-channel]**.
 
 ### Full-precision estimates — Appendix A, pp. 71–72
 
@@ -70,7 +73,7 @@ Errors" block:
 - v: 0.15438, 0.51654, 0.03945, 0.63153, 0.54550, 0.13449, 0.44771; SEs
   0.13759, 0.12755, 0.04238, 0.13854, 0.12125, 0.05959, 0.13865.
 - z: 0.91358, 0.81222, 1.00102, 0.79058, 0.79269, 0.92497, 0.84376.
-- a₀ = 1.76119 (SE 0.26287); betas b₀ = 0.6378, b₁ = 0.3622.
+- a₀ = 1.76119 (SE 0.26287) **[1-channel]**; betas b₀ = 0.6378, b₁ = 0.3622.
 - MCSC, correlation at 180 degrees = 0.276.
 - Ratios of reproduced to input variances: 0.963, 1.000, 1.042, 1.020, 0.971,
   0.971, 1.031. These are not 1, which is the CIRCUM/CircE free-scaling
@@ -128,10 +131,14 @@ Used for input-refusal behavior only; no numeric result depends on it.
 
 ## Open questions
 
-- Browne (1982) is not on the shelf, so the communality-CI derivation cited at
-  pp. 95–96 above is recorded here as this paper reports it and is not
-  independently checked against Browne — observed 2026-07-19. M41 T5 carries
-  that source.
+- The communality-CI derivation attributed to Browne (1982, pp. 95–96) is
+  recorded here as *this* paper reports it, and has not been checked against
+  Browne himself. Those two pages are on the shelf as images
+  (`sources/browne1982_p95a.png`, `p95b`, `p96a`, `p96b`), added mid-session
+  on 2026-07-19; the rest of Browne (1982) is not — so the check is now
+  possible but has not been done. M41 T5 carries it — observed 2026-07-19,
+  re-checked at merge (an earlier form of this bullet said the pages were
+  absent, which was already false when written).
 - The CIRCUM/CircE free-scaling model difference (why our F̂ exceeds their
   published 0.089815 at finite N) is analysed in
   `tests/testthat/test-cpm_oracles.R:30-47` and `devel/m4-browne-design.md`

--- a/cairn/references/grassi2010.md
+++ b/cairn/references/grassi2010.md
@@ -1,0 +1,139 @@
+# grassi2010 — the published CPM oracle: CircE's worked vocational-interest example
+
+**Provenance.** Ingested 2026-07-19 by M40 from
+`cairn/references/sources/grassi2010.pdf` (gitignored).
+Pagination: journal pages 55–73; the shelf PDF is 19 pages, so PDF page *n* is
+printed page *n* + 54.
+Extraction: verified 2026-07-19 twice and independently — Jeff's second human re-read against the primary source (M7 AC3 attestation, which confirmed every transcribed value and changed no fixture), and an independent `pdftotext -layout` re-check during M40 that reproduced every value recorded on this page, including the reordered Appendix A communality block and the seventh variance ratio — observed 2026-07-19.
+
+**Citation.** Grassi, M., Luccio, R., & Di Blas, L. (2010). CircE: An R
+implementation of Browne's circular stochastic process model. *Behavior
+Research Methods, 42*(1), 55–73. doi:10.3758/BRM.42.1.55
+
+**Role.** The package's published-value oracle (O2) for the Circular Process
+Model engine. The paper states its example reanalyzes the data Browne (1992,
+Table 2) used, and that CircE's m = 1..3 results "coincide precisely with the
+ones obtained by CIRCUM" (p. 59), so these values transitively cover Browne's
+own program (oracle O1) as well.
+
+Two confidence levels appear in this source and must not be conflated: the
+**fit-measure** intervals (F₀, RMSEA) are **90%**, printed as
+`Confidence Interval 90 %` in the Appendix A output; the **communality-index**
+intervals are "approximate **95%** one at time confidence intervals" (Appendix
+A header, p. 71).
+
+## Extracted values
+
+### Vocational interest scales — input
+
+- Correlation matrix, 7 scales, all 21 off-diagonal values — Table 1, p. 58;
+  reprinted as the "Sample Correlation Matrix" block, Appendix A p. 72, and as
+  Listing 1, p. 58. Variable order: Health, Science, Technology, Trades,
+  Business operations, Business contact, Social.
+- N = 175 — Table 1 header, p. 58.
+
+### Unconstrained model 1a, m = 1 — Table 2, p. 60
+
+- β₀ = .638, β₁ = .362; ρ₁₈₀° = .28; polar angles 0, 55, 112, 123, 192, 210,
+  269 (whole degrees).
+- Communality indices .93, .81, .98, .78, .80, .94, .83.
+- **The Table 2/3 communality column is ρ̂, the communality index (Browne,
+  1992, Eq. 4) — not ζ.** The table's own footnote reads "Communality indices
+  ρᵢ, polar angles θᵢ, and minimal common score correlation ρ₁₈₀° are
+  unconstrained." (Corrected at M7 T3, finding A4; the repo's assertions were
+  already right — only the label was wrong.)
+- Table 2's angles are the **mirror** of Appendix A's: the paper prints both
+  directions, as its "360-ang. pos." column (p. 71) shows.
+
+### Unconstrained m = 1 fit measures — Appendix A, pp. 70–71
+
+**Not Table 3** (corrected at M7 T3, finding A3). Table 3, p. 60 prints an
+overlapping subset — F, F₀ and its CI, RMSEA and its CI — but only Appendix A
+carries the test statistic, df, p values, null χ², TLI, CFI, and SRMR.
+
+- F̂ = 0.089815 — iteration trace, "final value", p. 70.
+- Sample discrepancy 0.09; F₀ = 0.049, 90% CI (0.005 ; 0.139).
+- RMSEA = 0.084, 90% CI (0.026 ; 0.141).
+- Test statistic = 15.63; df = 7; p (H₀ perfect fit) = 0.029; p (H₀ close fit,
+  RMSEA = 0.050) = 0.137.
+- Null model χ² = 747.663, df = 21; NFI 0.979; TLI (Tucker–Lewis NNFI) 0.964;
+  CFI 0.988; SRMR 0.04; GFI 0.986; AGFI 0.944.
+
+### Full-precision estimates — Appendix A, pp. 71–72
+
+Printed in Table-1 variable order in the "Parameter estimates and Standard
+Errors" block:
+
+- Polar angles: 0.00000, 305.35328, 247.82980, 237.38218, 168.30615,
+  149.83787, 91.25973; SEs 0.00000, 9.01111, 7.35838, 9.44904, 9.08050,
+  7.95016, 8.72929.
+- v: 0.15438, 0.51654, 0.03945, 0.63153, 0.54550, 0.13449, 0.44771; SEs
+  0.13759, 0.12755, 0.04238, 0.13854, 0.12125, 0.05959, 0.13865.
+- z: 0.91358, 0.81222, 1.00102, 0.79058, 0.79269, 0.92497, 0.84376.
+- a₀ = 1.76119 (SE 0.26287); betas b₀ = 0.6378, b₁ = 0.3622.
+- MCSC, correlation at 180 degrees = 0.276.
+- Ratios of reproduced to input variances: 0.963, 1.000, 1.042, 1.020, 0.971,
+  0.971, 1.031. These are not 1, which is the CIRCUM/CircE free-scaling
+  signature — their fitted diagonal is not constrained to the observed unit
+  diagonal.
+
+### Communality indices with CIs — Appendix A, p. 71
+
+**This block is reordered.** Its header states: "Note: variable names have been
+reordered to yield increasing polar angles", and it prints in the order
+Health, Social, Business Contact, Business Operations, Trades, Technology,
+Science — *not* Table 1's order. A value read off the page must be re-mapped
+by scale before comparison. (M7 T3 finding A2: the flat row order invited a
+false mismatch; re-mapped by scale, every index and CI agrees exactly.)
+
+Re-mapped into Table-1 order, with their approximate 95% one-at-a-time CIs:
+
+| Scale | ρ̂ | 95% CI |
+|---|---|---|
+| Health | 0.93 | (0.73, 0.99) |
+| Science | 0.81 | (0.74, 0.87) |
+| Technology | 0.98 | (0.87, 1) |
+| Trades | 0.78 | (0.71, 0.84) |
+| Business Operations | 0.80 | (0.74, 0.86) |
+| Business Contact | 0.94 | (0.87, 0.97) |
+| Social | 0.83 | (0.74, 0.90) |
+
+The nonsymmetric CIs on ρ(xᵢ, cᵢ) are obtained from **symmetric** CIs on
+ln vᵢᵢ (Browne, 1982, pp. 95–96) — the symmetry belongs to the log-v scale,
+not to the communality CIs themselves (M7 T3 finding A5).
+
+### Verbal ability tests — Listing 7, p. 68
+
+Used for input-refusal behavior only; no numeric result depends on it.
+
+- 6 scales: Spelling, Punctuation, Grammar, Vocabulary, Literature, **Foreign
+  Literature** — printed exactly so on p. 68. (M7 T3 raised finding A6
+  claiming "Foreign Language" and **retracted it the same day**; the M40
+  re-read confirms the retraction was correct.)
+- All 15 off-diagonal correlations; N = 1046 (Listing 8, p. 68).
+- The source also attributes this matrix to Guttman (1954, p. 282) and Browne
+  (1992, p. 470).
+
+## Traces to
+
+- `tests/testthat/helper-cpm-oracles.R:13-31` — `cpm_oracle_voc()`: the Table 1
+  matrix, N, and the Table 2 model 1a start angles.
+- `tests/testthat/helper-cpm-oracles.R:39-62` — `cpm_oracle_voc_appendix()`:
+  every Appendix A full-precision estimate, fit measure, communality index and
+  CI, and the variance ratios.
+- `tests/testthat/helper-cpm-oracles.R:66-79` — `cpm_oracle_verbal()`: the
+  Listing 7 matrix and N.
+- `tests/testthat/test-cpm_oracles.R:1-47` — the validation battery and its
+  published-oracle provenance header.
+
+## Open questions
+
+- Browne (1982) is not on the shelf, so the communality-CI derivation cited at
+  pp. 95–96 above is recorded here as this paper reports it and is not
+  independently checked against Browne — observed 2026-07-19. M41 T5 carries
+  that source.
+- The CIRCUM/CircE free-scaling model difference (why our F̂ exceeds their
+  published 0.089815 at finite N) is analysed in
+  `tests/testthat/test-cpm_oracles.R:30-47` and `devel/m4-browne-design.md`
+  sec. 11, not here — this page records what the paper prints, not the
+  reconciliation.

--- a/cairn/references/zimmermann2017.md
+++ b/cairn/references/zimmermann2017.md
@@ -1,0 +1,161 @@
+# zimmermann2017 — SSM estimator accuracy: the vignette's sample-size guidance
+
+**Provenance.** Ingested 2026-07-19 by M40 from
+`cairn/references/sources/zimmermann2017.pdf` (gitignored).
+Pagination: SAGE OnlineFirst pages 1–21 (the shelf PDF is 21 pages, so PDF
+page *n* is printed page *n*); the journal's own pagination is *Assessment,
+24*(1), 3–23.
+Extraction: verified 2026-07-19 against the primary source by Jeff's complete second human re-read (M7 AC3, which found no value in the record wrong), and independently re-checked during M40 by `pdftotext -layout` across the Note 3 matrices, both Table 4 rows and Table 4's own note, the Study 2 thresholds, the Study 5 fit indices and IIP-SC parameters, and all eight published constants that Eq. A6/A7/Eq. 3 derive; three items lie outside a text layer's reach and rest on the human read alone — Figure 1A's octant angles, Figure 5's panel readings, and Eq. A7's √2 radicand and leading ½, which the text layer silently drops — observed 2026-07-19.
+
+**Citation.** Zimmermann, J., & Wright, A. G. C. (2017). Beyond description in
+interpersonal construct validation: Methodological advances in the circumplex
+Structural Summary Approach. *Assessment, 24*(1), 3–23.
+doi:10.1177/1073191115621795
+
+**Role.** The source of the package's sample-size and CI-accuracy guidance —
+`vignettes/evaluating-circumplex-structure.Rmd` ships an accuracy table and
+prose bullets drawn from Studies 1–3, and `jz2017` is this paper's Study 5
+sample. It is also the basis of `ssm_ci_accuracy()`'s framing.
+
+**Scope warning carried from M7 T3.** Every threshold below is about
+**95% percentile bootstrap CI coverage accuracy** — not point estimates, and
+not CIs generally. The vignette's accuracy-table header was rescoped at M7 to
+say *bootstrap* CI for exactly this reason.
+
+## Extracted values
+
+### Population octant matrices — Note 3, p. 18
+
+Model-based ("reproduced") correlations from SEM analyses of real instruments.
+
+- **Without** a substantial general factor (IAS, 2,988 students; Gurtman &
+  Pincus, 2000; Wiggins, 1995): ρ₁ = .430, ρ₂ = .030, ρ₃ = −.360, ρ₄ = −.740.
+- **With** a substantial general factor (IIP-C, 1,981 students; Gurtman &
+  Balakrishnan, 1998): ρ₁ = .683, ρ₂ = .500, ρ₃ = .345, ρ₄ = .288.
+
+### Scaling factors — Appendix, p. 18
+
+- Eq. A6: f_e = √((2ρ₁ + 2ρ₂ + 2ρ₃ + ρ₄ + 1) / 8)
+- Eq. A7: f_a = ½ · √(√2(ρ₁ − ρ₃) + (1 − ρ₄))
+
+**Eq. A7's text layer is corrupt** — `pdftotext` renders the radicand as
+`2(ρ1−ρ3)+(1−ρ4)`, dropping both the √2 and the leading ½. The M40 re-check
+reproduced this artifact, so the machine channel cannot confirm the equation's
+form; it rests on Jeff's 2026-07-19 page read, which confirmed both.
+
+Published values the equations must reproduce: f_e = .737 (IIP-C) and .240
+(IAS), both p. 9; f_a = .545 (IIP-C) and .845 (IAS), p. 9; f_a = .625
+(IIP-SC), p. 14.
+
+- Eq. 3, p. 12: |AFF_min| = 2.95 · f_a · n^(−0.587) (log-log r = −.994).
+
+**Numeric consistency check (M40, reproduced independently):** the transcribed
+ρ matrices with Eq. A6/A7/Eq. 3 give f_e = .7369 / .2398, f_a = .5454 / .8452
+/ .6246, and Eq. 3 values .1077, .0279, .0292 — matching all eight published
+constants; the no-√2 variant gives .5891 / .9110 / .6749 and misses every one.
+**This is a consistency check, not an independent oracle** — the ρ values and
+the equations come from the same transcription pass, so compensating errors
+would still close it.
+
+### Study 2 — bootstrap CI coverage thresholds, pp. 9–11
+
+95% percentile bootstrap CIs from 2,000 replicates; accuracy = empirical
+coverage inside Bradley's (1978) liberal criterion [92.5%, 97.5%].
+
+- Elevation, affiliation, dominance: accurate from **n ≥ 50**.
+- Amplitude: accurate from **n ≥ 75 with** a general factor, **n ≥ 150
+  without**.
+- Angular displacement: accurate from **n ≥ 100 with** a general factor,
+  **n > 200 without**.
+- Goodness of fit: coverage 0 when R² = 1 (boundary); accurate only when
+  population R² < .9 — the bootstrap "seems unsuited" for goodness-of-fit CIs
+  (p. 11).
+- All amplitude/displacement recommendations presume A ≥ .1 (Discussion,
+  p. 10).
+
+**The paper states these thresholds twice, with different numbers.** Study 2
+*Results* (p. 10) gives amplitude 75/150 and displacement 100/200; the Study 2
+*Discussion*, same page, summarizes **both** parameters together as 100/200.
+Figure 5 (p. 12) supports the Results, so the Discussion's figure is
+displacement's thresholds applied to both — a conservative simplification, not
+a competing measurement. The vignette follows the Results (75/150), a choice
+ratified at M7 T3 rather than left implicit. The Figure 5 reading is Jeff's;
+no per-condition deviances were published against which to check it.
+
+### Study 3 — the accuracy frontier, pp. 11–13
+
+Interpret a/δ CIs only when the "probability of accurate CIs" is ≥ .50; fully
+trustworthy ≥ .95 (pp. 12–13, 16).
+
+### Study 5 — real data, pp. 13–16
+
+- N = 1,166 undergraduates; IIP-SC octants, PDQ-4+ PD scales as targets.
+- IIP-SC CircE fit: equal spacing + equal communality rejected — CFI = .824,
+  TLI = .795, RMSEA = .169; unequal spacing acceptable — CFI = .958,
+  TLI = .931, RMSEA = .098 (p. 14).
+- Model-based IIP-SC parameters: ρ₁ = .580, ρ₂ = .323, ρ₃ = .134, ρ₄ = .070
+  → f_a = .625; at N = 1,166, AFF or DOM > |.029| suffices (p. 14).
+
+**Table 4, p. 15** — the two rows the vignette uses:
+
+| PD scale | e | aff | dom | a | δ | R² | Prob |
+|---|---|---|---|---|---|---|---|
+| Paranoid | .250 [.218, .280] | −.094 [−.129, −.060] | .117 [.080, .152] | .150 [.115, .189] | 128.9° [116.7°, 141.6°] | .802 | 1 |
+| Obsessive–compulsive | .228 [.193, .261] | .011 [−.021, .041] | −.005 [−.038, .032] | .012 | 337.4° | .117 | .130 |
+
+OCPD's amplitude and displacement CIs are **not printed**, and this is the
+authors' deliberate omission. Table 4's own note reads: "Prob = probability of
+accurate confidence intervals for amplitude and angular displacement" — the
+two parameters withheld — and the authors' rule is not to interpret a/δ CIs
+when that estimate is < .50 (pp. 12–13, 16). **The trigger is the low
+Prob (.130), not the low R² (.117)**; R² is a separate quantity and governs
+nothing about which intervals print. (M7 T3 first recorded R² here and
+corrected it the same day; the M40 re-check confirms the correction against
+Table 4's note.)
+
+### Study 1 — bias, pp. 6–9
+
+- Bias in e/dom/aff very small (average −.0007, most extreme −.013).
+- Amplitude bias substantial and consistently positive: average relative bias
+  **15.5%**, range 0–135.8%; at n = 50 without a general factor, E(â) = .153
+  when A = 0 (p. 6).
+- Displacement bias trivial (avg −.03°); goodness of fit underestimated
+  (avg −.081, relative −9.5%).
+
+**The value 15.5% appears twice in this paper for two different quantities** —
+Study 1's average relative amplitude bias (p. 6) and Study 4's mean deviance
+when AFF₂ = 0 (p. 13). Confirmed a genuine coincidence, not a paste error.
+
+### Octant angles — Figure 1A, p. 3
+
+LM = 0°, NO = 45°, PA = 90°, BC = 135°, DE = 180°, FG = 225°, HI = 270°,
+JK = 315°. Figure content: not text-layer accessible, so this rests on Jeff's
+read (M7 T3 section B5), not the M40 machine channel.
+
+## Traces to
+
+- `vignettes/evaluating-circumplex-structure.Rmd:190-199` — the accuracy table
+  (its header rescoped to "95% bootstrap CI accurate when…" at M7 T3).
+- `vignettes/evaluating-circumplex-structure.Rmd:203-222` — prose bullets
+  carrying six shipped numbers, including one of the two 15.5% values.
+- `vignettes/evaluating-circumplex-structure.Rmd:237-238` — OCPD's amplitude
+  .012 as the cautionary near-flat case.
+- `vignettes/evaluating-circumplex-structure.Rmd:151-157,572-573` — Study 5
+  CircE fit indices; PARPD elevation .250.
+- `devel/m4-zw-transcription.md` — the M4/W1 transcription record this page
+  supersedes as the citable source; it retains the two-channel protocol
+  history and the O5 bridge re-scope, which this page does not restate.
+- `devel/m4-zw-bridge.R` — the seeded O5 bridge run built on these anchors.
+
+## Open questions
+
+- The article has **no supplemental materials** (Europe PMC PMID 26685192
+  records `hasSuppl: no`; the SAGE endpoint returns none), so per-condition
+  coverage values were never published — the published record is aggregate
+  mean absolute deviances, Bradley-band classifications, threshold statements,
+  and the Eq. 3 frontier. Any oracle wanting per-condition coverage must
+  reconstruct it, not look it up — observed 2026-07-19.
+- Eq. A7's form has never been confirmed by two *independent* channels: the
+  text layer is corrupt, and the numeric cross-check shares a transcription
+  pass with the values it checks. A second human read, or a clean text layer
+  from a different rendering of the PDF, would close it — observed 2026-07-19.


### PR DESCRIPTION
Retires the pre-migration deferral in `cairn/references/INDEX.md` by authoring committed source notes for the two primary sources already on the shelf.

## What this does

- `cairn/references/grassi2010.md` — the published CPM oracle (Grassi, Luccio & Di Blas 2010). Every value the test fixtures use, page/table anchored.
- `cairn/references/zimmermann2017.md` — SSM estimator accuracy behind the vignette's sample-size guidance (Zimmermann & Wright 2017).
- `cairn/references/INDEX.md` — rewritten; one line per committed page, deferral comment gone.

Docs-only: no package file is touched, and the three `devel/` transcription files are byte-identical (M7's open work log cites them by name).

## Verification

Both pages were independently re-checked against the shelf PDFs rather than carried from the existing transcriptions on trust. Every Grassi fixture value reproduced; for Zimmermann & Wright, Note 3, both Table 4 rows, the Study 2 thresholds, the Study 5 indices, and all eight constants the scaling equations derive reproduced.

Two facts no prior record held: Grassi's Appendix A uses **90%** CIs for fit measures but **95%** for communality indices; and Eq. A7 rests on a single channel — `pdftotext` drops its √2 radicand and leading ½ — which the page records rather than papering over.

`cairn_validate` 15/15 PASS. The references checks were mutation-proved: dropping an INDEX entry FAILs, stripping a Provenance block FAILs, blanking an `Extraction:` status fires the staleness WARN, and all restore clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)