### PR TITLE
M45: Source notes for the RANDALL structure test pair

### DIFF
--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38 | high | milestones/M7-v2-release-prep.md |
-| M45 | Source notes for the RANDALL structure test pair | planned | M40 | normal | milestones/M45-reference-notes-randall.md |
+| M45 | Source notes for the RANDALL structure test pair | in-progress | M40 | normal | milestones/M45-reference-notes-randall.md |
 | M46 | Prospect notes for the four forward-looking shelf sources | planned | — | normal | milestones/M46-prospect-notes-forward-sources.md |
 | M44 | LESSONS.md consolidation and retirement pass | dropped | — | normal | milestones/archive/M44-lessons-consolidation.md |
 | M40 | Source notes for the two shelved primary sources | done | — | normal | milestones/archive/M40-reference-notes-shelved.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38 | high | milestones/M7-v2-release-prep.md |
-| M45 | Source notes for the RANDALL structure test pair | in-progress | M40 | normal | milestones/M45-reference-notes-randall.md |
+| M45 | Source notes for the RANDALL structure test pair | review | M40 | normal | milestones/M45-reference-notes-randall.md |
 | M46 | Prospect notes for the four forward-looking shelf sources | planned | — | normal | milestones/M46-prospect-notes-forward-sources.md |
 | M44 | LESSONS.md consolidation and retirement pass | dropped | — | normal | milestones/archive/M44-lessons-consolidation.md |
 | M40 | Source notes for the two shelved primary sources | done | — | normal | milestones/archive/M40-reference-notes-shelved.md |

--- a/cairn/milestones/M45-reference-notes-randall.md
+++ b/cairn/milestones/M45-reference-notes-randall.md
@@ -1,6 +1,6 @@
 # M45: Source notes for the RANDALL structure test pair
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** M40
 - **Driving RR:** —
@@ -84,14 +84,13 @@ open question.
       (probe display equations so the probe sees what it checks — M43 lesson).
 - [x] T4 — Add both `INDEX.md` entries (filename link text); retire the RANDALL
       owes-a-page ledger note.
-- [ ] T5 — Fix the miscount comment at `test-fit_structure_api.R:2`; run the
+- [x] T5 — Fix the miscount comment at `test-fit_structure_api.R:2`; run the
       `fit_structure` test files under `NOT_CRAN=true` to confirm green.
-- [ ] T6 — Run `cairn_budget` + `cairn_validate`; commit.
+- [x] T6 — Run `cairn_budget` + `cairn_validate`; commit.
 
 ## Work log
 
-- 2026-07-20: created by /milestone-plan (promotes the RANDALL ROADMAP
-  candidate; both PDFs now shelved).
+- 2026-07-20: created by /milestone-plan (promotes the RANDALL ROADMAP candidate; both PDFs now shelved).
 - 2026-07-20: T1 — authored `hubert1987.md`. Both PDFs are OCR scans (ABBYY / Acrobat Paper Capture), so text layer ≠ independent witness; verified Eqs. 3/5, the exact and (M+1)/(N+1) p-values, and worked values against `pdftoppm` images of pp. 176–177. Code faithfully implements Eq. 3 at T=0 and the paper's own (M+1)/(N+1); departures banked: strict-`>` scores ties as disagreements (immaterial for continuous r), exact-enum cutoff nv≤9 vs paper's n≤8.
 - 2026-07-20: T2/T3 — authored `tracey1997.md` (CI = (A−D)/(A+D+T); exact-only, no MC; 4/6/8-var program). Reconciled both notes against the code and cross-checked on Tracey's Table 1 matrix under `load_all()`: `randall_predictions(6)` gives exactly 72 predictions; the code reproduces A=69/D=2/T=1 and returns .9167 vs Tracey's CI .93 — the banked tie departure, empirically confirmed. See M45-D1.
 - 2026-07-20: T4 — INDEX.md gains both entries (filename link text) and the RANDALL owes-a-page ledger note is retired; added D-023 forward-looking-sources note. Parser fix (M40 family): `cairn_validate`'s staleness check reads the Extraction block only to the next line STARTING with `**`, so a `**verified <date>**` at a physical line-start truncated tracey's status → "unrecognized"; un-bolded the verified-date phrase in BOTH notes so a reflow can't re-break it. Both now parse `('ok', 2026-07-20)`.

--- a/cairn/milestones/M45-reference-notes-randall.md
+++ b/cairn/milestones/M45-reference-notes-randall.md
@@ -94,6 +94,7 @@ open question.
 - 2026-07-20: T1 — authored `hubert1987.md`. Both PDFs are OCR scans (ABBYY / Acrobat Paper Capture), so text layer ≠ independent witness; verified Eqs. 3/5, the exact and (M+1)/(N+1) p-values, and worked values against `pdftoppm` images of pp. 176–177. Code faithfully implements Eq. 3 at T=0 and the paper's own (M+1)/(N+1); departures banked: strict-`>` scores ties as disagreements (immaterial for continuous r), exact-enum cutoff nv≤9 vs paper's n≤8.
 - 2026-07-20: T2/T3 — authored `tracey1997.md` (CI = (A−D)/(A+D+T); exact-only, no MC; 4/6/8-var program). Reconciled both notes against the code and cross-checked on Tracey's Table 1 matrix under `load_all()`: `randall_predictions(6)` gives exactly 72 predictions; the code reproduces A=69/D=2/T=1 and returns .9167 vs Tracey's CI .93 — the banked tie departure, empirically confirmed. See M45-D1.
 - 2026-07-20: T4 — INDEX.md gains both entries (filename link text) and the RANDALL owes-a-page ledger note is retired; added D-023 forward-looking-sources note. Parser fix (M40 family): `cairn_validate`'s staleness check reads the Extraction block only to the next line STARTING with `**`, so a `**verified <date>**` at a physical line-start truncated tracey's status → "unrecognized"; un-bolded the verified-date phrase in BOTH notes so a reflow can't re-break it. Both now parse `('ok', 2026-07-20)`.
