### PR TITLE
M49: fit-index guidance source-backed caveats

### DIFF
--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38 | high | milestones/M7-v2-release-prep.md |
-| M49 | Fit-index guidance — the two source-backed caveats | planned | — | normal | milestones/M49-fitindex-source-caveats.md |
+| M49 | Fit-index guidance — the two source-backed caveats | in-progress | — | normal | milestones/M49-fitindex-source-caveats.md |
 | M47 | SSM estimator source notes (Wright 2009 + defining Gurtman) | done | — | normal | milestones/archive/M47-estimator-source-notes.md |
 | M48 | Fit-index and uncited shelf sources (browne1993 twin + strack2013) | done | — | normal | milestones/archive/M48-fitindex-uncited-sources.md |
 | M45 | Source notes for the RANDALL structure test pair | done | M40 | normal | milestones/archive/M45-reference-notes-randall.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38 | high | milestones/M7-v2-release-prep.md |
-| M49 | Fit-index guidance — the two source-backed caveats | in-progress | — | normal | milestones/M49-fitindex-source-caveats.md |
+| M49 | Fit-index guidance — the two source-backed caveats | review | — | normal | milestones/M49-fitindex-source-caveats.md |
 | M47 | SSM estimator source notes (Wright 2009 + defining Gurtman) | done | — | normal | milestones/archive/M47-estimator-source-notes.md |
 | M48 | Fit-index and uncited shelf sources (browne1993 twin + strack2013) | done | — | normal | milestones/archive/M48-fitindex-uncited-sources.md |
 | M45 | Source notes for the RANDALL structure test pair | done | M40 | normal | milestones/archive/M45-reference-notes-randall.md |

--- a/cairn/milestones/M49-fitindex-source-caveats.md
+++ b/cairn/milestones/M49-fitindex-source-caveats.md
@@ -1,11 +1,11 @@
 # M49: Fit-index guidance — the two source-backed caveats
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** m49-fitindex-source-caveats
 
 ## Goal
 

--- a/cairn/milestones/M49-fitindex-source-caveats.md
+++ b/cairn/milestones/M49-fitindex-source-caveats.md
@@ -33,13 +33,14 @@ Add the two caveats its own cited sources state to the fit-index guidance in `vi
 
 ## Tasks
 
-- [ ] T1 — Insert the Hu & Bentler small-*n* overrejection caveat into `### Reading the fit indices` (at/after the benchmark paragraph, lines 91–97): scoped to TLI and RMSEA, explicitly excluding CFI, attributed to Hu & Bentler (1999), tied to the modest-*n* circumplex context. Verify wording against `hu1999.md`'s abstract quote.
-- [ ] T2 — Insert Browne & Cudeck's "subjective judgment / not infallible" characterization, attributed to Browne & Cudeck (1993), as a source-literature caveat distinct from the package-simulation cautions list. Verify against `browne1992a.md`'s p. 239 quote.
+- [x] T1 — Insert the Hu & Bentler small-*n* overrejection caveat into `### Reading the fit indices` (at/after the benchmark paragraph, lines 91–97): scoped to TLI and RMSEA, explicitly excluding CFI, attributed to Hu & Bentler (1999), tied to the modest-*n* circumplex context. Verify wording against `hu1999.md`'s abstract quote.
+- [x] T2 — Insert Browne & Cudeck's "subjective judgment / not infallible" characterization, attributed to Browne & Cudeck (1993), as a source-literature caveat distinct from the package-simulation cautions list. Verify against `browne1992a.md`'s p. 239 quote.
 - [ ] T3 — Build via `devtools::check(args = "--no-manual")` (authoritative build, not a standalone `render()` — M21/M34); confirm no new NOTE/WARNING and an unchanged References list; check the edited region's bytes for leaked scaffolding (M34).
 
 ## Work log
 
 - 2026-07-21: created by /milestone-plan. Absorbs the "fit-index guidance omits two caveats" candidate row (ROADMAP); lineage: `hu1999.md` open question deferred this from M41. Gate decisions: overrejection caveat scoped to TLI+RMSEA only (CFI excluded, per source); both caveats added.
+- 2026-07-21: T1+T2 — inserted both source-literature caveats as one prose paragraph after the benchmark paragraph, kept distinct from the package-simulation cautions list (relabeled "Two further cautions are circumplex-specific"). Quotes verified verbatim against `browne1992a.md` (p. 239) and `hu1999.md` (abstract); CFI excluded from the overrejection claim.
 
 ## Decisions
 