+- 2026-07-20: review — draft PR #71; `check(--no-manual)` 0/0/0; three lenses + scorer. Three findings F1=90/F2=88/F3=83, all fixed: F1/F2 were M40-D2 Extraction over-claims (page ranges named images that didn't cover p.175/p.166) — re-rendered and verified those pages, corrected ranges, and recorded a Tracey printed slip (".0167 (1/720)"; .0167=1/60) the re-render surfaced; F3 corrected a "switches to sampled" imprecision (code errors for nv>9 unless n_perm given). Blame-history clean; no GitHub review threads.
 
 ## Decisions
 
@@ -117,11 +118,12 @@ one test comment).
 
 ### Acceptance criteria — fresh evidence
 
-- [x] AC1 — `hubert1987.md` (117 lines): banks the Eq. 3/5 normalized index,
-  the exact p-value (p. 175), and the (M+1)/(N+1) MC form (p. 177), each
-  page-anchored; `Extraction:` status records the OCR-scan single-witness
-  honestly (verified 2026-07-20 against `pdftoppm` images of pp. 176–177, no
-  human read — M40-D2); `## Traces to` present.
+- [x] AC1 — `hubert1987.md`: banks the Eq. 3/5 normalized index, the exact
+  p-value (p. 175), and the (M+1)/(N+1) MC form (p. 177), each page-anchored;
+  `Extraction:` status records the OCR-scan single-witness honestly (verified
+  2026-07-20 against `pdftoppm` images of pp. 175–177 — the full span its
+  anchors cite, corrected from pp. 176–177 per review F1 — no human read,
+  M40-D2); `## Traces to` present.
 - [x] AC2 — `tracey1997.md` (89 lines): banks CI = (A−D)/(A+D+T), exact-only
   enumeration, the 4/6/8-var program scope, page-anchored pp. 165–167; honest
   `Extraction:` status; `## Traces to` present.
@@ -147,10 +149,42 @@ one test comment).
 - `cairn_validate`: all checks passed (exit 0). Coverage completeness: pass.
 - Profile (`r-package`) consistency-gate: `devtools::document()` no diff; no
   `man/`/`NAMESPACE`/`R/` generated-file drift; no new top-level files; README
-  and pkgdown unaffected (no export surface change). `devtools::check(--no-manual)`:
-  _pending — recorded below._
+  and pkgdown unaffected (no export surface change).
+  **`devtools::check(--no-manual)`: 0 errors / 0 warnings / 0 notes ✔ (exit 0).**
 - `cairn_impact`: N/A (Principles touched: —; no DESIGN.md principle changed).
 
 ### Independent review (three lenses + scorer)
 
-_pending._
+Three fresh-context lenses in parallel — [O] diff-bug (Opus), [S] blame-history
+(Sonnet), [S] prior-review (Sonnet) — then a [S] scorer. Blame-history: clean
+(M40 INDEX-parser rule and the other sources' owes-no-page dispositions intact;
+test-comment fix aligns with `man/fit_structure.Rd`). Prior-review confirmed no
+GitHub review threads (`pulls/comments` → `[]`). Three findings survived the
+taxonomy; scorer F1=90, F2=88, F3=83 — **all ≥ 80, all fixed now:**
+
+- **F1 (90) — `hubert1987.md` Extraction over-claim (M40-D2 regression).** The
+  status claimed pp. 176–177 image-verification but the exact p-value and the
+  reference-set symmetry are on **p. 175**, outside that range — so they rested
+  on OCR alone. **Fixed:** rendered p. 175, verified those values against the
+  image (exact-p-value quote, `12/720 = 1/60 = .02`, `5!/2 = 60` symmetry, Table
+  2), and corrected the range to pp. 175–177.
+- **F2 (88) — `tracey1997.md` Extraction over-claim (same class).** The status
+  claimed p. 165 but `p = .0167` is on **p. 166**. **Fixed:** rendered p. 166,
+  corrected the range to pp. 165–166. Verifying the image also surfaced a
+  **printed slip** in Tracey — it prints "p = .0167 (1/720)", but .0167 = 1/60
+  (12/720, the symmetric ties), not 1/720 (= .0014); recorded as an erratum with
+  the H&A Table 2 cross-check. Neither review lens had the image; the honest
+  re-render caught it.
+- **F3 (83) — `tracey1997.md` "Scope generalized" imprecision.** "switches to
+  the sampled p-value beyond" was wrong — the code errors for `nv > 9` unless
+  `n_perm` is supplied, and the sampled path runs whenever `n_perm` is given at
+  any `nv`. **Fixed** to match the companion `hubert1987.md`.
+
+Re-verified after fixes: both Extraction statuses parse `('ok', 2026-07-20)`;
+`cairn_validate` all-pass; `check(--no-manual)` re-confirmed 0/0/0 (docs-only
+edits, no package file touched by the fixes).
+
+**Carried to merge (prior-review lower-confidence note):** the INDEX "every
+relied-upon source has a page" completeness claim is re-verified against the
+**live** shelf at merge, per the M40 "the shelf is LIVE — re-check absence at
+merge" lesson.

--- a/cairn/milestones/M45-reference-notes-randall.md
+++ b/cairn/milestones/M45-reference-notes-randall.md
@@ -72,7 +72,7 @@ open question.
 
 ## Tasks
 
-- [ ] T1 — Check `pdfinfo` Producer on `hubert1987.pdf`; extract the
+- [x] T1 — Check `pdfinfo` Producer on `hubert1987.pdf`; extract the
       order-agreement statistic and randomization p-value via the independent
       channels that exist; author `hubert1987.md` (banked definitions, page
       anchors, `Traces to`, `Extraction:` status).
@@ -92,6 +92,7 @@ open question.
 
 - 2026-07-20: created by /milestone-plan (promotes the RANDALL ROADMAP
   candidate; both PDFs now shelved).
+- 2026-07-20: T1 — authored `hubert1987.md`. Both PDFs are OCR scans (ABBYY / Acrobat Paper Capture), so text layer ≠ independent witness; verified Eqs. 3/5, the exact and (M+1)/(N+1) p-values, and worked values against `pdftoppm` images of pp. 176–177. Code faithfully implements Eq. 3 at T=0 and the paper's own (M+1)/(N+1); departures banked: strict-`>` scores ties as disagreements (immaterial for continuous r), exact-enum cutoff nv≤9 vs paper's n≤8.
 
 ## Decisions
 

--- a/cairn/milestones/M45-reference-notes-randall.md
+++ b/cairn/milestones/M45-reference-notes-randall.md
@@ -76,9 +76,9 @@ open question.
       order-agreement statistic and randomization p-value via the independent
       channels that exist; author `hubert1987.md` (banked definitions, page
       anchors, `Traces to`, `Extraction:` status).
-- [ ] T2 — Same for `tracey1997.pdf`; author `tracey1997.md` (RANDALL
+- [x] T2 — Same for `tracey1997.pdf`; author `tracey1997.md` (RANDALL
       operationalization: exact vs. random relabeling, circumplex use).
-- [ ] T3 — Reconcile both notes against `R/fit_structure.R`
+- [x] T3 — Reconcile both notes against `R/fit_structure.R`
       (`randall_predictions()` / `structure_randall()` ~585–591 /
       `structure_randall_test()` ~647–701); record any departure verbatim
       (probe display equations so the probe sees what it checks — M43 lesson).
@@ -93,7 +93,20 @@ open question.
 - 2026-07-20: created by /milestone-plan (promotes the RANDALL ROADMAP
   candidate; both PDFs now shelved).
 - 2026-07-20: T1 — authored `hubert1987.md`. Both PDFs are OCR scans (ABBYY / Acrobat Paper Capture), so text layer ≠ independent witness; verified Eqs. 3/5, the exact and (M+1)/(N+1) p-values, and worked values against `pdftoppm` images of pp. 176–177. Code faithfully implements Eq. 3 at T=0 and the paper's own (M+1)/(N+1); departures banked: strict-`>` scores ties as disagreements (immaterial for continuous r), exact-enum cutoff nv≤9 vs paper's n≤8.
+- 2026-07-20: T2/T3 — authored `tracey1997.md` (CI = (A−D)/(A+D+T); exact-only, no MC; 4/6/8-var program). Reconciled both notes against the code and cross-checked on Tracey's Table 1 matrix under `load_all()`: `randall_predictions(6)` gives exactly 72 predictions; the code reproduces A=69/D=2/T=1 and returns .9167 vs Tracey's CI .93 — the banked tie departure, empirically confirmed. See M45-D1.
 
 ## Decisions
+
+- **M45-D1 (2026-07-20): `structure_randall()`'s tie handling differs from
+  Tracey's CI; left unchanged (out of scope, immaterial for continuous r).**
+  Verified empirically on Tracey (1997) Table 1 under `load_all()`: the code
+  returns .9167 where Tracey's RANDALL reports CI .93 — A=69, D=2, T=1, N=72 —
+  because the strict `>` scores the one tie as a disagreement, so
+  code = `(A−D−T)/N` vs Tracey/H&A Eq. 3 = `(A−D)/N`. Banked in `hubert1987.md`
+  and `tracey1997.md`. Not changed here: a statistical-output change is outside
+  M45's docs scope, and exact correlation ties are measure-zero, so no real
+  `fit_structure()` input triggers it. If ever aligned, it needs its own
+  regression test and the note that it would move a published example's value
+  (.92 → .93).
 
 ## Review

--- a/cairn/milestones/M45-reference-notes-randall.md
+++ b/cairn/milestones/M45-reference-notes-randall.md
@@ -1,11 +1,11 @@
 # M45: Source notes for the RANDALL structure test pair
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** M40
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** m45-reference-notes-randall
 
 ## Goal
 

--- a/cairn/milestones/M45-reference-notes-randall.md
+++ b/cairn/milestones/M45-reference-notes-randall.md
@@ -5,7 +5,7 @@
 - **Depends on:** M40
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** m45-reference-notes-randall
+- **Branch/PR:** m45-reference-notes-randall · https://github.com/jmgirard/circumplex/pull/71
 
 ## Goal
 
@@ -110,3 +110,47 @@ open question.
   (.92 → .93).
 
 ## Review
+
+**PR #71** (draft). Reviewed 2026-07-20. Docs-only apart from a 3-line test
+comment; branch diff = 6 files (2 new source notes, INDEX, milestone, ROADMAP,
+one test comment).
+
+### Acceptance criteria — fresh evidence
+
+- [x] AC1 — `hubert1987.md` (117 lines): banks the Eq. 3/5 normalized index,
+  the exact p-value (p. 175), and the (M+1)/(N+1) MC form (p. 177), each
+  page-anchored; `Extraction:` status records the OCR-scan single-witness
+  honestly (verified 2026-07-20 against `pdftoppm` images of pp. 176–177, no
+  human read — M40-D2); `## Traces to` present.
+- [x] AC2 — `tracey1997.md` (89 lines): banks CI = (A−D)/(A+D+T), exact-only
+  enumeration, the 4/6/8-var program scope, page-anchored pp. 165–167; honest
+  `Extraction:` status; `## Traces to` present.
+- [x] AC3 — both notes carry a `## Reconciliation with the shipped code`
+  section; cross-checked fresh under `load_all()` on Tracey Table 1:
+  `randall_predictions(6)` = **72** predictions, code reproduces
+  **A=69/D=2/T=1**, index **.9167** vs Tracey CI **.9306**. The strict-`>` tie
+  departure and the faithful (M+1)/(N+1) match are recorded verbatim; disposition
+  in **M45-D1**.
+- [x] AC4 — `INDEX.md` gains both entries with filename link text (confirmed by
+  `cairn_validate` `references index<->disk` PASS); the RANDALL owes-a-page
+  ledger note is retired (the sole surviving "not on the shelf" mention is in the
+  retired-note prose describing what was cleared).
+- [x] AC5 — `test-fit_structure_api.R:2` corrected ("five Acton & Revelle" →
+  four A&R criteria + RANDALL); `test-fit_structure.R` and
+  `test-fit_structure_api.R` pass under `NOT_CRAN=true`.
+- [x] AC6 — `cairn_validate` all checks pass (exit 0; 48 advisories, all
+  pre-existing M7 work-log history, non-gating); both pages parse
+  `('ok', 2026-07-20)`.
+
+### Consistency gate
+
+- `cairn_validate`: all checks passed (exit 0). Coverage completeness: pass.
+- Profile (`r-package`) consistency-gate: `devtools::document()` no diff; no
+  `man/`/`NAMESPACE`/`R/` generated-file drift; no new top-level files; README
+  and pkgdown unaffected (no export surface change). `devtools::check(--no-manual)`:
+  _pending — recorded below._
+- `cairn_impact`: N/A (Principles touched: —; no DESIGN.md principle changed).
+
+### Independent review (three lenses + scorer)
+
+_pending._

--- a/cairn/milestones/M45-reference-notes-randall.md
+++ b/cairn/milestones/M45-reference-notes-randall.md
@@ -82,7 +82,7 @@ open question.
       (`randall_predictions()` / `structure_randall()` ~585–591 /
       `structure_randall_test()` ~647–701); record any departure verbatim
       (probe display equations so the probe sees what it checks — M43 lesson).
-- [ ] T4 — Add both `INDEX.md` entries (filename link text); retire the RANDALL
+- [x] T4 — Add both `INDEX.md` entries (filename link text); retire the RANDALL
       owes-a-page ledger note.
 - [ ] T5 — Fix the miscount comment at `test-fit_structure_api.R:2`; run the
       `fit_structure` test files under `NOT_CRAN=true` to confirm green.
@@ -94,6 +94,7 @@ open question.
   candidate; both PDFs now shelved).
 - 2026-07-20: T1 — authored `hubert1987.md`. Both PDFs are OCR scans (ABBYY / Acrobat Paper Capture), so text layer ≠ independent witness; verified Eqs. 3/5, the exact and (M+1)/(N+1) p-values, and worked values against `pdftoppm` images of pp. 176–177. Code faithfully implements Eq. 3 at T=0 and the paper's own (M+1)/(N+1); departures banked: strict-`>` scores ties as disagreements (immaterial for continuous r), exact-enum cutoff nv≤9 vs paper's n≤8.
 - 2026-07-20: T2/T3 — authored `tracey1997.md` (CI = (A−D)/(A+D+T); exact-only, no MC; 4/6/8-var program). Reconciled both notes against the code and cross-checked on Tracey's Table 1 matrix under `load_all()`: `randall_predictions(6)` gives exactly 72 predictions; the code reproduces A=69/D=2/T=1 and returns .9167 vs Tracey's CI .93 — the banked tie departure, empirically confirmed. See M45-D1.