--- a/cairn/milestones/M49-fitindex-source-caveats.md
+++ b/cairn/milestones/M49-fitindex-source-caveats.md
@@ -5,7 +5,7 @@
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** m49-fitindex-source-caveats
+- **Branch/PR:** m49-fitindex-source-caveats · https://github.com/jmgirard/circumplex/pull/75
 
 ## Goal
 
@@ -19,10 +19,10 @@ Add the two caveats its own cited sources state to the fit-index guidance in `vi
 
 ## Acceptance criteria
 
-- [ ] The section states that TLI and RMSEA tend to overreject true-population models at small sample size, attributed to Hu & Bentler (1999), and **explicitly notes CFI is not among the indices the source flags** — matching the `hu1999.md` abstract quote "the ML-based TLI, Mc, and RMSEA tend to overreject true-population models at small sample size"; the prose ties this to the modest-*n* circumplex context (`hu1999.md` records `zimmermann2017.md` placing several SSM accuracy thresholds at n = 50–200).
-- [ ] The section carries Browne & Cudeck's own characterization of their RMSEA cutoffs as "based on subjective judgment… cannot be regarded as infallible or correct", attributed to Browne & Cudeck (1993), matching the `browne1992a.md` p. 239 verbatim quote.
-- [ ] Both caveats read as external-literature caveats attached to the benchmark paragraph, kept **distinct from** the existing "Two circumplex-specific cautions, both from this package's own validation simulations" list — provenance not blurred.
-- [ ] `devtools::check(args = "--no-manual")` builds the vignette clean with no new NOTE/WARNING, and the `## References` list is unchanged (both sources already listed at `:613` and `:625`).
+- [x] The section states that TLI and RMSEA tend to overreject true-population models at small sample size, attributed to Hu & Bentler (1999), and **explicitly notes CFI is not among the indices the source flags** — matching the `hu1999.md` abstract quote "the ML-based TLI, Mc, and RMSEA tend to overreject true-population models at small sample size"; the prose ties this to the modest-*n* circumplex context (`hu1999.md` records `zimmermann2017.md` placing several SSM accuracy thresholds at n = 50–200).
+- [x] The section carries Browne & Cudeck's own characterization of their RMSEA cutoffs as "based on subjective judgment… cannot be regarded as infallible or correct", attributed to Browne & Cudeck (1993), matching the `browne1992a.md` p. 239 verbatim quote.
+- [x] Both caveats read as external-literature caveats attached to the benchmark paragraph, kept **distinct from** the existing "Two circumplex-specific cautions, both from this package's own validation simulations" list — provenance not blurred.
+- [x] `devtools::check(args = "--no-manual")` builds the vignette clean with no new NOTE/WARNING, and the `## References` list is unchanged (both sources already listed at `:613` and `:625`).
 
 ## Coverage
 
@@ -42,7 +42,21 @@ Add the two caveats its own cited sources state to the fit-index guidance in `vi
 - 2026-07-21: created by /milestone-plan. Absorbs the "fit-index guidance omits two caveats" candidate row (ROADMAP); lineage: `hu1999.md` open question deferred this from M41. Gate decisions: overrejection caveat scoped to TLI+RMSEA only (CFI excluded, per source); both caveats added.
 - 2026-07-21: T1+T2 — inserted both source-literature caveats as one prose paragraph after the benchmark paragraph, kept distinct from the package-simulation cautions list (relabeled "Two further cautions are circumplex-specific"). Quotes verified verbatim against `browne1992a.md` (p. 239) and `hu1999.md` (abstract); CFI excluded from the overrejection claim.
 - 2026-07-21: T3 — `devtools::check(args = "--no-manual")` clean (0/0/0); log shows "re-building of vignette outputs ... OK" (vignette genuinely rebuilt). Diff is the one inserted paragraph + relabel; References list unchanged. Status → review.
+- 2026-07-21: review — PR #75 (draft). Consistency gate clean (cairn_validate exit 0, document() no-diff, pkgdown clean, full check() 0/0/0). 3-lens fan-out + scorer: F1 (score 90) RMSEA "comparative-fit" mislabel fixed on branch; F2 (score 78) subjective-judgment quote-scope logged below threshold. Re-ran full check() post-fix: 0/0/0.
 
 ## Decisions
 
 ## Review
+
+**AC evidence (fresh, this session):**
+- AC1 — `evaluating-circumplex-structure.Rmd:103-107`: "the ML-based TLI and RMSEA tend to *overreject* true-population models when the sample is small (CFI is not among the indices they flag)… the SSM accuracy thresholds in Section 3 span roughly $n = 50$ to $200$." Attributed Hu & Bentler (1999); CFI excluded; matches `hu1999.md` abstract quote (Mc dropped — not computed by `cpm_fit()`, plan-sanctioned). Verbatim/scoping confirmed by all three lenses.
+- AC2 — `:99-101`: "based on subjective judgment," … "cannot be regarded as infallible or correct" (Browne & Cudeck, 1993). Verbatim against `browne1992a.md` p. 239 (all three lenses). See logged Finding 2 on quote scope.
+- AC3 — new source-literature paragraph ("Two caveats come from the benchmark sources themselves") kept distinct from the relabeled package-simulation list ("Two further cautions are circumplex-specific, both from this package's own validation simulations"). Provenance clean (blame-history lens confirmed).
+- AC4 — `devtools::check()` full run clean **0/0/0** (re-run post-fix; "re-building of vignette outputs … OK"); References list untouched (git diff: 0 ref-list lines changed).
+
+**Consistency gate:** `cairn_validate` exit 0 (coverage complete PASS; 47 advisories all M7's pre-existing work-log wraps). `document()` no generated-file diff. `pkgdown::check_pkgdown()` clean. Full `devtools::check()` 0/0/0. No principle changed → `cairn_impact` skipped. NEWS: no entry owed — the "Evaluating Circumplex Structure" vignette is new-in-2.0.0 (already logged under `## Documentation`), so M49 refines unreleased content with no release-relative delta.
+
+**Independent review — 3 lenses + scorer:**
+- [O] diff-bug (Opus): 2 findings. **F1 (score 90, actioned/fixed):** the caveat sentence called RMSEA "the comparative-fit benchmark", a category error contradicting the vignette's own terminology (RMSEA = approximate fit; comparative fit reserved for CFI/TLI). Fixed on branch → "these benchmarks are least dependable at small samples". **F2 (score 78, below threshold — logged, not actioned):** the "subjective judgment / infallible" quote attaches to Browne & Cudeck's 0.05 close-fit figure specifically, while the vignette presents the .08/.10 cutoffs; the passage is subjective in spirit throughout and AC2 framed the target as the cutoffs plural. Surfaced to the maintainer at the approval gate.
+- [S] blame-history (Sonnet): no findings — edit resolves M41's explicitly-deferred caveat, undoes/contradicts nothing; independently flagged the same RMSEA/comparative-fit wording (folds into F1).
+- [S] prior-review (Sonnet): no prior-review evidence (GitHub comment probe empty; archived Review sections orthogonal to this vignette text); zero findings.

--- a/cairn/milestones/M49-fitindex-source-caveats.md
+++ b/cairn/milestones/M49-fitindex-source-caveats.md
@@ -1,6 +1,6 @@
 # M49: Fit-index guidance — the two source-backed caveats
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
@@ -35,12 +35,13 @@ Add the two caveats its own cited sources state to the fit-index guidance in `vi
 
 - [x] T1 — Insert the Hu & Bentler small-*n* overrejection caveat into `### Reading the fit indices` (at/after the benchmark paragraph, lines 91–97): scoped to TLI and RMSEA, explicitly excluding CFI, attributed to Hu & Bentler (1999), tied to the modest-*n* circumplex context. Verify wording against `hu1999.md`'s abstract quote.
 - [x] T2 — Insert Browne & Cudeck's "subjective judgment / not infallible" characterization, attributed to Browne & Cudeck (1993), as a source-literature caveat distinct from the package-simulation cautions list. Verify against `browne1992a.md`'s p. 239 quote.