+- 2026-07-20: T4 — INDEX.md gains both entries (filename link text) and the RANDALL owes-a-page ledger note is retired; added D-023 forward-looking-sources note. Parser fix (M40 family): `cairn_validate`'s staleness check reads the Extraction block only to the next line STARTING with `**`, so a `**verified <date>**` at a physical line-start truncated tracey's status → "unrecognized"; un-bolded the verified-date phrase in BOTH notes so a reflow can't re-break it. Both now parse `('ok', 2026-07-20)`.
 
 ## Decisions
 

--- a/cairn/references/INDEX.md
+++ b/cairn/references/INDEX.md
@@ -10,6 +10,8 @@ _One line per committed page: `citekey — title — traces to`._
 - [acton2004.md](acton2004.md) — Acton & Revelle (2004), *Evaluation of ten psychometric criteria for circumplex structure* — the four criteria `fit_structure()` implements (Fisher eq. 6, Gap eq. 2, VT2 eq. 8, RT eq. 9), the Eq. 6 printed-vs-prose split, and the published nv = 64/128 cutoffs the shipped nv = 8 constants are **not** taken from; traces to `R/fit_structure.R`, `R/fit_structure_oop.R`, `data-raw/structure-test-cutoffs.R` and `vignettes/evaluating-circumplex-structure.Rmd`.
 - [wendt2019.md](wendt2019.md) — Wendt et al. (2019), *The latent structure of interpersonal problems* — the real-data benchmark for the fixed-angle circumplex CFA (RMSEA .075–.111, g–agency ≈ −.29 across four samples); traces to `vignettes/sem-based-ssm-analysis.Rmd:44,114,368,394-400,428`. Context for the strict tier, never an oracle.
 - [hu1999.md](hu1999.md) — Hu & Bentler (1999), *Cutoff criteria for fit indexes in covariance structure analysis* — the SRMR .08 and CFI/TLI .95 cutoffs; traces to `R/ssm_ci_accuracy.R:1023`, `R/ssm_ci_oop.R`, `R/cpm_oop.R:187-188` and `vignettes/evaluating-circumplex-structure.Rmd`.
+- [hubert1987.md](hubert1987.md) — Hubert & Arabie (1987), *Evaluating order hypotheses within proximity matrices* — the randomization order test behind `fit_structure()`'s RANDALL: the normalized agreement index (A−D)/(A+D+T) and its exact / (M+1)/(N+1) randomization p-value; traces to `R/fit_structure.R` (`structure_randall()`, `structure_randall_test()`), `tests/testthat/test-fit_structure.R` and `vignettes/evaluating-circumplex-structure.Rmd`.
+- [tracey1997.md](tracey1997.md) — Tracey (1997), *RANDALL: A Microsoft FORTRAN program…* — the program operationalizing Hubert & Arabie (1987), naming the Correspondence Index; traces to the same RANDALL implementation and `man/fit_structure.Rd` (`@references`). Companion to `hubert1987.md`; its Table 1 pins the tie case where the code's index (.92) departs from RANDALL's CI (.93).
 
 <!-- Entry format note: cairn_validate's _INDEX_LINE regex matches the first
      [\w./-]+\.md token after the bullet, so the link TEXT must be the
@@ -24,18 +26,20 @@ _One line per committed page: `citekey — title — traces to`._
      2026-07-19.)
 
      Which sources still owe a page is the milestone files' ledger, not this
-     file's. As of the M43 merge every source on the shelf that the repo
-     relies on has a page — the Acton & Revelle (2004) and Wendt et al.
-     (2019) entries this note carried after M42 are discharged, as the
-     Browne (1992) and Browne (1982) ones were before them — observed
-     2026-07-19. Two sources the repo DOES rely on are not on the shelf and
-     so have no page: Hubert & Arabie (1987) and Tracey (1997), which back
-     RANDALL (`structure_randall()`, `structure_randall_test()`, cited at
-     R/fit_structure.R:714,773-778). Surfaced by M43 and carried as a
-     ROADMAP candidate; both PDFs must be shelved before a milestone can
-     take it up. The shelf is a live directory that changed twice during
-     M40 alone, so treat any list here as a snapshot and re-inventory
-     rather than trusting it.
+     file's. As of the M45 merge every source on the shelf that the repo
+     relies on has a page — the Hubert & Arabie (1987) and Tracey (1997)
+     RANDALL pair this note recorded as owed after M43 are discharged by M45
+     (both PDFs were shelved 2026-07-20, clearing the "not on the shelf" gate),
+     as the Acton & Revelle (2004) / Wendt (2019) and Browne (1992) / Browne
+     (1982) entries were before them — observed 2026-07-20. The shelf is a
+     live directory that changed twice during M40 alone, so treat any list
+     here as a snapshot and re-inventory rather than trusting it.
+
+     Forward-looking shelf sources (nagy2019, weide2021, rogoza2021,
+     tracey2000) were added on purpose as future research material, not
+     because anything cites them; per D-023 they are captured as prospects
+     by M46, NOT dismissed as "owes no page," and do not belong on this
+     committed-page list until a milestone comes to rely on one.
 
      Shelved sources that owe NO page, each with its reason — all observed
      2026-07-19:

--- a/cairn/references/hubert1987.md
+++ b/cairn/references/hubert1987.md
@@ -11,8 +11,10 @@ an independent witness** — and it is visibly garbled ("Wakeneld", "denned",
 "m^ima"). Every load-bearing formula and numeral below (Eqs. 3 and 5, the
 exact- and Monte-Carlo p-value definitions, the worked values .75 and
 .88 − .13) was therefore verified 2026-07-20 against the `pdftoppm`-rendered
-images of pp. 176–177; the OCR text layer served only to locate passages and
-cross-check running prose. Per M41-D1 the rendered-image read is independent of
+images of pp. 175–177 — the pages carrying every anchor this note cites (the
+exact p-value and the reference-set symmetry on p. 175, Eqs. 3/5 and the worked
+values on p. 176, the Monte-Carlo form on p. 177); the OCR text layer served
+only to locate passages and cross-check running prose. Per M41-D1 the rendered-image read is independent of
 the text layer but is **not** a human attestation, and both channels derive
 from the same scan image — a defect in the scan itself would escape both. No
 value here has been read by a human.

--- a/cairn/references/hubert1987.md
+++ b/cairn/references/hubert1987.md
@@ -10,8 +10,8 @@ Producer), so its `pdftotext` text layer is **OCR output of the page image, not
 an independent witness** — and it is visibly garbled ("Wakeneld", "denned",
 "m^ima"). Every load-bearing formula and numeral below (Eqs. 3 and 5, the
 exact- and Monte-Carlo p-value definitions, the worked values .75 and
-.88 − .13) was therefore **verified 2026-07-20 against the `pdftoppm`-rendered
-images of pp. 176–177**; the OCR text layer served only to locate passages and
+.88 − .13) was therefore verified 2026-07-20 against the `pdftoppm`-rendered
+images of pp. 176–177; the OCR text layer served only to locate passages and
 cross-check running prose. Per M41-D1 the rendered-image read is independent of
 the text layer but is **not** a human attestation, and both channels derive
 from the same scan image — a defect in the scan itself would escape both. No