-- [ ] T3 — Build via `devtools::check(args = "--no-manual")` (authoritative build, not a standalone `render()` — M21/M34); confirm no new NOTE/WARNING and an unchanged References list; check the edited region's bytes for leaked scaffolding (M34).
+- [x] T3 — Build via `devtools::check(args = "--no-manual")` (authoritative build, not a standalone `render()` — M21/M34); confirm no new NOTE/WARNING and an unchanged References list; check the edited region's bytes for leaked scaffolding (M34).
 
 ## Work log
 
 - 2026-07-21: created by /milestone-plan. Absorbs the "fit-index guidance omits two caveats" candidate row (ROADMAP); lineage: `hu1999.md` open question deferred this from M41. Gate decisions: overrejection caveat scoped to TLI+RMSEA only (CFI excluded, per source); both caveats added.
 - 2026-07-21: T1+T2 — inserted both source-literature caveats as one prose paragraph after the benchmark paragraph, kept distinct from the package-simulation cautions list (relabeled "Two further cautions are circumplex-specific"). Quotes verified verbatim against `browne1992a.md` (p. 239) and `hu1999.md` (abstract); CFI excluded from the overrejection claim.
+- 2026-07-21: T3 — `devtools::check(args = "--no-manual")` clean (0/0/0); log shows "re-building of vignette outputs ... OK" (vignette genuinely rebuilt). Diff is the one inserted paragraph + relabel; References list unchanged. Status → review.
 
 ## Decisions
 

--- a/vignettes/evaluating-circumplex-structure.Rmd
+++ b/vignettes/evaluating-circumplex-structure.Rmd
@@ -96,8 +96,20 @@ at or below about .08 suggests acceptable average residuals (Hu & Bentler,
 Bentler, 1999). Treat these as conventions from the broader
 covariance-structure literature, not circumplex-specific laws.
 
-Two circumplex-specific cautions, both from this package's own validation
-simulations:
+Two caveats come from the benchmark sources themselves. Browne and Cudeck
+call their own RMSEA thresholds "based on subjective judgment," cautioning
+that such a figure "cannot be regarded as infallible or correct" (Browne &
+Cudeck, 1993) — read the cutoffs as conventions, not decision rules. And the
+comparative-fit benchmark is least dependable at small samples: Hu and
+Bentler (1999) found that the ML-based TLI and RMSEA tend to *overreject*
+true-population models when the sample is small (CFI is not among the indices
+they flag), and circumplex analyses are often run at modest sample sizes —
+the SSM accuracy thresholds in Section 3 span roughly $n = 50$ to $200$. At
+small $n$, then, a TLI or RMSEA that falls short of its benchmark can reflect
+the index's small-sample behavior as much as the model's fit.
+
+Two further cautions are circumplex-specific, both from this package's own
+validation simulations:
 
 - **Boundary solutions are common at realistic sample sizes.** When octant
   scales share a strong general factor (as interpersonal problem scales

--- a/vignettes/evaluating-circumplex-structure.Rmd
+++ b/vignettes/evaluating-circumplex-structure.Rmd
@@ -99,8 +99,8 @@ covariance-structure literature, not circumplex-specific laws.
 Two caveats come from the benchmark sources themselves. Browne and Cudeck
 call their own RMSEA thresholds "based on subjective judgment," cautioning
 that such a figure "cannot be regarded as infallible or correct" (Browne &
-Cudeck, 1993) — read the cutoffs as conventions, not decision rules. And the
-comparative-fit benchmark is least dependable at small samples: Hu and
+Cudeck, 1993) — read the cutoffs as conventions, not decision rules. And these
+benchmarks are least dependable at small samples: Hu and
 Bentler (1999) found that the ML-based TLI and RMSEA tend to *overreject*
 true-population models when the sample is small (CFI is not among the indices
 they flag), and circumplex analyses are often run at modest sample sizes —


### PR DESCRIPTION
Adds the two caveats its cited sources state to the fit-index guidance in `vignettes/evaluating-circumplex-structure.Rmd` (the `### Reading the fit indices` section):

- **Browne & Cudeck (1993)** call their own RMSEA cutoffs "based on subjective judgment," not "infallible or correct" — read them as conventions, not decision rules.
- **Hu & Bentler (1999)** found the ML-based TLI and RMSEA tend to *overreject* true-population models at small samples (CFI is not among the indices they flag), and circumplex analyses often run at modest n.

Docs-only. Both quotes verified verbatim against the banked source notes (`cairn/references/hu1999.md`, `browne1992a.md`). No package code, no References-list change. `devtools::check(args="--no-manual")` clean (0/0/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)