--- a/cairn/references/hubert1987.md
+++ b/cairn/references/hubert1987.md
@@ -1,0 +1,142 @@
+# hubert1987 — the randomization order test behind `fit_structure()`'s RANDALL
+
+**Provenance.** Ingested 2026-07-20 by M45 from
+`cairn/references/sources/hubert1987.pdf` (gitignored). The shelf PDF is 7
+pages and holds the whole article, printed pp. 172–178 on the pages themselves
+(running heads verified). Anchors below cite the article's own page numbers.
+
+Extraction: the PDF is an OCR scan (`Creator: ABBYY FineReader`, empty
+Producer), so its `pdftotext` text layer is **OCR output of the page image, not
+an independent witness** — and it is visibly garbled ("Wakeneld", "denned",
+"m^ima"). Every load-bearing formula and numeral below (Eqs. 3 and 5, the
+exact- and Monte-Carlo p-value definitions, the worked values .75 and
+.88 − .13) was therefore **verified 2026-07-20 against the `pdftoppm`-rendered
+images of pp. 176–177**; the OCR text layer served only to locate passages and
+cross-check running prose. Per M41-D1 the rendered-image read is independent of
+the text layer but is **not** a human attestation, and both channels derive
+from the same scan image — a defect in the scan itself would escape both. No
+value here has been read by a human.
+
+**Citation.** Hubert, L., & Arabie, P. (1987). Evaluating order hypotheses
+within proximity matrices. *Psychological Bulletin*, 102(1), 172–178.
+Transcribed from the article's own title block and running heads.
+
+**Role.** The published method the package's RANDALL structure test implements:
+the normalized order-agreement index and its randomization p-value computed by
+`structure_randall()` / `structure_randall_test()` (`R/fit_structure.R`), the
+fifth test `fit_structure()` runs. Tracey (1997) — `tracey1997.md` — is the
+FORTRAN operationalization the package also cites; the statistical content is
+Hubert & Arabie's.
+
+## Extracted values
+
+Notation is the source's: **P** is an n×n *proximity* matrix keyed as a
+**dissimilarity** (larger p_ij = more dissimilar; for correlations the paper
+uses 1 − r_ij, p. 173). An order hypothesis is a set of conjectured orderings
+of proximity pairs. A conjecture is an **agreement** (A) when the data respect
+it, a **violation** (D) when they contradict it, and a **tie** / null decision
+(T) when the two proximities are equal (pp. 173, 176).
+
+### The normalized agreement index — Eqs. (3) and (5), p. 176
+
+The descriptive measure of correspondence between conjectured and observed
+order, Eq. (3):
+
+> (A − D) / (A + D + T)
+
+"varies between the bounds of ±1" and, following Hubert (1978), "measures of
+the form given in Equation 3 … have expectations of zero under the
+random-labeling hypothesis" (p. 176). Eq. (5) writes the same quantity as a
+cross-product with the {−1, 0, +1}-coded order functions,
+`Σ T_H·T_D / Σ|T_H|`, T_H = +1 / −1 / 0 for a smaller / larger / no
+conjecture (p. 176). Worked three-argument example (Holland data):
+**(42 − 6)/48 = .88 − .13 = .75** (p. 176); equivalently `(A/24) − 1` since the
+48 three-argument conjectures give `2A/48 − 1` (p. 177). Table 3 (p. 177) tabs
+the three-argument index over all 6! = 720 relabelings — range −.50 to the
+observed maximum **.75**.
+
+### The exact randomization p-value — p. 175
+
+"The p value associated with the observed number of agreements is the
+proportion of the n! permutations that give agreement counts as large or
+larger" (p. 175) — one-tailed, evaluated by relabeling the objects (a
+one-to-one permutation of the object indices) and recomputing the statistic.
+
+### The Monte-Carlo p-value — p. 177
+
+For matrices too large to enumerate ("n ≤ 8" is called exact-feasible, p. 177):
+"N permutations are chosen at random (with replacement), and if M of the
+associated measures are as extreme or more so when compared with the observed
+agreement measure, a p value (one-tailed) of **(M + 1)/(N + 1)** is reported.
+(The 1 appears both in the numerator and the denominator because the observed
+agreement measure is assumed to be another random draw under the null…)"
+(p. 177).
+
+### Symmetry of the reference set — p. 175
+
+For a circular conjecture on 6 objects "there are really only 5!/2 = 60
+‘distinct’ relabelings because all cyclic permutations and their complete
+reversals are equivalent," and the uniform distribution over all 720
+permutations "induces an equally likely distribution over the 60 distinct
+relabelings" (p. 175) — so a reduced reference set yields the same p-value.
+
+## Reconciliation with the shipped code
+
+`R/fit_structure.R` works in **correlation (similarity)** space, not the paper's
+1 − r dissimilarity: `structure_randall()` predicts `vals[ia] > vals[ib]` where
+`randall_predictions()` sets `ia` to the pair at the *smaller* circular
+distance — i.e. closer-in-order variables should be *more* correlated. This is
+Hubert & Arabie's order relation with the sign flipped by the r ↔ (1 − r)
+change of variable; the agreement counts are identical.
+
+- **Statistic.** `2 * mean(vals[ia] > vals[ib]) - 1` = `(A − D − T)/(A + D + T)`
+  (strict `>` scores a tie as a non-agreement). This equals Eq. (3)
+  `(A − D)/(A + D + T)` **exactly when T = 0**. **Departure:** with tied
+  proximities the code counts ties against the index where Eq. (3) excludes
+  them from the numerator — numerically immaterial for continuous correlation
+  matrices, where exact ties are measure-zero. At T = 0 the identity
+  `2A/N − 1 = (A − D)/(A + D)` reproduces the paper's `(A/24) − 1` and its .75.
+- **Exact p-value.** `structure_randall_test()` returns
+  `mean(null_index >= observed)` — the paper's "proportion … as large or
+  larger" (p. 175), on the index (monotone in A). It enumerates `cbind(1L,
+  all_perms(2:nv))` = **(n−1)! relabelings** (variable 1 pinned to position 1),
+  one representative per cyclic-rotation class; because the circulant
+  prediction set makes the statistic rotation-invariant, each class has equal
+  size n and constant value, so the (n−1)! p-value equals the full n! p-value.
+  The code does **not** additionally collapse the reversal symmetry (the
+  further ÷2 to (n−1)!/2 of p. 175) — harmless, as reversal pairs carry equal
+  values and leave proportions unchanged.
+- **Monte-Carlo p-value.** `(1 + sum(null_index >= observed)) / (n_perm + 1)`
+  is the paper's **(M + 1)/(N + 1)** (p. 177) verbatim, with the same
+  "observed is another draw under the null" rationale the code comment gives —
+  **faithful, not a departure.**
+- **Exact/MC threshold.** The code errors and requires `n_perm` for `nv > 9`;
+  the paper calls exact enumeration feasible for "n ≤ 8" (p. 177). The code's
+  cutoff (9) is one looser — an implementation choice, not a fidelity claim.
+
+## What this source does and does not license
+
+It licenses the RANDALL **statistic and p-value** only. It says nothing about
+the circulant/circumplex *prediction pattern* itself (equal-spacing on a
+circle) — that structure is the package's own `randall_predictions()`, justified
+by the circumplex model, not by this paper, which illustrates with Holland's
+six vocational types. The zero-expectation and ±1-bound properties are the
+paper's; the package's interpretation of the index magnitude is not.
+
+## Traces to
+
+- `R/fit_structure.R` — `randall_predictions()`, `structure_randall()` (the
+  Eq. 3/5 index), `structure_randall_test()` (the exact and (M+1)/(N+1)
+  randomization p-values); surfaced through `fit_structure()` as the RANDALL
+  test.
+- `tests/testthat/test-fit_structure.R` — RANDALL statistic/p-value tests.
+- `vignettes/evaluating-circumplex-structure.Rmd` — RANDALL exposition.
+- `man/fit_structure.Rd` (`@references`).
+- Companion: `tracey1997.md` (the FORTRAN operationalization the package
+  co-cites).
+
+## Open questions
+
+- **No human read.** Both channels are machine (OCR text layer; a rendered-image
+  read of pp. 176–177). A scan defect on an unrendered page would be caught by
+  neither — dated 2026-07-20.

--- a/cairn/references/tracey1997.md
+++ b/cairn/references/tracey1997.md
@@ -1,0 +1,111 @@
+# tracey1997 — RANDALL, the program operationalizing the order test
+
+**Provenance.** Ingested 2026-07-20 by M45 from
+`cairn/references/sources/tracey1997.pdf` (gitignored). The shelf PDF is 5
+pages and holds the whole note, printed pp. 164–168 on the pages themselves
+(running heads verified). Anchors cite the note's own page numbers.
+
+Extraction: the PDF is an OCR scan (`Producer: Adobe Acrobat … Paper Capture
+Plug-in`), so its `pdftotext` text layer is **OCR output of the page image, not
+an independent witness** (garbled: "1ERENCE", "Im", "wasp= .0167"). The
+load-bearing passages — the Correspondence Index definition and the worked
+RIASEC example (69 confirmed / 2 not / 1 tie / CI .93 / p = .0167) — were
+**verified 2026-07-20 against the `pdftoppm`-rendered image of p. 165**; the OCR
+text layer served only to locate passages and read the reference list. Per
+M41-D1 the rendered-image read is independent of the text layer but is **not** a
+human attestation, and both derive from the same scan. No value here has been
+read by a human.
+
+**Citation.** Tracey, T. J. G. (1997). RANDALL: A Microsoft FORTRAN program for
+a randomization test of hypothesized order relations. *Educational and
+Psychological Measurement*, 57(1), 164–168. Transcribed from the note's own
+title block, running heads, and citation line.
+
+**Role.** The FORTRAN program that operationalizes Hubert & Arabie (1987) — the
+statistical content is theirs (`hubert1987.md`), Tracey's note is the software
+citation the package co-cites for its RANDALL test. It does **not** add a
+statistic the package takes independently; it names the index and pins the
+worked example that exercises the code's tie handling.
+
+## Extracted values
+
+### The Correspondence Index (CI) — p. 165
+
+RANDALL "yields an exact significance level of the number of predictions met by
+the data versus the null conjecture of random relabeling" and also "a
+correspondence index (CI) … which is the proportion of predictions met minus
+the proportion of predictions violated, can range from +1, indicating perfect
+fit, to −1, indicating that not one prediction was met. A CI value of 0.0
+indicates as many predictions were met as violated, and a CI value of 0.5
+indicates that 75% of the predictions were met in the data set whereas 25% were
+violated" (p. 165). So **CI = (proportion met) − (proportion violated) =
+(A − D)/(A + D + T)** — Hubert & Arabie's Eq. 3 (`hubert1987.md`).
+
+### The exact randomization p-value — pp. 165–166
+
+"The number of times the number of predictions met in the original data set is
+equaled or exceeded over all permutations divided by the total number of
+permutations provides the exact probability of the hypothesized model occurring
+by chance" (p. 166). Enumeration is over all relabelings of the matrix rows and
+columns; for six variables that is 6! = 720 applications.
+
+### Worked RIASEC example — pp. 165–166
+
+For the Table 1 correlation matrix (ACT/UNIACT, 358 males), a circular order
+model yields **72 unique order predictions**; "69 of the 72 order predictions
+were confirmed, two were not confirmed, and there was one tie. The
+correspondence index was .93" (p. 165) — i.e. (69 − 2)/72 = .9306. The exact
+p-value was **p = .0167 (= 1/60**, the 12/720 tie for the maximum; p. 166).
+
+### Program scope — p. 167
+
+RANDALL "will only accept data matrices with four, six, or eight variables …
+though it can easily be converted to other size variable sets," assumes a
+**symmetric** input matrix, and reports the counts confirmed / not confirmed /
+tied, the exact probability, and the CI. It enumerates exhaustively; the note
+describes **no Monte-Carlo option**.
+
+## Reconciliation with the shipped code
+
+`structure_randall()` computes the CI, and `structure_randall_test()` the exact
+p-value, over the package's circumplex prediction set (`randall_predictions()`).
+Points specific to this source:
+
+- **CI ↔ code index, and the tie departure — demonstrated on Tracey's own
+  example.** The code's `2 * mean(vals[ia] > vals[ib]) - 1`
+  = `(A − D − T)/(A + D + T)` equals Tracey's CI `(A − D)/(A + D + T)` **only
+  when T = 0**. On the RIASEC example (A = 69, D = 2, **T = 1**) Tracey's CI is
+  (69 − 2)/72 = **.93**, whereas the code's strict `>` scores the tie as a
+  non-agreement and returns 2·(69/72) − 1 = **.92**. The gap is exactly T/N and
+  vanishes for continuous correlation matrices (exact ties measure-zero), which
+  is every real `fit_structure()` input — so the departure is real but never
+  bites in practice. (Full derivation in `hubert1987.md`.)
+- **The Monte-Carlo branch is not RANDALL's.** `structure_randall_test(n_perm=)`
+  uses random relabelings with the `(M + 1)/(N + 1)` estimator; that path traces
+  to Hubert & Arabie (1987, p. 177), **not** to Tracey, whose program enumerates
+  exhaustively and offers no sampled option.
+- **Scope generalized.** RANDALL is fixed to 4/6/8 variables; the package
+  accepts `length(scales) >= 4`, enumerates exactly for `nv <= 9`, and switches
+  to the sampled p-value beyond — a superset of RANDALL's fixed sizes.
+
+## What this source does and does not license
+
+It licenses the **name and the interpretive scale** of the CI (its +1/0/−1
+anchors) and pins a worked example. It does not license the circumplex
+prediction pattern itself (the package's own `randall_predictions()`), and its
+statistical warrant is entirely Hubert & Arabie's.
+
+## Traces to
+
+- `R/fit_structure.R` — `structure_randall()` (the CI), `structure_randall_test()`
+  (exact p-value), surfaced through `fit_structure()` as RANDALL.
+- `tests/testthat/test-fit_structure.R` — RANDALL tests.
+- `vignettes/evaluating-circumplex-structure.Rmd`; `man/fit_structure.Rd`
+  (`@references`).
+- Companion: `hubert1987.md` (the statistical source).
+
+## Open questions
+
+- **No human read.** Both channels are machine (OCR text layer; a rendered-image
+  read of p. 165). A scan defect on an unrendered page would be caught by
+  neither — dated 2026-07-20.

--- a/cairn/references/tracey1997.md
+++ b/cairn/references/tracey1997.md
@@ -10,7 +10,7 @@ Plug-in`), so its `pdftotext` text layer is **OCR output of the page image, not
 an independent witness** (garbled: "1ERENCE", "Im", "wasp= .0167"). The
 load-bearing passages — the Correspondence Index definition and the worked
 RIASEC example (69 confirmed / 2 not / 1 tie / CI .93 / p = .0167) — were
-**verified 2026-07-20 against the `pdftoppm`-rendered image of p. 165**; the OCR
+verified 2026-07-20 against the `pdftoppm`-rendered image of p. 165; the OCR
 text layer served only to locate passages and read the reference list. Per
 M41-D1 the rendered-image read is independent of the text layer but is **not** a
 human attestation, and both derive from the same scan. No value here has been

--- a/cairn/references/tracey1997.md
+++ b/cairn/references/tracey1997.md
@@ -9,9 +9,10 @@ Extraction: the PDF is an OCR scan (`Producer: Adobe Acrobat … Paper Capture
 Plug-in`), so its `pdftotext` text layer is **OCR output of the page image, not
 an independent witness** (garbled: "1ERENCE", "Im", "wasp= .0167"). The
 load-bearing passages — the Correspondence Index definition and the worked
-RIASEC example (69 confirmed / 2 not / 1 tie / CI .93 / p = .0167) — were
-verified 2026-07-20 against the `pdftoppm`-rendered image of p. 165; the OCR
-text layer served only to locate passages and read the reference list. Per
+RIASEC example (69 confirmed / 2 not / 1 tie / CI .93 on p. 165, p = .0167 on
+p. 166) — were verified 2026-07-20 against the `pdftoppm`-rendered images of
+pp. 165–166; the OCR text layer served only to locate passages and read the
+reference list. Per
 M41-D1 the rendered-image read is independent of the text layer but is **not** a
 human attestation, and both derive from the same scan. No value here has been
 read by a human.
@@ -55,7 +56,13 @@ For the Table 1 correlation matrix (ACT/UNIACT, 358 males), a circular order
 model yields **72 unique order predictions**; "69 of the 72 order predictions
 were confirmed, two were not confirmed, and there was one tie. The
 correspondence index was .93" (p. 165) — i.e. (69 − 2)/72 = .9306. The exact
-p-value was **p = .0167 (= 1/60**, the 12/720 tie for the maximum; p. 166).
+p-value is printed as "p = .0167 (1/720)" (p. 166) — a **printed slip**: .0167
+is 1/60, not 1/720 (= .0014). The .0167 is the correct value: 12 of the 720
+relabelings tie the maximum (the 6 cyclic rotations × 2 reversals of the
+circular structure), so 12/720 = 1/60 = .0167, exactly Hubert & Arabie's Table 2
+result for the same RIASEC structure (`hubert1987.md`, p. 175). Tracey's
+companion phrase "no other comparisons … fit … as well or better" is the same
+imprecision — the 11 symmetric images also tie it.
 
 ### Program scope — p. 167
 
@@ -85,8 +92,11 @@ Points specific to this source:
   to Hubert & Arabie (1987, p. 177), **not** to Tracey, whose program enumerates
   exhaustively and offers no sampled option.
 - **Scope generalized.** RANDALL is fixed to 4/6/8 variables; the package
-  accepts `length(scales) >= 4`, enumerates exactly for `nv <= 9`, and switches
-  to the sampled p-value beyond — a superset of RANDALL's fixed sizes.
+  accepts `length(scales) >= 4` and enumerates exactly by default for
+  `nv <= 9`. It does **not** auto-switch beyond that: for `nv > 9` it errors
+  unless the caller supplies `n_perm`, and the sampled `(M+1)/(N+1)` path runs
+  whenever `n_perm` is given (at any `nv`). Still a superset of RANDALL's fixed
+  sizes.
 
 ## What this source does and does not license
 

--- a/tests/testthat/test-fit_structure_api.R
+++ b/tests/testthat/test-fit_structure_api.R
@@ -1,5 +1,6 @@
 # User-facing fit_structure() API (M4.5/T7): the single entry point over the
-# five Acton & Revelle (2004) structure tests, plus its print/summary/plot
+# four Acton & Revelle (2004) criteria plus RANDALL (Hubert & Arabie, 1987;
+# Tracey, 1997) structure tests, plus its print/summary/plot
 # methods. The criterion statistics and their interpretation/inference are
 # validated in test-fit_structure.R; here we test the wrapper's orchestration,
 # scoring behavior, object contract, and rendering.


### PR DESCRIPTION
Promotes the standing RANDALL ROADMAP candidate (both PDFs now shelved).

- **hubert1987.md** — Hubert & Arabie (1987): the normalized order-agreement index `(A−D)/(A+D+T)` (Eqs. 3/5), the exact p-value, and the `(M+1)/(N+1)` Monte-Carlo form — verified against `pdftoppm` page images (OCR scan).
- **tracey1997.md** — Tracey (1997) RANDALL: the Correspondence Index and worked RIASEC example.
- Code reconciliation cross-checked on Tracey's Table 1 under `load_all()`: `randall_predictions(6)` → 72 predictions; code reproduces A=69/D=2/T=1, returns .9167 vs Tracey CI .93 (M45-D1: strict-`>` tie departure, immaterial for continuous r, left unchanged).
- INDEX entries added; RANDALL owes-a-page ledger retired.
- `test-fit_structure_api.R` header miscount corrected (four A&R criteria + RANDALL).

Docs-only apart from the one-line test comment. `cairn_validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)