### PR TITLE
M50: rework Advanced Visualization vignette for a less-advanced audience

### DIFF
--- a/R/ssm_trajectory.R
+++ b/R/ssm_trajectory.R
@@ -607,7 +607,12 @@ ssm_trajectory_ggplot <- function(df, time_col, xlab, base_size, na.rm) {
     ggplot2::theme_bw(base_size = base_size) +
     ggplot2::theme(
       legend.position = "bottom",
-      panel.grid.minor = ggplot2::element_blank()
+      panel.grid.minor = ggplot2::element_blank(),
+      # scales = "free_y" gives each panel its own interior y-axis, so the
+      # Amplitude and Displacement panels' tick labels sit in the gutter to
+      # their left and crowd the neighbouring panel at vignette width. Widen
+      # the horizontal panel gap so the labels clear it (M50).
+      panel.spacing.x = grid::unit(1.2, "lines")
     )
 
   if (show_cert) {

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38 | high | milestones/M7-v2-release-prep.md |
-| M50 | Advanced Visualization vignette — rework for a less-advanced audience | planned | — | normal | milestones/M50-viz-vignette-approachable.md |
+| M50 | Advanced Visualization vignette — rework for a less-advanced audience | in-progress | — | normal | milestones/M50-viz-vignette-approachable.md |
 | M49 | Fit-index guidance — the two source-backed caveats | done | — | normal | milestones/archive/M49-fitindex-source-caveats.md |
 | M47 | SSM estimator source notes (Wright 2009 + defining Gurtman) | done | — | normal | milestones/archive/M47-estimator-source-notes.md |
 | M48 | Fit-index and uncited shelf sources (browne1993 twin + strack2013) | done | — | normal | milestones/archive/M48-fitindex-uncited-sources.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38 | high | milestones/M7-v2-release-prep.md |
-| M50 | Advanced Visualization vignette — rework for a less-advanced audience | in-progress | — | normal | milestones/M50-viz-vignette-approachable.md |
+| M50 | Advanced Visualization vignette — rework for a less-advanced audience | review | — | normal | milestones/M50-viz-vignette-approachable.md |
 | M49 | Fit-index guidance — the two source-backed caveats | done | — | normal | milestones/archive/M49-fitindex-source-caveats.md |
 | M47 | SSM estimator source notes (Wright 2009 + defining Gurtman) | done | — | normal | milestones/archive/M47-estimator-source-notes.md |
 | M48 | Fit-index and uncited shelf sources (browne1993 twin + strack2013) | done | — | normal | milestones/archive/M48-fitindex-uncited-sources.md |

--- a/cairn/milestones/M50-viz-vignette-approachable.md
+++ b/cairn/milestones/M50-viz-vignette-approachable.md
@@ -63,7 +63,7 @@ ggplot2 experts, and fix the one shipped-function defect that rework surfaces.
       trajectory vdiffr baselines are regenerated (only the intended ones
       move), and a render-and-inspect confirms no interior-label collision.
       Evidence: `R/ssm_trajectory.R` diff; `_snaps/ssm_trajectory*`; the figure.
-- [ ] `devtools::test()` (NOT_CRAN=true) green and
+- [x] `devtools::test()` (NOT_CRAN=true) green and
       `devtools::check(args = "--no-manual")` clean with every vignette figure
       knitting. Evidence: check/test logs (the `verify` slot).
 
@@ -124,6 +124,7 @@ _Reviewed 2026-07-21. PR #76. Driving RR: none (no projection-vs-outcome)._
 - AC3 — grep for `extending the layers` / `ggproto` / `GeomSsmStar` / `geom_ssm_star` = 0 occurrences.
 - AC4 — the only flagged construct remaining is `matrix(` at Rmd L302–303, inside the `echo = FALSE` `occasions-data-sim` chunk (L293); no `do.call(`/`lapply(`/`[, c(`/`[!is.na(` anywhere. Full vignette knits under `load_all()` (KNIT OK, 13 figures); reworked figures equivalent.
 - AC5 — `R/ssm_trajectory.R:615` adds `panel.spacing.x = grid::unit(1.2, "lines")`; 5 vdiffr baselines regenerated (`_snaps/ssm_trajectory{,_table}`), env parity confirmed (coord_circumplex byte-identical), diff is pure panel geometry; 3- and 5-panel layouts render-inspected, labels clear.
+- AC6 — review-time `devtools::check(args = "--no-manual")` = 0 errors / 0 warnings / 0 notes (tests, incl. the 5 regenerated snapshots, run within it); post-fix vignette re-knit KNIT OK (13 figures). PR CI runs the full matrix on the final commit.
 
 **Consistency gate:**
 

--- a/cairn/milestones/M50-viz-vignette-approachable.md
+++ b/cairn/milestones/M50-viz-vignette-approachable.md
@@ -78,7 +78,7 @@ ggplot2 experts, and fix the one shipped-function defect that rework surfaces.
 
 ## Tasks
 
-- [ ] T1 — Add horizontal panel spacing to `ssm_trajectory_ggplot()`'s theme
+- [x] T1 — Add horizontal panel spacing to `ssm_trajectory_ggplot()`'s theme
       (`R/ssm_trajectory.R:607-611`); render-and-inspect the grouped,
       ungrouped, and table figures (M33/M38: data-level tests and a stale
       baseline both pass a figure that reads wrong); regenerate the 5
@@ -103,6 +103,7 @@ ggplot2 experts, and fix the one shipped-function defect that rework surfaces.
 ## Work log
 
 - 2026-07-21: created by /milestone-plan.
+- 2026-07-21: T1 — added `panel.spacing.x = grid::unit(1.2, "lines")` to `ssm_trajectory_ggplot()`; render-inspected 3- and 5-panel layouts (labels clear); regenerated 5 vdiffr baselines (env parity confirmed via coord_circumplex byte-identical); trajectory tests 145 pass / 0 fail.
 
 ## Decisions
 

--- a/cairn/milestones/M50-viz-vignette-approachable.md
+++ b/cairn/milestones/M50-viz-vignette-approachable.md
@@ -5,7 +5,7 @@
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** m50-viz-vignette-approachable
+- **Branch/PR:** m50-viz-vignette-approachable · https://github.com/jmgirard/circumplex/pull/76
 
 ## Goal
 
@@ -47,19 +47,19 @@ ggplot2 experts, and fix the one shipped-function defect that rework surfaces.
 
 ## Acceptance criteria
 
-- [ ] The instrument/label example renders spokes with full descriptive scale
+- [x] The instrument/label example renders spokes with full descriptive scale
       names (not `PA`–`NO`), and no vignette prose claims a bundled instrument
       relabels spokes. Evidence: the reworked chunk knits; grep the Rmd.
-- [ ] No figure in the coordinate-system section shows spokes on ggplot2
+- [x] No figure in the coordinate-system section shows spokes on ggplot2
       default breaks (0/100/200/300); every circumplex figure carries octant
       spokes. Evidence: the `coord-bare` broken-figure chunk is gone; render.
-- [ ] The "Extending the layers" section is removed. Evidence: the Rmd contains
+- [x] The "Extending the layers" section is removed. Evidence: the Rmd contains
       no `ggproto`, `GeomSsmStar`, or "Extending the layers".
-- [ ] The vignette's echoed R chunks contain none of `do.call(`, `lapply(`,
+- [x] The vignette's echoed R chunks contain none of `do.call(`, `lapply(`,
       `matrix(`, `[, c(`, or logical/negative row-filtering `[!is.na(`; any
       unavoidable construction is confined to a non-echoed setup chunk.
       Evidence: grep over echoed chunks + render shows equivalent figures.
-- [ ] `ssm_trajectory_ggplot()` sets a horizontal panel spacing, the 5
+- [x] `ssm_trajectory_ggplot()` sets a horizontal panel spacing, the 5
       trajectory vdiffr baselines are regenerated (only the intended ones
       move), and a render-and-inspect confirms no interior-label collision.
       Evidence: `R/ssm_trajectory.R` diff; `_snaps/ssm_trajectory*`; the figure.
@@ -113,3 +113,19 @@ ggplot2 experts, and fix the one shipped-function defect that rework surfaces.
 ## Decisions
 
 ## Review
+
+_Reviewed 2026-07-21. PR #76. Driving RR: none (no projection-vs-outcome)._
+
+**Acceptance-criterion evidence (fresh):**
+
+- AC1 — `canvas-descriptive` chunk renders `ggcircumplex(octants(), labels = csip$Scales$Label)` (full interpersonal names); the `instrument = csip` reference is now inline prose, not a figure; no prose claims a bundled instrument produces different spokes. Render-inspected: all 8 names fit at `fig.width = 7`, none clipped.
+- AC2 — grep for `coord-bare` / `0, 100, 200` / "visibly unfinished" / "default axis breaks" returns nothing; `coord-built` renders octant spokes (verified in-vignette render).
+- AC3 — grep for `extending the layers` / `ggproto` / `GeomSsmStar` / `geom_ssm_star` = 0 occurrences.
+- AC4 — the only flagged construct remaining is `matrix(` at Rmd L302–303, inside the `echo = FALSE` `occasions-data-sim` chunk (L293); no `do.call(`/`lapply(`/`[, c(`/`[!is.na(` anywhere. Full vignette knits under `load_all()` (KNIT OK, 13 figures); reworked figures equivalent.
+- AC5 — `R/ssm_trajectory.R:615` adds `panel.spacing.x = grid::unit(1.2, "lines")`; 5 vdiffr baselines regenerated (`_snaps/ssm_trajectory{,_table}`), env parity confirmed (coord_circumplex byte-identical), diff is pure panel geometry; 3- and 5-panel layouts render-inspected, labels clear.
+
+**Consistency gate:**
+
+- `cairn_validate.py` — exit 0, all checks PASS (47 work-log-format advisories, all pre-existing M7 lines; not M50's).
+- No `DESIGN.md` principle changed → `cairn_impact` skipped.
+- Toolchain (`r-package` consistency-gate slot): `devtools::document()` no-diff (man/, NAMESPACE, RcppExports unchanged); `pkgdown::check_pkgdown()` passes; NEWS entry not owed — `ssm_plot_trajectory()` and the vignette are both new in the unreleased 2.0.0, so the panel-spacing refinement is intra-development, not user-visible vs a released version.

--- a/cairn/milestones/M50-viz-vignette-approachable.md
+++ b/cairn/milestones/M50-viz-vignette-approachable.md
@@ -109,6 +109,7 @@ ggplot2 experts, and fix the one shipped-function defect that rework surfaces.
 - 2026-07-21: T4 — removed the "Extending the layers" section (`GeomSsmStar` ggproto subclass); no dangling cross-references remain.
 - 2026-07-21: T5 — `[, c()]` displays → `subset(select=)`; `people[!is.na(),]` → `subset()`; moved the `do.call(rbind, lapply())`+`matrix()` occasions simulation into a non-echoed `echo = FALSE` chunk. Echoed chunks now carry no flagged base-R; full vignette knits under load_all (KNIT OK, 13 figures).
 - 2026-07-21: T6 — `devtools::check(args = "--no-manual")` clean: 0 errors / 0 warnings / 0 notes (4m52s), authoritative vignette build included. Status → review.
+- 2026-07-21: review — PR #76; AC1–AC6 verified; consistency gate clean (validate exit 0, document no-diff, pkgdown ok). Fan-out (3 lenses + inline scoring): no regressions; F1 (garbled sentence, all 3 lenses) and F2 (`angles` undefined in echoed chunk) fixed on-branch; re-knit KNIT OK.
 
 ## Decisions
 
@@ -129,3 +130,16 @@ _Reviewed 2026-07-21. PR #76. Driving RR: none (no projection-vs-outcome)._
 - `cairn_validate.py` — exit 0, all checks PASS (47 work-log-format advisories, all pre-existing M7 lines; not M50's).
 - No `DESIGN.md` principle changed → `cairn_impact` skipped.
 - Toolchain (`r-package` consistency-gate slot): `devtools::document()` no-diff (man/, NAMESPACE, RcppExports unchanged); `pkgdown::check_pkgdown()` passes; NEWS entry not owed — `ssm_plot_trajectory()` and the vignette are both new in the unreleased 2.0.0, so the panel-spacing refinement is intra-development, not user-visible vs a released version.
+
+**Independent fresh-context review (3 lenses + scorer):**
+
+- [O] diff-bug: statistical/mechanical core clean (panel.spacing touches no data/branch/certification; 5 baselines geometry-only — text and numeric values unchanged; `subset()` rewrites behaviourally equivalent; labels pair correctly). 2 findings (below).
+- [S] blame-history: no regressions — the spacing change touches none of the M27/M33/M35 seam/unwrap invariants (those live in `GeomSsmArc$setup_data()`, untouched); removed vignette sections were M34 docs choices, not decision-backed; exported API unchanged. Independently flagged F1.
+- [S] prior-review: no regressions — M34's statistical-precision caveats survive, occasion-ordering intact, seam case preserved, all 5 baselines regenerated (per M31/M38 lesson), no leaked scaffolding (M34). Independently flagged F1.
+
+Findings (scored inline — both self-evidently real and actioned, so no exclusion gate needed):
+
+- F1 (score 98) — garbled sentence at `advanced-visualization.Rmd` descriptive-labels example (flagged by all three lenses). **Fixed**: reworded to "The octant scales also have full interpersonal names, which you can put on the spokes instead:".
+- F2 (score 92) — the echoed `occasions-path` chunk used `ggcircumplex(angles, ...)` but `angles` moved into the `echo = FALSE` sim chunk, so a reader copying the visible chunk hits `object 'angles' not found`. **Fixed**: chunk now calls `ggcircumplex(octants(), ...)`. Re-knit KNIT OK.
+
+No findings scored below 80; no follow-ups spawned.

--- a/cairn/milestones/M50-viz-vignette-approachable.md
+++ b/cairn/milestones/M50-viz-vignette-approachable.md
@@ -84,15 +84,15 @@ ggplot2 experts, and fix the one shipped-function defect that rework surfaces.
       baseline both pass a figure that reads wrong); regenerate the 5
       trajectory vdiffr baselines under `NOT_CRAN=true` (M31: bare `Rscript`
       auto-skips vdiffr) and confirm no unrelated baseline moved.
-- [ ] T2 — Rework the instrument/label example (`advanced-visualization.Rmd`
+- [x] T2 — Rework the instrument/label example (`advanced-visualization.Rmd`
       ~L66–82): descriptive full-scale-name spokes; one sentence that an
       instrument object can be passed; correct the surrounding prose.
-- [ ] T3 — Cut the broken `coord-bare` figure and its "unfinished" prose
+- [x] T3 — Cut the broken `coord-bare` figure and its "unfinished" prose
       (~L84–122); lead with the correctly-scaled construction, explaining the
       scale line in prose. Verify no remaining figure shows default breaks.
-- [ ] T4 — Remove the "Extending the layers" section (~L236–270) and any
+- [x] T4 — Remove the "Extending the layers" section (~L236–270) and any
       cross-reference to it.
-- [ ] T5 — Simplify advanced base-R in the visible chunks (the `[, c(...)]`
+- [x] T5 — Simplify advanced base-R in the visible chunks (the `[, c(...)]`
       selections, the `do.call(rbind, lapply())` + `matrix()` occasions build,
       `people[!is.na(...), ]`) into simpler idioms, or move unavoidable
       construction into a non-echoed setup chunk; keep every figure equivalent.
@@ -104,6 +104,10 @@ ggplot2 experts, and fix the one shipped-function defect that rework surfaces.
 
 - 2026-07-21: created by /milestone-plan.
 - 2026-07-21: T1 — added `panel.spacing.x = grid::unit(1.2, "lines")` to `ssm_trajectory_ggplot()`; render-inspected 3- and 5-panel layouts (labels clear); regenerated 5 vdiffr baselines (env parity confirmed via coord_circumplex byte-identical); trajectory tests 145 pass / 0 fail.
+- 2026-07-21: T2 — replaced the `instrument = csip` figure (identical PA–NO abbrevs) with descriptive full scale-name spokes (`labels = csip$Scales$Label`); kept a one-sentence note that an instrument can be passed. Render-inspected: all 8 names fit at fig.width=7.
+- 2026-07-21: T3 — cut the deliberately-broken `coord-bare` figure (spokes on default 0/100/200/300) and its "unfinished" prose; lead with the correctly-scaled `coord-built` figure and explain the scale line in prose.
+- 2026-07-21: T4 — removed the "Extending the layers" section (`GeomSsmStar` ggproto subclass); no dangling cross-references remain.
+- 2026-07-21: T5 — `[, c()]` displays → `subset(select=)`; `people[!is.na(),]` → `subset()`; moved the `do.call(rbind, lapply())`+`matrix()` occasions simulation into a non-echoed `echo = FALSE` chunk. Echoed chunks now carry no flagged base-R; full vignette knits under load_all (KNIT OK, 13 figures).
 
 ## Decisions
 

--- a/cairn/milestones/M50-viz-vignette-approachable.md
+++ b/cairn/milestones/M50-viz-vignette-approachable.md
@@ -1,6 +1,6 @@
 # M50: Advanced Visualization vignette — rework for a less-advanced audience
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
@@ -96,7 +96,7 @@ ggplot2 experts, and fix the one shipped-function defect that rework surfaces.
       selections, the `do.call(rbind, lapply())` + `matrix()` occasions build,
       `people[!is.na(...), ]`) into simpler idioms, or move unavoidable
       construction into a non-echoed setup chunk; keep every figure equivalent.
-- [ ] T6 — `devtools::test()` (NOT_CRAN=true) and
+- [x] T6 — `devtools::test()` (NOT_CRAN=true) and
       `devtools::check(args = "--no-manual")`; confirm the vignette builds and
       every figure knits; final render-and-inspect sweep of the reworked figures.
 
@@ -108,6 +108,7 @@ ggplot2 experts, and fix the one shipped-function defect that rework surfaces.
 - 2026-07-21: T3 — cut the deliberately-broken `coord-bare` figure (spokes on default 0/100/200/300) and its "unfinished" prose; lead with the correctly-scaled `coord-built` figure and explain the scale line in prose.
 - 2026-07-21: T4 — removed the "Extending the layers" section (`GeomSsmStar` ggproto subclass); no dangling cross-references remain.
 - 2026-07-21: T5 — `[, c()]` displays → `subset(select=)`; `people[!is.na(),]` → `subset()`; moved the `do.call(rbind, lapply())`+`matrix()` occasions simulation into a non-echoed `echo = FALSE` chunk. Echoed chunks now carry no flagged base-R; full vignette knits under load_all (KNIT OK, 13 figures).
+- 2026-07-21: T6 — `devtools::check(args = "--no-manual")` clean: 0 errors / 0 warnings / 0 notes (4m52s), authoritative vignette build included. Status → review.
 
 ## Decisions
 

--- a/cairn/milestones/M50-viz-vignette-approachable.md
+++ b/cairn/milestones/M50-viz-vignette-approachable.md
@@ -1,11 +1,11 @@
 # M50: Advanced Visualization vignette — rework for a less-advanced audience
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** m50-viz-vignette-approachable
 
 ## Goal
 

--- a/tests/testthat/_snaps/ssm_trajectory/trajectory-grouped.svg
+++ b/tests/testthat/_snaps/ssm_trajectory/trajectory-grouped.svg
@@ -18,188 +18,188 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMjIuNjR8MjM3LjM2fDM5LjQzfDQ5Mi41NQ=='>
-    <rect x='22.64' y='39.43' width='214.71' height='453.12' />
+  <clipPath id='cpMjIuNjR8MjI5LjQ5fDM5LjQzfDQ5Mi41NQ=='>
+    <rect x='22.64' y='39.43' width='206.85' height='453.12' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjIuNjR8MjM3LjM2fDM5LjQzfDQ5Mi41NQ==)'>
-<rect x='22.64' y='39.43' width='214.71' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='22.64,406.10 237.36,406.10 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,304.37 237.36,304.37 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,202.65 237.36,202.65 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,100.93 237.36,100.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='53.32,492.55 53.32,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='104.44,492.55 104.44,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='155.56,492.55 155.56,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='206.68,492.55 206.68,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='53.32,170.05 104.44,212.07 155.56,121.03 206.68,279.85 206.68,471.96 155.56,424.33 104.44,452.76 53.32,408.62 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #F8766D; fill-opacity: 0.20;' />
-<polyline points='53.32,170.05 104.44,212.07 155.56,121.03 206.68,279.85 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='206.68,471.96 155.56,424.33 104.44,452.76 53.32,408.62 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polygon points='53.32,214.59 104.44,60.03 155.56,97.01 206.68,178.90 206.68,450.47 155.56,367.31 104.44,275.90 53.32,457.20 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #00BFC4; fill-opacity: 0.20;' />
-<polyline points='53.32,214.59 104.44,60.03 155.56,97.01 206.68,178.90 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='206.68,450.47 155.56,367.31 104.44,275.90 53.32,457.20 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='53.32,288.36 104.44,330.20 155.56,271.48 206.68,370.81 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
-<polyline points='53.32,322.97 104.44,167.91 155.56,223.22 206.68,325.37 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
-<circle cx='53.32' cy='288.36' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='104.44' cy='330.20' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='155.56' cy='271.48' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='206.68' cy='370.81' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='53.32' cy='322.97' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='104.44' cy='167.91' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='155.56' cy='223.22' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='206.68' cy='325.37' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<rect x='22.64' y='39.43' width='214.71' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMjIuNjR8MjI5LjQ5fDM5LjQzfDQ5Mi41NQ==)'>
+<rect x='22.64' y='39.43' width='206.85' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='22.64,406.10 229.49,406.10 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,304.37 229.49,304.37 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,202.65 229.49,202.65 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,100.93 229.49,100.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='52.19,492.55 52.19,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='101.44,492.55 101.44,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='150.69,492.55 150.69,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='199.94,492.55 199.94,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='52.19,170.05 101.44,212.07 150.69,121.03 199.94,279.85 199.94,471.96 150.69,424.33 101.44,452.76 52.19,408.62 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #F8766D; fill-opacity: 0.20;' />
+<polyline points='52.19,170.05 101.44,212.07 150.69,121.03 199.94,279.85 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='199.94,471.96 150.69,424.33 101.44,452.76 52.19,408.62 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polygon points='52.19,214.59 101.44,60.03 150.69,97.01 199.94,178.90 199.94,450.47 150.69,367.31 101.44,275.90 52.19,457.20 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #00BFC4; fill-opacity: 0.20;' />
+<polyline points='52.19,214.59 101.44,60.03 150.69,97.01 199.94,178.90 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='199.94,450.47 150.69,367.31 101.44,275.90 52.19,457.20 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='52.19,288.36 101.44,330.20 150.69,271.48 199.94,370.81 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='52.19,322.97 101.44,167.91 150.69,223.22 199.94,325.37 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<circle cx='52.19' cy='288.36' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='101.44' cy='330.20' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='150.69' cy='271.48' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='199.94' cy='370.81' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='52.19' cy='322.97' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='101.44' cy='167.91' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='150.69' cy='223.22' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='199.94' cy='325.37' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<rect x='22.64' y='39.43' width='206.85' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjYwLjAwfDQ3NC43MXwzOS40M3w0OTIuNTU='>
-    <rect x='260.00' y='39.43' width='214.71' height='453.12' />
+  <clipPath id='cpMjYzLjk0fDQ3MC43OHwzOS40M3w0OTIuNTU='>
+    <rect x='263.94' y='39.43' width='206.85' height='453.12' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjYwLjAwfDQ3NC43MXwzOS40M3w0OTIuNTU=)'>
-<rect x='260.00' y='39.43' width='214.71' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='260.00,381.78 474.71,381.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='260.00,238.81 474.71,238.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='260.00,95.85 474.71,95.85 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='290.67,492.55 290.67,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='341.80,492.55 341.80,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='392.92,492.55 392.92,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='444.04,492.55 444.04,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='290.67,184.17 341.80,170.93 392.92,81.97 444.04,88.49 444.04,279.30 392.92,286.64 341.80,406.35 290.67,402.85 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #F8766D; fill-opacity: 0.20;' />
-<polyline points='290.67,184.17 341.80,170.93 392.92,81.97 444.04,88.49 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='444.04,279.30 392.92,286.64 341.80,406.35 290.67,402.85 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polygon points='290.67,225.40 341.80,179.77 392.92,60.03 444.04,129.19 444.04,391.63 392.92,262.58 341.80,374.04 290.67,471.96 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #00BFC4; fill-opacity: 0.20;' />
-<polyline points='290.67,225.40 341.80,179.77 392.92,60.03 444.04,129.19 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='444.04,391.63 392.92,262.58 341.80,374.04 290.67,471.96 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='290.67,296.98 341.80,281.62 392.92,182.39 444.04,186.62 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
-<polyline points='290.67,340.61 341.80,278.36 392.92,168.51 444.04,261.72 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
-<circle cx='290.67' cy='296.98' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='341.80' cy='281.62' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='392.92' cy='182.39' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='444.04' cy='186.62' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='290.67' cy='340.61' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='341.80' cy='278.36' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='392.92' cy='168.51' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='444.04' cy='261.72' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<rect x='260.00' y='39.43' width='214.71' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMjYzLjk0fDQ3MC43OHwzOS40M3w0OTIuNTU=)'>
+<rect x='263.94' y='39.43' width='206.85' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='263.94,381.78 470.78,381.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='263.94,238.81 470.78,238.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='263.94,95.85 470.78,95.85 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='293.48,492.55 293.48,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='342.73,492.55 342.73,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='391.98,492.55 391.98,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='441.23,492.55 441.23,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='293.48,184.17 342.73,170.93 391.98,81.97 441.23,88.49 441.23,279.30 391.98,286.64 342.73,406.35 293.48,402.85 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #F8766D; fill-opacity: 0.20;' />
+<polyline points='293.48,184.17 342.73,170.93 391.98,81.97 441.23,88.49 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='441.23,279.30 391.98,286.64 342.73,406.35 293.48,402.85 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polygon points='293.48,225.40 342.73,179.77 391.98,60.03 441.23,129.19 441.23,391.63 391.98,262.58 342.73,374.04 293.48,471.96 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #00BFC4; fill-opacity: 0.20;' />
+<polyline points='293.48,225.40 342.73,179.77 391.98,60.03 441.23,129.19 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='441.23,391.63 391.98,262.58 342.73,374.04 293.48,471.96 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='293.48,296.98 342.73,281.62 391.98,182.39 441.23,186.62 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='293.48,340.61 342.73,278.36 391.98,168.51 441.23,261.72 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<circle cx='293.48' cy='296.98' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='342.73' cy='281.62' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='391.98' cy='182.39' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='441.23' cy='186.62' r='2.49' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='293.48' cy='340.61' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='342.73' cy='278.36' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='391.98' cy='168.51' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='441.23' cy='261.72' r='2.49' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<rect x='263.94' y='39.43' width='206.85' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDk5LjgxfDcxNC41MnwzOS40M3w0OTIuNTU='>
-    <rect x='499.81' y='39.43' width='214.71' height='453.12' />
+  <clipPath id='cpNTA3LjY4fDcxNC41MnwzOS40M3w0OTIuNTU='>
+    <rect x='507.68' y='39.43' width='206.85' height='453.12' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDk5LjgxfDcxNC41MnwzOS40M3w0OTIuNTU=)'>
-<rect x='499.81' y='39.43' width='214.71' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='499.81,459.39 714.52,459.39 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='499.81,381.32 714.52,381.32 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='499.81,303.26 714.52,303.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='499.81,225.19 714.52,225.19 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='499.81,147.13 714.52,147.13 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='499.81,69.06 714.52,69.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='530.48,492.55 530.48,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='581.60,492.55 581.60,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='632.73,492.55 632.73,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='683.85,492.55 683.85,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='530.48,237.23 581.60,327.01 632.73,207.71 683.85,60.03 683.85,210.92 632.73,374.10 581.60,433.00 530.48,394.99 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #F8766D; fill-opacity: 0.20;' />
-<polyline points='530.48,237.23 581.60,327.01 632.73,207.71 683.85,60.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='683.85,210.92 632.73,374.10 581.60,433.00 530.48,394.99 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polygon points='530.48,315.24 581.60,197.81 632.73,169.23 683.85,89.12 683.85,248.16 632.73,323.23 581.60,380.67 530.48,471.96 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #00BFC4; fill-opacity: 0.20;' />
-<polyline points='530.48,315.24 581.60,197.81 632.73,169.23 683.85,89.12 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='683.85,248.16 632.73,323.23 581.60,380.67 530.48,471.96 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='530.48,320.10 581.60,380.15 632.73,273.42 683.85,128.96 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
-<polyline points='530.48,392.59 581.60,280.68 632.73,245.33 683.85,169.90 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
-<circle cx='530.48' cy='320.10' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
-<circle cx='581.60' cy='380.15' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
-<circle cx='632.73' cy='273.42' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
-<circle cx='683.85' cy='128.96' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
-<circle cx='530.48' cy='392.59' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
-<circle cx='581.60' cy='280.68' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
-<circle cx='632.73' cy='245.33' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
-<circle cx='683.85' cy='169.90' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
-<rect x='499.81' y='39.43' width='214.71' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpNTA3LjY4fDcxNC41MnwzOS40M3w0OTIuNTU=)'>
+<rect x='507.68' y='39.43' width='206.85' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='507.68,459.39 714.52,459.39 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='507.68,381.32 714.52,381.32 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='507.68,303.26 714.52,303.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='507.68,225.19 714.52,225.19 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='507.68,147.13 714.52,147.13 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='507.68,69.06 714.52,69.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='537.22,492.55 537.22,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='586.47,492.55 586.47,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='635.72,492.55 635.72,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='684.97,492.55 684.97,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='537.22,237.23 586.47,327.01 635.72,207.71 684.97,60.03 684.97,210.92 635.72,374.10 586.47,433.00 537.22,394.99 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #F8766D; fill-opacity: 0.20;' />
+<polyline points='537.22,237.23 586.47,327.01 635.72,207.71 684.97,60.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='684.97,210.92 635.72,374.10 586.47,433.00 537.22,394.99 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polygon points='537.22,315.24 586.47,197.81 635.72,169.23 684.97,89.12 684.97,248.16 635.72,323.23 586.47,380.67 537.22,471.96 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #00BFC4; fill-opacity: 0.20;' />
+<polyline points='537.22,315.24 586.47,197.81 635.72,169.23 684.97,89.12 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='684.97,248.16 635.72,323.23 586.47,380.67 537.22,471.96 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='537.22,320.10 586.47,380.15 635.72,273.42 684.97,128.96 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='537.22,392.59 586.47,280.68 635.72,245.33 684.97,169.90 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<circle cx='537.22' cy='320.10' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='586.47' cy='380.15' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='635.72' cy='273.42' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='684.97' cy='128.96' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='537.22' cy='392.59' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='586.47' cy='280.68' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='635.72' cy='245.33' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='684.97' cy='169.90' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<rect x='507.68' y='39.43' width='206.85' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjIuNjR8MjM3LjM2fDIyLjc4fDM5LjQz'>
-    <rect x='22.64' y='22.78' width='214.71' height='16.65' />
+  <clipPath id='cpMjIuNjR8MjI5LjQ5fDIyLjc4fDM5LjQz'>
+    <rect x='22.64' y='22.78' width='206.85' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjIuNjR8MjM3LjM2fDIyLjc4fDM5LjQz)'>
-<rect x='22.64' y='22.78' width='214.71' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
-<text x='130.00' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='36.20px' lengthAdjust='spacingAndGlyphs'>Elevation</text>
+<g clip-path='url(#cpMjIuNjR8MjI5LjQ5fDIyLjc4fDM5LjQz)'>
+<rect x='22.64' y='22.78' width='206.85' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='126.07' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='36.20px' lengthAdjust='spacingAndGlyphs'>Elevation</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjYwLjAwfDQ3NC43MXwyMi43OHwzOS40Mw=='>
-    <rect x='260.00' y='22.78' width='214.71' height='16.65' />
+  <clipPath id='cpMjYzLjk0fDQ3MC43OHwyMi43OHwzOS40Mw=='>
+    <rect x='263.94' y='22.78' width='206.85' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjYwLjAwfDQ3NC43MXwyMi43OHwzOS40Mw==)'>
-<rect x='260.00' y='22.78' width='214.71' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<g clip-path='url(#cpMjYzLjk0fDQ3MC43OHwyMi43OHwzOS40Mw==)'>
+<rect x='263.94' y='22.78' width='206.85' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
 <text x='367.36' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='39.14px' lengthAdjust='spacingAndGlyphs'>Amplitude</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDk5LjgxfDcxNC41MnwyMi43OHwzOS40Mw=='>
-    <rect x='499.81' y='22.78' width='214.71' height='16.65' />
+  <clipPath id='cpNTA3LjY4fDcxNC41MnwyMi43OHwzOS40Mw=='>
+    <rect x='507.68' y='22.78' width='206.85' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDk5LjgxfDcxNC41MnwyMi43OHwzOS40Mw==)'>
-<rect x='499.81' y='22.78' width='214.71' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
-<text x='607.16' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='53.32px' lengthAdjust='spacingAndGlyphs'>Displacement</text>
+<g clip-path='url(#cpNTA3LjY4fDcxNC41MnwyMi43OHwzOS40Mw==)'>
+<rect x='507.68' y='22.78' width='206.85' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='611.10' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='53.32px' lengthAdjust='spacingAndGlyphs'>Displacement</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='53.32,495.29 53.32,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='104.44,495.29 104.44,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='155.56,495.29 155.56,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='206.68,495.29 206.68,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='53.32' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T1</text>
-<text x='104.44' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T2</text>
-<text x='155.56' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T3</text>
-<text x='206.68' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T4</text>
-<polyline points='290.67,495.29 290.67,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='341.80,495.29 341.80,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='392.92,495.29 392.92,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='444.04,495.29 444.04,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='290.67' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T1</text>
-<text x='341.80' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T2</text>
-<text x='392.92' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T3</text>
-<text x='444.04' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T4</text>
-<polyline points='530.48,495.29 530.48,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='581.60,495.29 581.60,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='632.73,495.29 632.73,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='683.85,495.29 683.85,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='530.48' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T1</text>
-<text x='581.60' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T2</text>
-<text x='632.73' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T3</text>
-<text x='683.85' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T4</text>
-<text x='494.88' y='462.41' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>340</text>
-<text x='494.88' y='384.35' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>350</text>
-<text x='494.88' y='306.29' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>360</text>
-<text x='494.88' y='228.22' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>370</text>
-<text x='494.88' y='150.16' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>380</text>
-<text x='494.88' y='72.09' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>390</text>
-<polyline points='497.07,459.39 499.81,459.39 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='497.07,381.32 499.81,381.32 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='497.07,303.26 499.81,303.26 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='497.07,225.19 499.81,225.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='497.07,147.13 499.81,147.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='497.07,69.06 499.81,69.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='255.07' y='384.80' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
-<text x='255.07' y='241.84' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='255.07' y='98.88' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.2</text>
-<polyline points='257.26,381.78 260.00,381.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='257.26,238.81 260.00,238.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='257.26,95.85 260.00,95.85 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='52.19,495.29 52.19,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='101.44,495.29 101.44,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='150.69,495.29 150.69,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='199.94,495.29 199.94,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='52.19' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T1</text>
+<text x='101.44' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T2</text>
+<text x='150.69' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T3</text>
+<text x='199.94' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T4</text>
+<polyline points='293.48,495.29 293.48,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='342.73,495.29 342.73,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='391.98,495.29 391.98,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='441.23,495.29 441.23,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='293.48' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T1</text>
+<text x='342.73' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T2</text>
+<text x='391.98' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T3</text>
+<text x='441.23' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T4</text>
+<polyline points='537.22,495.29 537.22,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='586.47,495.29 586.47,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='635.72,495.29 635.72,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='684.97,495.29 684.97,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='537.22' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T1</text>
+<text x='586.47' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T2</text>
+<text x='635.72' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T3</text>
+<text x='684.97' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T4</text>
+<text x='502.74' y='462.41' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>340</text>
+<text x='502.74' y='384.35' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>350</text>
+<text x='502.74' y='306.29' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>360</text>
+<text x='502.74' y='228.22' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>370</text>
+<text x='502.74' y='150.16' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>380</text>
+<text x='502.74' y='72.09' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>390</text>
+<polyline points='504.94,459.39 507.68,459.39 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='504.94,381.32 507.68,381.32 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='504.94,303.26 507.68,303.26 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='504.94,225.19 507.68,225.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='504.94,147.13 507.68,147.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='504.94,69.06 507.68,69.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='259.00' y='384.80' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='259.00' y='241.84' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='259.00' y='98.88' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<polyline points='261.20,381.78 263.94,381.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='261.20,238.81 263.94,238.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='261.20,95.85 263.94,95.85 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <text x='17.71' y='409.12' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.9</text>
 <text x='17.71' y='307.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
 <text x='17.71' y='205.68' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.1</text>

--- a/tests/testthat/_snaps/ssm_trajectory/trajectory-ungrouped.svg
+++ b/tests/testthat/_snaps/ssm_trajectory/trajectory-ungrouped.svg
@@ -18,242 +18,242 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<rect x='0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMjIuNjR8MjM0Ljc1fDM5LjQzfDI1NC45Mw=='>
-    <rect x='22.64' y='39.43' width='212.10' height='215.49' />
+  <clipPath id='cpMjIuNjR8MjI2Ljg4fDM5LjQzfDI1NC45Mw=='>
+    <rect x='22.64' y='39.43' width='204.24' height='215.49' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjIuNjR8MjM0Ljc1fDM5LjQzfDI1NC45Mw==)'>
-<rect x='22.64' y='39.43' width='212.10' height='215.49' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='22.64,223.68 234.75,223.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,156.46 234.75,156.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,89.25 234.75,89.25 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='52.95,254.93 52.95,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='103.45,254.93 103.45,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='153.95,254.93 153.95,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='204.45,254.93 204.45,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='52.95,100.83 103.45,59.17 153.95,49.23 204.45,134.88 204.45,245.13 153.95,183.72 103.45,167.98 52.95,207.57 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
-<polyline points='52.95,100.83 103.45,59.17 153.95,49.23 204.45,134.88 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='204.45,245.13 153.95,183.72 103.45,167.98 52.95,207.57 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='52.95,157.32 103.45,119.91 153.95,118.78 204.45,185.35 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='52.95' cy='157.32' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='103.45' cy='119.91' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='153.95' cy='118.78' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='204.45' cy='185.35' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='22.64' y='39.43' width='212.10' height='215.49' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMjIuNjR8MjI2Ljg4fDM5LjQzfDI1NC45Mw==)'>
+<rect x='22.64' y='39.43' width='204.24' height='215.49' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='22.64,223.68 226.88,223.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,156.46 226.88,156.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,89.25 226.88,89.25 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.82,254.93 51.82,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='100.45,254.93 100.45,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='149.08,254.93 149.08,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='197.70,254.93 197.70,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='51.82,100.83 100.45,59.17 149.08,49.23 197.70,134.88 197.70,245.13 149.08,183.72 100.45,167.98 51.82,207.57 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
+<polyline points='51.82,100.83 100.45,59.17 149.08,49.23 197.70,134.88 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='197.70,245.13 149.08,183.72 100.45,167.98 51.82,207.57 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='51.82,157.32 100.45,119.91 149.08,118.78 197.70,185.35 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='51.82' cy='157.32' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='100.45' cy='119.91' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='149.08' cy='118.78' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='197.70' cy='185.35' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='22.64' y='39.43' width='204.24' height='215.49' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjIuNjR8MjM0Ljc1fDI3Ny4wNnw0OTIuNTU='>
-    <rect x='22.64' y='277.06' width='212.10' height='215.49' />
+  <clipPath id='cpMjIuNjR8MjI2Ljg4fDI3Ny4wNnw0OTIuNTU='>
+    <rect x='22.64' y='277.06' width='204.24' height='215.49' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjIuNjR8MjM0Ljc1fDI3Ny4wNnw0OTIuNTU=)'>
-<rect x='22.64' y='277.06' width='212.10' height='215.49' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='22.64,464.80 234.75,464.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,418.96 234.75,418.96 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,373.11 234.75,373.11 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,327.27 234.75,327.27 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,281.42 234.75,281.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='52.95,492.55 52.95,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='103.45,492.55 103.45,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='153.95,492.55 153.95,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='204.45,492.55 204.45,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='52.95,364.58 103.45,346.28 153.95,286.85 204.45,310.74 204.45,416.33 153.95,378.45 103.45,453.86 52.95,482.76 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
-<polyline points='52.95,364.58 103.45,346.28 153.95,286.85 204.45,310.74 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='204.45,416.33 153.95,378.45 103.45,453.86 52.95,482.76 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='52.95,425.75 103.45,402.19 153.95,332.72 204.45,364.21 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='52.95' cy='425.75' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='103.45' cy='402.19' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='153.95' cy='332.72' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='204.45' cy='364.21' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='22.64' y='277.06' width='212.10' height='215.49' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMjIuNjR8MjI2Ljg4fDI3Ny4wNnw0OTIuNTU=)'>
+<rect x='22.64' y='277.06' width='204.24' height='215.49' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='22.64,464.80 226.88,464.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,418.96 226.88,418.96 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,373.11 226.88,373.11 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,327.27 226.88,327.27 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,281.42 226.88,281.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.82,492.55 51.82,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='100.45,492.55 100.45,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='149.08,492.55 149.08,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='197.70,492.55 197.70,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='51.82,364.58 100.45,346.28 149.08,286.85 197.70,310.74 197.70,416.33 149.08,378.45 100.45,453.86 51.82,482.76 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
+<polyline points='51.82,364.58 100.45,346.28 149.08,286.85 197.70,310.74 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='197.70,416.33 149.08,378.45 100.45,453.86 51.82,482.76 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='51.82,425.75 100.45,402.19 149.08,332.72 197.70,364.21 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='51.82' cy='425.75' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='100.45' cy='402.19' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='149.08' cy='332.72' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='197.70' cy='364.21' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='22.64' y='277.06' width='204.24' height='215.49' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjU5Ljg0fDQ3MS45NXwzOS40M3wyNTQuOTM='>
-    <rect x='259.84' y='39.43' width='212.10' height='215.49' />
+  <clipPath id='cpMjYzLjc4fDQ2OC4wMXwzOS40M3wyNTQuOTM='>
+    <rect x='263.78' y='39.43' width='204.24' height='215.49' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjU5Ljg0fDQ3MS45NXwzOS40M3wyNTQuOTM=)'>
-<rect x='259.84' y='39.43' width='212.10' height='215.49' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='259.84,225.55 471.95,225.55 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='259.84,178.90 471.95,178.90 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='259.84,132.25 471.95,132.25 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='259.84,85.60 471.95,85.60 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='290.14,254.93 290.14,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='340.64,254.93 340.64,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='391.15,254.93 391.15,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='441.65,254.93 441.65,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='290.14,128.98 340.64,108.55 391.15,49.23 441.65,101.75 441.65,198.06 391.15,143.15 340.64,214.44 290.14,245.13 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
-<polyline points='290.14,128.98 340.64,108.55 391.15,49.23 441.65,101.75 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='441.65,198.06 391.15,143.15 340.64,214.44 290.14,245.13 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='290.14,188.57 340.64,162.63 391.15,93.60 441.65,151.42 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='290.14' cy='188.57' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='340.64' cy='162.63' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='391.15' cy='93.60' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='441.65' cy='151.42' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='259.84' y='39.43' width='212.10' height='215.49' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMjYzLjc4fDQ2OC4wMXwzOS40M3wyNTQuOTM=)'>
+<rect x='263.78' y='39.43' width='204.24' height='215.49' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='263.78,225.55 468.01,225.55 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='263.78,178.90 468.01,178.90 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='263.78,132.25 468.01,132.25 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='263.78,85.60 468.01,85.60 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='292.95,254.93 292.95,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='341.58,254.93 341.58,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='390.21,254.93 390.21,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='438.84,254.93 438.84,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='292.95,128.98 341.58,108.55 390.21,49.23 438.84,101.75 438.84,198.06 390.21,143.15 341.58,214.44 292.95,245.13 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
+<polyline points='292.95,128.98 341.58,108.55 390.21,49.23 438.84,101.75 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='438.84,198.06 390.21,143.15 341.58,214.44 292.95,245.13 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='292.95,188.57 341.58,162.63 390.21,93.60 438.84,151.42 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='292.95' cy='188.57' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='341.58' cy='162.63' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='390.21' cy='93.60' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='438.84' cy='151.42' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='263.78' y='39.43' width='204.24' height='215.49' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjU5Ljg0fDQ3MS45NXwyNzcuMDZ8NDkyLjU1'>
-    <rect x='259.84' y='277.06' width='212.10' height='215.49' />
+  <clipPath id='cpMjYzLjc4fDQ2OC4wMXwyNzcuMDZ8NDkyLjU1'>
+    <rect x='263.78' y='277.06' width='204.24' height='215.49' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjU5Ljg0fDQ3MS45NXwyNzcuMDZ8NDkyLjU1)'>
-<rect x='259.84' y='277.06' width='212.10' height='215.49' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='259.84,460.92 471.95,460.92 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='259.84,412.93 471.95,412.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='259.84,364.93 471.95,364.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='259.84,316.94 471.95,316.94 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='290.14,492.55 290.14,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='340.64,492.55 340.64,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='391.15,492.55 391.15,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='441.65,492.55 441.65,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='290.14,409.42 340.64,396.07 391.15,357.68 441.65,286.85 441.65,352.01 391.15,424.10 340.64,459.10 290.14,482.76 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
-<polyline points='290.14,409.42 340.64,396.07 391.15,357.68 441.65,286.85 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='441.65,352.01 391.15,424.10 340.64,459.10 290.14,482.76 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='290.14,444.80 340.64,429.55 391.15,385.87 441.65,317.70 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='290.14' cy='444.80' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
-<circle cx='340.64' cy='429.55' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
-<circle cx='391.15' cy='385.87' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
-<circle cx='441.65' cy='317.70' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
-<rect x='259.84' y='277.06' width='212.10' height='215.49' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMjYzLjc4fDQ2OC4wMXwyNzcuMDZ8NDkyLjU1)'>
+<rect x='263.78' y='277.06' width='204.24' height='215.49' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='263.78,460.92 468.01,460.92 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='263.78,412.93 468.01,412.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='263.78,364.93 468.01,364.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='263.78,316.94 468.01,316.94 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='292.95,492.55 292.95,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='341.58,492.55 341.58,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='390.21,492.55 390.21,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='438.84,492.55 438.84,277.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='292.95,409.42 341.58,396.07 390.21,357.68 438.84,286.85 438.84,352.01 390.21,424.10 341.58,459.10 292.95,482.76 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
+<polyline points='292.95,409.42 341.58,396.07 390.21,357.68 438.84,286.85 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='438.84,352.01 390.21,424.10 341.58,459.10 292.95,482.76 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='292.95,444.80 341.58,429.55 390.21,385.87 438.84,317.70 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='292.95' cy='444.80' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<circle cx='341.58' cy='429.55' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<circle cx='390.21' cy='385.87' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<circle cx='438.84' cy='317.70' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<rect x='263.78' y='277.06' width='204.24' height='215.49' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNTAyLjQyfDcxNC41MnwzOS40M3wyNTQuOTM='>
-    <rect x='502.42' y='39.43' width='212.10' height='215.49' />
+  <clipPath id='cpNTEwLjI4fDcxNC41MnwzOS40M3wyNTQuOTM='>
+    <rect x='510.28' y='39.43' width='204.24' height='215.49' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNTAyLjQyfDcxNC41MnwzOS40M3wyNTQuOTM=)'>
-<rect x='502.42' y='39.43' width='212.10' height='215.49' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='502.42,252.06 714.52,252.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='502.42,180.29 714.52,180.29 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='502.42,108.51 714.52,108.51 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='532.72,254.93 532.72,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='583.22,254.93 583.22,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='633.72,254.93 633.72,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='684.22,254.93 684.22,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='532.72,177.13 583.22,164.56 633.72,118.01 684.22,49.23 684.22,120.86 633.72,193.52 583.22,228.51 532.72,245.13 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
-<polyline points='532.72,177.13 583.22,164.56 633.72,118.01 684.22,49.23 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='684.22,120.86 633.72,193.52 583.22,228.51 532.72,245.13 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='532.72,209.68 583.22,196.53 633.72,149.60 684.22,80.95 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='532.72' cy='209.68' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='583.22' cy='196.53' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='633.72' cy='149.60' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='684.22' cy='80.95' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='502.42' y='39.43' width='212.10' height='215.49' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpNTEwLjI4fDcxNC41MnwzOS40M3wyNTQuOTM=)'>
+<rect x='510.28' y='39.43' width='204.24' height='215.49' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='510.28,252.06 714.52,252.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='510.28,180.29 714.52,180.29 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='510.28,108.51 714.52,108.51 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='539.46,254.93 539.46,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='588.09,254.93 588.09,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='636.72,254.93 636.72,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='685.34,254.93 685.34,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='539.46,177.13 588.09,164.56 636.72,118.01 685.34,49.23 685.34,120.86 636.72,193.52 588.09,228.51 539.46,245.13 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
+<polyline points='539.46,177.13 588.09,164.56 636.72,118.01 685.34,49.23 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='685.34,120.86 636.72,193.52 588.09,228.51 539.46,245.13 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='539.46,209.68 588.09,196.53 636.72,149.60 685.34,80.95 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='539.46' cy='209.68' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='588.09' cy='196.53' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='636.72' cy='149.60' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='685.34' cy='80.95' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='510.28' y='39.43' width='204.24' height='215.49' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjIuNjR8MjM0Ljc1fDI2MC40MXwyNzcuMDY='>
-    <rect x='22.64' y='260.41' width='212.10' height='16.65' />
+  <clipPath id='cpMjIuNjR8MjI2Ljg4fDI2MC40MXwyNzcuMDY='>
+    <rect x='22.64' y='260.41' width='204.24' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjIuNjR8MjM0Ljc1fDI2MC40MXwyNzcuMDY=)'>
-<rect x='22.64' y='260.41' width='212.10' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
-<text x='128.70' y='271.76' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='39.14px' lengthAdjust='spacingAndGlyphs'>Amplitude</text>
+<g clip-path='url(#cpMjIuNjR8MjI2Ljg4fDI2MC40MXwyNzcuMDY=)'>
+<rect x='22.64' y='260.41' width='204.24' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='124.76' y='271.76' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='39.14px' lengthAdjust='spacingAndGlyphs'>Amplitude</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjU5Ljg0fDQ3MS45NXwyNjAuNDF8Mjc3LjA2'>
-    <rect x='259.84' y='260.41' width='212.10' height='16.65' />
+  <clipPath id='cpMjYzLjc4fDQ2OC4wMXwyNjAuNDF8Mjc3LjA2'>
+    <rect x='263.78' y='260.41' width='204.24' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjU5Ljg0fDQ3MS45NXwyNjAuNDF8Mjc3LjA2)'>
-<rect x='259.84' y='260.41' width='212.10' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<g clip-path='url(#cpMjYzLjc4fDQ2OC4wMXwyNjAuNDF8Mjc3LjA2)'>
+<rect x='263.78' y='260.41' width='204.24' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
 <text x='365.90' y='271.76' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='53.32px' lengthAdjust='spacingAndGlyphs'>Displacement</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjIuNjR8MjM0Ljc1fDIyLjc4fDM5LjQz'>
-    <rect x='22.64' y='22.78' width='212.10' height='16.65' />
+  <clipPath id='cpMjIuNjR8MjI2Ljg4fDIyLjc4fDM5LjQz'>
+    <rect x='22.64' y='22.78' width='204.24' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjIuNjR8MjM0Ljc1fDIyLjc4fDM5LjQz)'>
-<rect x='22.64' y='22.78' width='212.10' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
-<text x='128.70' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='36.20px' lengthAdjust='spacingAndGlyphs'>Elevation</text>
+<g clip-path='url(#cpMjIuNjR8MjI2Ljg4fDIyLjc4fDM5LjQz)'>
+<rect x='22.64' y='22.78' width='204.24' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='124.76' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='36.20px' lengthAdjust='spacingAndGlyphs'>Elevation</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjU5Ljg0fDQ3MS45NXwyMi43OHwzOS40Mw=='>
-    <rect x='259.84' y='22.78' width='212.10' height='16.65' />
+  <clipPath id='cpMjYzLjc4fDQ2OC4wMXwyMi43OHwzOS40Mw=='>
+    <rect x='263.78' y='22.78' width='204.24' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjU5Ljg0fDQ3MS45NXwyMi43OHwzOS40Mw==)'>
-<rect x='259.84' y='22.78' width='212.10' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<g clip-path='url(#cpMjYzLjc4fDQ2OC4wMXwyMi43OHwzOS40Mw==)'>
+<rect x='263.78' y='22.78' width='204.24' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
 <text x='365.90' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='29.84px' lengthAdjust='spacingAndGlyphs'>X-value</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNTAyLjQyfDcxNC41MnwyMi43OHwzOS40Mw=='>
-    <rect x='502.42' y='22.78' width='212.10' height='16.65' />
+  <clipPath id='cpNTEwLjI4fDcxNC41MnwyMi43OHwzOS40Mw=='>
+    <rect x='510.28' y='22.78' width='204.24' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNTAyLjQyfDcxNC41MnwyMi43OHwzOS40Mw==)'>
-<rect x='502.42' y='22.78' width='212.10' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
-<text x='608.47' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='29.84px' lengthAdjust='spacingAndGlyphs'>Y-value</text>
+<g clip-path='url(#cpNTEwLjI4fDcxNC41MnwyMi43OHwzOS40Mw==)'>
+<rect x='510.28' y='22.78' width='204.24' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='612.40' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='29.84px' lengthAdjust='spacingAndGlyphs'>Y-value</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='52.95,495.29 52.95,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='103.45,495.29 103.45,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='153.95,495.29 153.95,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='204.45,495.29 204.45,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='52.95' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T1</text>
-<text x='103.45' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T2</text>
-<text x='153.95' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T3</text>
-<text x='204.45' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T4</text>
-<polyline points='290.14,495.29 290.14,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='340.64,495.29 340.64,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='391.15,495.29 391.15,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='441.65,495.29 441.65,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='290.14' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T1</text>
-<text x='340.64' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T2</text>
-<text x='391.15' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T3</text>
-<text x='441.65' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T4</text>
-<polyline points='532.72,257.67 532.72,254.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='583.22,257.67 583.22,254.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='633.72,257.67 633.72,254.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='684.22,257.67 684.22,254.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='532.72' y='265.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T1</text>
-<text x='583.22' y='265.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T2</text>
-<text x='633.72' y='265.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T3</text>
-<text x='684.22' y='265.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T4</text>
-<text x='497.49' y='255.09' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.25</text>
-<text x='497.49' y='183.32' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
-<text x='497.49' y='111.54' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
-<polyline points='499.68,252.06 502.42,252.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='499.68,180.29 502.42,180.29 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='499.68,108.51 502.42,108.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='254.91' y='228.58' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
-<text x='254.91' y='181.93' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.9</text>
-<text x='254.91' y='135.27' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='254.91' y='88.62' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.1</text>
-<polyline points='257.10,225.55 259.84,225.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='257.10,178.90 259.84,178.90 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='257.10,132.25 259.84,132.25 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='257.10,85.60 259.84,85.60 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='254.91' y='463.95' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>350</text>
-<text x='254.91' y='415.96' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>360</text>
-<text x='254.91' y='367.96' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>370</text>
-<text x='254.91' y='319.96' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>380</text>
-<polyline points='257.10,460.92 259.84,460.92 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='257.10,412.93 259.84,412.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='257.10,364.93 259.84,364.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='257.10,316.94 259.84,316.94 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='51.82,495.29 51.82,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='100.45,495.29 100.45,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='149.08,495.29 149.08,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='197.70,495.29 197.70,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='51.82' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T1</text>
+<text x='100.45' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T2</text>
+<text x='149.08' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T3</text>
+<text x='197.70' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T4</text>
+<polyline points='292.95,495.29 292.95,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='341.58,495.29 341.58,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='390.21,495.29 390.21,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='438.84,495.29 438.84,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='292.95' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T1</text>
+<text x='341.58' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T2</text>
+<text x='390.21' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T3</text>
+<text x='438.84' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T4</text>
+<polyline points='539.46,257.67 539.46,254.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='588.09,257.67 588.09,254.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='636.72,257.67 636.72,254.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='685.34,257.67 685.34,254.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='539.46' y='265.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T1</text>
+<text x='588.09' y='265.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T2</text>
+<text x='636.72' y='265.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T3</text>
+<text x='685.34' y='265.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>T4</text>
+<text x='505.35' y='255.09' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.25</text>
+<text x='505.35' y='183.32' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='505.35' y='111.54' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<polyline points='507.54,252.06 510.28,252.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='507.54,180.29 510.28,180.29 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='507.54,108.51 510.28,108.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='258.85' y='228.58' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='258.85' y='181.93' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='258.85' y='135.27' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='258.85' y='88.62' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.1</text>
+<polyline points='261.04,225.55 263.78,225.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='261.04,178.90 263.78,178.90 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='261.04,132.25 263.78,132.25 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='261.04,85.60 263.78,85.60 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='258.85' y='463.95' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>350</text>
+<text x='258.85' y='415.96' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>360</text>
+<text x='258.85' y='367.96' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>370</text>
+<text x='258.85' y='319.96' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>380</text>
+<polyline points='261.04,460.92 263.78,460.92 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='261.04,412.93 263.78,412.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='261.04,364.93 263.78,364.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='261.04,316.94 263.78,316.94 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <text x='17.71' y='226.70' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.9</text>
 <text x='17.71' y='159.49' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
 <text x='17.71' y='92.28' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.1</text>

--- a/tests/testthat/_snaps/ssm_trajectory_table/trajectory-table-no-certification.svg
+++ b/tests/testthat/_snaps/ssm_trajectory_table/trajectory-table-no-certification.svg
@@ -21,115 +21,115 @@
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMjIuNjR8MzU2LjA0fDM5LjQzfDUzMS43NQ=='>
-    <rect x='22.64' y='39.43' width='333.39' height='492.32' />
+  <clipPath id='cpMjIuNjR8MzUwLjE0fDM5LjQzfDUzMS43NQ=='>
+    <rect x='22.64' y='39.43' width='327.49' height='492.32' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjIuNjR8MzU2LjA0fDM5LjQzfDUzMS43NQ==)'>
-<rect x='22.64' y='39.43' width='333.39' height='492.32' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='22.64,509.37 356.04,509.37 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,381.50 356.04,381.50 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,253.62 356.04,253.62 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,125.75 356.04,125.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='37.80,531.75 37.80,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='113.57,531.75 113.57,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='189.34,531.75 189.34,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='265.11,531.75 265.11,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='340.88,531.75 340.88,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='37.80,100.17 113.57,164.11 189.34,202.47 265.11,125.75 340.88,61.81 340.88,368.71 265.11,432.65 189.34,509.37 113.57,471.01 37.80,407.07 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
-<polyline points='37.80,100.17 113.57,164.11 189.34,202.47 265.11,125.75 340.88,61.81 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='340.88,368.71 265.11,432.65 189.34,509.37 113.57,471.01 37.80,407.07 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='37.80,253.62 113.57,317.56 189.34,355.92 265.11,279.20 340.88,215.26 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='37.80' cy='253.62' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='113.57' cy='317.56' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='189.34' cy='355.92' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='265.11' cy='279.20' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='340.88' cy='215.26' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='22.64' y='39.43' width='333.39' height='492.32' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMjIuNjR8MzUwLjE0fDM5LjQzfDUzMS43NQ==)'>
+<rect x='22.64' y='39.43' width='327.49' height='492.32' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='22.64,509.37 350.14,509.37 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,381.50 350.14,381.50 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,253.62 350.14,253.62 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,125.75 350.14,125.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='37.53,531.75 37.53,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='111.96,531.75 111.96,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='186.39,531.75 186.39,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.82,531.75 260.82,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='335.25,531.75 335.25,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='37.53,100.17 111.96,164.11 186.39,202.47 260.82,125.75 335.25,61.81 335.25,368.71 260.82,432.65 186.39,509.37 111.96,471.01 37.53,407.07 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
+<polyline points='37.53,100.17 111.96,164.11 186.39,202.47 260.82,125.75 335.25,61.81 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='335.25,368.71 260.82,432.65 186.39,509.37 111.96,471.01 37.53,407.07 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='37.53,253.62 111.96,317.56 186.39,355.92 260.82,279.20 335.25,215.26 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='37.53' cy='253.62' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='111.96' cy='317.56' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='186.39' cy='355.92' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='260.82' cy='279.20' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='335.25' cy='215.26' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='22.64' y='39.43' width='327.49' height='492.32' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzgxLjEzfDcxNC41MnwzOS40M3w1MzEuNzU='>
-    <rect x='381.13' y='39.43' width='333.39' height='492.32' />
+  <clipPath id='cpMzg3LjAzfDcxNC41MnwzOS40M3w1MzEuNzU='>
+    <rect x='387.03' y='39.43' width='327.49' height='492.32' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzgxLjEzfDcxNC41MnwzOS40M3w1MzEuNzU=)'>
-<rect x='381.13' y='39.43' width='333.39' height='492.32' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='381.13,509.37 714.52,509.37 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='381.13,402.81 714.52,402.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='381.13,296.25 714.52,296.25 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='381.13,189.69 714.52,189.69 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='381.13,83.12 714.52,83.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='396.28,531.75 396.28,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='472.05,531.75 472.05,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='547.83,531.75 547.83,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='623.60,531.75 623.60,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='699.37,531.75 699.37,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='396.28,296.25 472.05,242.97 547.83,168.37 623.60,104.44 699.37,61.81 699.37,274.94 623.60,317.56 547.83,381.50 472.05,456.09 396.28,509.37 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
-<polyline points='396.28,296.25 472.05,242.97 547.83,168.37 623.60,104.44 699.37,61.81 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='699.37,274.94 623.60,317.56 547.83,381.50 472.05,456.09 396.28,509.37 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='396.28,402.81 472.05,349.53 547.83,274.94 623.60,211.00 699.37,168.37 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='396.28' cy='402.81' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='472.05' cy='349.53' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='547.83' cy='274.94' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='623.60' cy='211.00' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='699.37' cy='168.37' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='381.13' y='39.43' width='333.39' height='492.32' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMzg3LjAzfDcxNC41MnwzOS40M3w1MzEuNzU=)'>
+<rect x='387.03' y='39.43' width='327.49' height='492.32' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='387.03,509.37 714.52,509.37 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='387.03,402.81 714.52,402.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='387.03,296.25 714.52,296.25 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='387.03,189.69 714.52,189.69 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='387.03,83.12 714.52,83.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='401.92,531.75 401.92,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='476.35,531.75 476.35,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='550.78,531.75 550.78,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='625.21,531.75 625.21,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='699.63,531.75 699.63,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='401.92,296.25 476.35,242.97 550.78,168.37 625.21,104.44 699.63,61.81 699.63,274.94 625.21,317.56 550.78,381.50 476.35,456.09 401.92,509.37 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
+<polyline points='401.92,296.25 476.35,242.97 550.78,168.37 625.21,104.44 699.63,61.81 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='699.63,274.94 625.21,317.56 550.78,381.50 476.35,456.09 401.92,509.37 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='401.92,402.81 476.35,349.53 550.78,274.94 625.21,211.00 699.63,168.37 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='401.92' cy='402.81' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='476.35' cy='349.53' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='550.78' cy='274.94' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='625.21' cy='211.00' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='699.63' cy='168.37' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='387.03' y='39.43' width='327.49' height='492.32' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjIuNjR8MzU2LjA0fDIyLjc4fDM5LjQz'>
-    <rect x='22.64' y='22.78' width='333.39' height='16.65' />
+  <clipPath id='cpMjIuNjR8MzUwLjE0fDIyLjc4fDM5LjQz'>
+    <rect x='22.64' y='22.78' width='327.49' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjIuNjR8MzU2LjA0fDIyLjc4fDM5LjQz)'>
-<rect x='22.64' y='22.78' width='333.39' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
-<text x='189.34' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='39.14px' lengthAdjust='spacingAndGlyphs'>Amplitude</text>
+<g clip-path='url(#cpMjIuNjR8MzUwLjE0fDIyLjc4fDM5LjQz)'>
+<rect x='22.64' y='22.78' width='327.49' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='186.39' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='39.14px' lengthAdjust='spacingAndGlyphs'>Amplitude</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzgxLjEzfDcxNC41MnwyMi43OHwzOS40Mw=='>
-    <rect x='381.13' y='22.78' width='333.39' height='16.65' />
+  <clipPath id='cpMzg3LjAzfDcxNC41MnwyMi43OHwzOS40Mw=='>
+    <rect x='387.03' y='22.78' width='327.49' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzgxLjEzfDcxNC41MnwyMi43OHwzOS40Mw==)'>
-<rect x='381.13' y='22.78' width='333.39' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
-<text x='547.83' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='53.32px' lengthAdjust='spacingAndGlyphs'>Displacement</text>
+<g clip-path='url(#cpMzg3LjAzfDcxNC41MnwyMi43OHwzOS40Mw==)'>
+<rect x='387.03' y='22.78' width='327.49' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='550.78' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='53.32px' lengthAdjust='spacingAndGlyphs'>Displacement</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='37.80,534.49 37.80,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='113.57,534.49 113.57,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='189.34,534.49 189.34,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='265.11,534.49 265.11,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='340.88,534.49 340.88,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='37.80' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='113.57' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='189.34' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='265.11' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='340.88' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
-<polyline points='396.28,534.49 396.28,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='472.05,534.49 472.05,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='547.83,534.49 547.83,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='623.60,534.49 623.60,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='699.37,534.49 699.37,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='396.28' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='472.05' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='547.83' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='623.60' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='699.37' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='376.20' y='512.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>340</text>
-<text x='376.20' y='405.84' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>350</text>
-<text x='376.20' y='299.28' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>360</text>
-<text x='376.20' y='192.71' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>370</text>
-<text x='376.20' y='86.15' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>380</text>
-<polyline points='378.39,509.37 381.13,509.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.39,402.81 381.13,402.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.39,296.25 381.13,296.25 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.39,189.69 381.13,189.69 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.39,83.12 381.13,83.12 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.53,534.49 37.53,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='111.96,534.49 111.96,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='186.39,534.49 186.39,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='260.82,534.49 260.82,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='335.25,534.49 335.25,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='37.53' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='111.96' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='186.39' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='260.82' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='335.25' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polyline points='401.92,534.49 401.92,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='476.35,534.49 476.35,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='550.78,534.49 550.78,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='625.21,534.49 625.21,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='699.63,534.49 699.63,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='401.92' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='476.35' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='550.78' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='625.21' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='699.63' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='382.10' y='512.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>340</text>
+<text x='382.10' y='405.84' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>350</text>
+<text x='382.10' y='299.28' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>360</text>
+<text x='382.10' y='192.71' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>370</text>
+<text x='382.10' y='86.15' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>380</text>
+<polyline points='384.29,509.37 387.03,509.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.29,402.81 387.03,402.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.29,296.25 387.03,296.25 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.29,189.69 387.03,189.69 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.29,83.12 387.03,83.12 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <text x='17.71' y='512.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
 <text x='17.71' y='384.53' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='17.71' y='256.65' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>

--- a/tests/testthat/_snaps/ssm_trajectory_table/trajectory-table-uncertified.svg
+++ b/tests/testthat/_snaps/ssm_trajectory_table/trajectory-table-uncertified.svg
@@ -21,115 +21,115 @@
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMjIuNjR8MzU2LjA0fDM5LjQzfDQ5Mi41NQ=='>
-    <rect x='22.64' y='39.43' width='333.39' height='453.12' />
+  <clipPath id='cpMjIuNjR8MzUwLjE0fDM5LjQzfDQ5Mi41NQ=='>
+    <rect x='22.64' y='39.43' width='327.49' height='453.12' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjIuNjR8MzU2LjA0fDM5LjQzfDQ5Mi41NQ==)'>
-<rect x='22.64' y='39.43' width='333.39' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='22.64,471.96 356.04,471.96 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,354.26 356.04,354.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,236.57 356.04,236.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,118.88 356.04,118.88 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='37.80,492.55 37.80,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='113.57,492.55 113.57,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='189.34,492.55 189.34,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='265.11,492.55 265.11,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='340.88,492.55 340.88,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='37.80,95.34 113.57,154.18 189.34,189.49 265.11,118.88 340.88,60.03 340.88,342.49 265.11,401.34 189.34,471.96 113.57,436.65 37.80,377.80 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
-<polyline points='37.80,95.34 113.57,154.18 189.34,189.49 265.11,118.88 340.88,60.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='340.88,342.49 265.11,401.34 189.34,471.96 113.57,436.65 37.80,377.80 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='37.80,236.57 113.57,295.42 189.34,330.72 265.11,260.11 340.88,201.26 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='37.80' cy='236.57' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='113.57' cy='295.42' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='189.34' cy='330.72' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='265.11' cy='260.11' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='340.88' cy='201.26' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='22.64' y='39.43' width='333.39' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMjIuNjR8MzUwLjE0fDM5LjQzfDQ5Mi41NQ==)'>
+<rect x='22.64' y='39.43' width='327.49' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='22.64,471.96 350.14,471.96 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,354.26 350.14,354.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,236.57 350.14,236.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,118.88 350.14,118.88 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='37.53,492.55 37.53,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='111.96,492.55 111.96,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='186.39,492.55 186.39,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.82,492.55 260.82,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='335.25,492.55 335.25,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='37.53,95.34 111.96,154.18 186.39,189.49 260.82,118.88 335.25,60.03 335.25,342.49 260.82,401.34 186.39,471.96 111.96,436.65 37.53,377.80 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
+<polyline points='37.53,95.34 111.96,154.18 186.39,189.49 260.82,118.88 335.25,60.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='335.25,342.49 260.82,401.34 186.39,471.96 111.96,436.65 37.53,377.80 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='37.53,236.57 111.96,295.42 186.39,330.72 260.82,260.11 335.25,201.26 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='37.53' cy='236.57' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='111.96' cy='295.42' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='186.39' cy='330.72' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='260.82' cy='260.11' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='335.25' cy='201.26' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='22.64' y='39.43' width='327.49' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzgxLjEzfDcxNC41MnwzOS40M3w0OTIuNTU='>
-    <rect x='381.13' y='39.43' width='333.39' height='453.12' />
+  <clipPath id='cpMzg3LjAzfDcxNC41MnwzOS40M3w0OTIuNTU='>
+    <rect x='387.03' y='39.43' width='327.49' height='453.12' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzgxLjEzfDcxNC41MnwzOS40M3w0OTIuNTU=)'>
-<rect x='381.13' y='39.43' width='333.39' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='381.13,471.96 714.52,471.96 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='381.13,373.88 714.52,373.88 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='381.13,275.80 714.52,275.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='381.13,177.72 714.52,177.72 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='381.13,79.65 714.52,79.65 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='396.28,492.55 396.28,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='472.05,492.55 472.05,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='547.83,492.55 547.83,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='623.60,492.55 623.60,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='699.37,492.55 699.37,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='396.28,275.80 472.05,226.76 547.83,158.11 623.60,99.26 699.37,60.03 699.37,256.19 623.60,295.42 547.83,354.26 472.05,422.92 396.28,471.96 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
-<polyline points='396.28,275.80 472.05,226.76 547.83,158.11 623.60,99.26 699.37,60.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='699.37,256.19 623.60,295.42 547.83,354.26 472.05,422.92 396.28,471.96 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='396.28,373.88 472.05,324.84 547.83,256.19 623.60,197.34 699.37,158.11 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='396.28' cy='373.88' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
-<circle cx='472.05' cy='324.84' r='2.49' style='stroke-width: 0.71;' />
-<circle cx='547.83' cy='256.19' r='2.49' style='stroke-width: 0.71;' />
-<circle cx='623.60' cy='197.34' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
-<circle cx='699.37' cy='158.11' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
-<rect x='381.13' y='39.43' width='333.39' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMzg3LjAzfDcxNC41MnwzOS40M3w0OTIuNTU=)'>
+<rect x='387.03' y='39.43' width='327.49' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='387.03,471.96 714.52,471.96 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='387.03,373.88 714.52,373.88 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='387.03,275.80 714.52,275.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='387.03,177.72 714.52,177.72 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='387.03,79.65 714.52,79.65 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='401.92,492.55 401.92,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='476.35,492.55 476.35,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='550.78,492.55 550.78,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='625.21,492.55 625.21,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='699.63,492.55 699.63,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='401.92,275.80 476.35,226.76 550.78,158.11 625.21,99.26 699.63,60.03 699.63,256.19 625.21,295.42 550.78,354.26 476.35,422.92 401.92,471.96 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
+<polyline points='401.92,275.80 476.35,226.76 550.78,158.11 625.21,99.26 699.63,60.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='699.63,256.19 625.21,295.42 550.78,354.26 476.35,422.92 401.92,471.96 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='401.92,373.88 476.35,324.84 550.78,256.19 625.21,197.34 699.63,158.11 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='401.92' cy='373.88' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<circle cx='476.35' cy='324.84' r='2.49' style='stroke-width: 0.71;' />
+<circle cx='550.78' cy='256.19' r='2.49' style='stroke-width: 0.71;' />
+<circle cx='625.21' cy='197.34' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<circle cx='699.63' cy='158.11' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<rect x='387.03' y='39.43' width='327.49' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjIuNjR8MzU2LjA0fDIyLjc4fDM5LjQz'>
-    <rect x='22.64' y='22.78' width='333.39' height='16.65' />
+  <clipPath id='cpMjIuNjR8MzUwLjE0fDIyLjc4fDM5LjQz'>
+    <rect x='22.64' y='22.78' width='327.49' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjIuNjR8MzU2LjA0fDIyLjc4fDM5LjQz)'>
-<rect x='22.64' y='22.78' width='333.39' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
-<text x='189.34' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='39.14px' lengthAdjust='spacingAndGlyphs'>Amplitude</text>
+<g clip-path='url(#cpMjIuNjR8MzUwLjE0fDIyLjc4fDM5LjQz)'>
+<rect x='22.64' y='22.78' width='327.49' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='186.39' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='39.14px' lengthAdjust='spacingAndGlyphs'>Amplitude</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzgxLjEzfDcxNC41MnwyMi43OHwzOS40Mw=='>
-    <rect x='381.13' y='22.78' width='333.39' height='16.65' />
+  <clipPath id='cpMzg3LjAzfDcxNC41MnwyMi43OHwzOS40Mw=='>
+    <rect x='387.03' y='22.78' width='327.49' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzgxLjEzfDcxNC41MnwyMi43OHwzOS40Mw==)'>
-<rect x='381.13' y='22.78' width='333.39' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
-<text x='547.83' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='53.32px' lengthAdjust='spacingAndGlyphs'>Displacement</text>
+<g clip-path='url(#cpMzg3LjAzfDcxNC41MnwyMi43OHwzOS40Mw==)'>
+<rect x='387.03' y='22.78' width='327.49' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='550.78' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='53.32px' lengthAdjust='spacingAndGlyphs'>Displacement</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='37.80,495.29 37.80,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='113.57,495.29 113.57,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='189.34,495.29 189.34,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='265.11,495.29 265.11,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='340.88,495.29 340.88,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='37.80' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='113.57' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='189.34' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='265.11' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='340.88' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
-<polyline points='396.28,495.29 396.28,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='472.05,495.29 472.05,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='547.83,495.29 547.83,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='623.60,495.29 623.60,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='699.37,495.29 699.37,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='396.28' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='472.05' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='547.83' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='623.60' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='699.37' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='376.20' y='474.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>340</text>
-<text x='376.20' y='376.91' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>350</text>
-<text x='376.20' y='278.83' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>360</text>
-<text x='376.20' y='180.75' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>370</text>
-<text x='376.20' y='82.67' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>380</text>
-<polyline points='378.39,471.96 381.13,471.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.39,373.88 381.13,373.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.39,275.80 381.13,275.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.39,177.72 381.13,177.72 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.39,79.65 381.13,79.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.53,495.29 37.53,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='111.96,495.29 111.96,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='186.39,495.29 186.39,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='260.82,495.29 260.82,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='335.25,495.29 335.25,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='37.53' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='111.96' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='186.39' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='260.82' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='335.25' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polyline points='401.92,495.29 401.92,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='476.35,495.29 476.35,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='550.78,495.29 550.78,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='625.21,495.29 625.21,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='699.63,495.29 699.63,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='401.92' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='476.35' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='550.78' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='625.21' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='699.63' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='382.10' y='474.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>340</text>
+<text x='382.10' y='376.91' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>350</text>
+<text x='382.10' y='278.83' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>360</text>
+<text x='382.10' y='180.75' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>370</text>
+<text x='382.10' y='82.67' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>380</text>
+<polyline points='384.29,471.96 387.03,471.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.29,373.88 387.03,373.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.29,275.80 387.03,275.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.29,177.72 387.03,177.72 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.29,79.65 387.03,79.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <text x='17.71' y='474.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
 <text x='17.71' y='357.29' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='17.71' y='239.60' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>

--- a/tests/testthat/_snaps/ssm_trajectory_table/trajectory-table.svg
+++ b/tests/testthat/_snaps/ssm_trajectory_table/trajectory-table.svg
@@ -21,115 +21,115 @@
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMjIuNjR8MzU2LjA0fDM5LjQzfDQ5Mi41NQ=='>
-    <rect x='22.64' y='39.43' width='333.39' height='453.12' />
+  <clipPath id='cpMjIuNjR8MzUwLjE0fDM5LjQzfDQ5Mi41NQ=='>
+    <rect x='22.64' y='39.43' width='327.49' height='453.12' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjIuNjR8MzU2LjA0fDM5LjQzfDQ5Mi41NQ==)'>
-<rect x='22.64' y='39.43' width='333.39' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='22.64,471.96 356.04,471.96 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,354.26 356.04,354.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,236.57 356.04,236.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='22.64,118.88 356.04,118.88 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='37.80,492.55 37.80,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='113.57,492.55 113.57,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='189.34,492.55 189.34,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='265.11,492.55 265.11,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='340.88,492.55 340.88,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='37.80,95.34 113.57,154.18 189.34,189.49 265.11,118.88 340.88,60.03 340.88,342.49 265.11,401.34 189.34,471.96 113.57,436.65 37.80,377.80 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
-<polyline points='37.80,95.34 113.57,154.18 189.34,189.49 265.11,118.88 340.88,60.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='340.88,342.49 265.11,401.34 189.34,471.96 113.57,436.65 37.80,377.80 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='37.80,236.57 113.57,295.42 189.34,330.72 265.11,260.11 340.88,201.26 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='37.80' cy='236.57' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='113.57' cy='295.42' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='189.34' cy='330.72' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='265.11' cy='260.11' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='340.88' cy='201.26' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='22.64' y='39.43' width='333.39' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMjIuNjR8MzUwLjE0fDM5LjQzfDQ5Mi41NQ==)'>
+<rect x='22.64' y='39.43' width='327.49' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='22.64,471.96 350.14,471.96 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,354.26 350.14,354.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,236.57 350.14,236.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='22.64,118.88 350.14,118.88 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='37.53,492.55 37.53,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='111.96,492.55 111.96,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='186.39,492.55 186.39,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.82,492.55 260.82,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='335.25,492.55 335.25,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='37.53,95.34 111.96,154.18 186.39,189.49 260.82,118.88 335.25,60.03 335.25,342.49 260.82,401.34 186.39,471.96 111.96,436.65 37.53,377.80 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
+<polyline points='37.53,95.34 111.96,154.18 186.39,189.49 260.82,118.88 335.25,60.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='335.25,342.49 260.82,401.34 186.39,471.96 111.96,436.65 37.53,377.80 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='37.53,236.57 111.96,295.42 186.39,330.72 260.82,260.11 335.25,201.26 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='37.53' cy='236.57' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='111.96' cy='295.42' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='186.39' cy='330.72' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='260.82' cy='260.11' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='335.25' cy='201.26' r='2.49' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='22.64' y='39.43' width='327.49' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzgxLjEzfDcxNC41MnwzOS40M3w0OTIuNTU='>
-    <rect x='381.13' y='39.43' width='333.39' height='453.12' />
+  <clipPath id='cpMzg3LjAzfDcxNC41MnwzOS40M3w0OTIuNTU='>
+    <rect x='387.03' y='39.43' width='327.49' height='453.12' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzgxLjEzfDcxNC41MnwzOS40M3w0OTIuNTU=)'>
-<rect x='381.13' y='39.43' width='333.39' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='381.13,471.96 714.52,471.96 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='381.13,373.88 714.52,373.88 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='381.13,275.80 714.52,275.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='381.13,177.72 714.52,177.72 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='381.13,79.65 714.52,79.65 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='396.28,492.55 396.28,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='472.05,492.55 472.05,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='547.83,492.55 547.83,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='623.60,492.55 623.60,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='699.37,492.55 699.37,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='396.28,275.80 472.05,226.76 547.83,158.11 623.60,99.26 699.37,60.03 699.37,256.19 623.60,295.42 547.83,354.26 472.05,422.92 396.28,471.96 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
-<polyline points='396.28,275.80 472.05,226.76 547.83,158.11 623.60,99.26 699.37,60.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='699.37,256.19 623.60,295.42 547.83,354.26 472.05,422.92 396.28,471.96 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='396.28,373.88 472.05,324.84 547.83,256.19 623.60,197.34 699.37,158.11 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='396.28' cy='373.88' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
-<circle cx='472.05' cy='324.84' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
-<circle cx='547.83' cy='256.19' r='2.49' style='stroke-width: 0.71;' />
-<circle cx='623.60' cy='197.34' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
-<circle cx='699.37' cy='158.11' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
-<rect x='381.13' y='39.43' width='333.39' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMzg3LjAzfDcxNC41MnwzOS40M3w0OTIuNTU=)'>
+<rect x='387.03' y='39.43' width='327.49' height='453.12' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='387.03,471.96 714.52,471.96 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='387.03,373.88 714.52,373.88 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='387.03,275.80 714.52,275.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='387.03,177.72 714.52,177.72 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='387.03,79.65 714.52,79.65 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='401.92,492.55 401.92,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='476.35,492.55 476.35,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='550.78,492.55 550.78,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='625.21,492.55 625.21,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='699.63,492.55 699.63,39.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='401.92,275.80 476.35,226.76 550.78,158.11 625.21,99.26 699.63,60.03 699.63,256.19 625.21,295.42 550.78,354.26 476.35,422.92 401.92,471.96 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.20;' />
+<polyline points='401.92,275.80 476.35,226.76 550.78,158.11 625.21,99.26 699.63,60.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='699.63,256.19 625.21,295.42 550.78,354.26 476.35,422.92 401.92,471.96 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='401.92,373.88 476.35,324.84 550.78,256.19 625.21,197.34 699.63,158.11 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='401.92' cy='373.88' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<circle cx='476.35' cy='324.84' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<circle cx='550.78' cy='256.19' r='2.49' style='stroke-width: 0.71;' />
+<circle cx='625.21' cy='197.34' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<circle cx='699.63' cy='158.11' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<rect x='387.03' y='39.43' width='327.49' height='453.12' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjIuNjR8MzU2LjA0fDIyLjc4fDM5LjQz'>
-    <rect x='22.64' y='22.78' width='333.39' height='16.65' />
+  <clipPath id='cpMjIuNjR8MzUwLjE0fDIyLjc4fDM5LjQz'>
+    <rect x='22.64' y='22.78' width='327.49' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjIuNjR8MzU2LjA0fDIyLjc4fDM5LjQz)'>
-<rect x='22.64' y='22.78' width='333.39' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
-<text x='189.34' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='39.14px' lengthAdjust='spacingAndGlyphs'>Amplitude</text>
+<g clip-path='url(#cpMjIuNjR8MzUwLjE0fDIyLjc4fDM5LjQz)'>
+<rect x='22.64' y='22.78' width='327.49' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='186.39' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='39.14px' lengthAdjust='spacingAndGlyphs'>Amplitude</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzgxLjEzfDcxNC41MnwyMi43OHwzOS40Mw=='>
-    <rect x='381.13' y='22.78' width='333.39' height='16.65' />
+  <clipPath id='cpMzg3LjAzfDcxNC41MnwyMi43OHwzOS40Mw=='>
+    <rect x='387.03' y='22.78' width='327.49' height='16.65' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzgxLjEzfDcxNC41MnwyMi43OHwzOS40Mw==)'>
-<rect x='381.13' y='22.78' width='333.39' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
-<text x='547.83' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='53.32px' lengthAdjust='spacingAndGlyphs'>Displacement</text>
+<g clip-path='url(#cpMzg3LjAzfDcxNC41MnwyMi43OHwzOS40Mw==)'>
+<rect x='387.03' y='22.78' width='327.49' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='550.78' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='53.32px' lengthAdjust='spacingAndGlyphs'>Displacement</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='37.80,495.29 37.80,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='113.57,495.29 113.57,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='189.34,495.29 189.34,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='265.11,495.29 265.11,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='340.88,495.29 340.88,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='37.80' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='113.57' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='189.34' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='265.11' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='340.88' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
-<polyline points='396.28,495.29 396.28,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='472.05,495.29 472.05,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='547.83,495.29 547.83,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='623.60,495.29 623.60,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='699.37,495.29 699.37,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='396.28' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='472.05' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='547.83' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='623.60' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='699.37' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='376.20' y='474.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>340</text>
-<text x='376.20' y='376.91' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>350</text>
-<text x='376.20' y='278.83' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>360</text>
-<text x='376.20' y='180.75' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>370</text>
-<text x='376.20' y='82.67' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>380</text>
-<polyline points='378.39,471.96 381.13,471.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.39,373.88 381.13,373.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.39,275.80 381.13,275.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.39,177.72 381.13,177.72 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.39,79.65 381.13,79.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.53,495.29 37.53,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='111.96,495.29 111.96,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='186.39,495.29 186.39,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='260.82,495.29 260.82,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='335.25,495.29 335.25,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='37.53' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='111.96' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='186.39' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='260.82' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='335.25' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polyline points='401.92,495.29 401.92,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='476.35,495.29 476.35,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='550.78,495.29 550.78,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='625.21,495.29 625.21,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='699.63,495.29 699.63,492.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='401.92' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='476.35' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='550.78' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='625.21' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='699.63' y='503.54' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='382.10' y='474.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>340</text>
+<text x='382.10' y='376.91' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>350</text>
+<text x='382.10' y='278.83' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>360</text>
+<text x='382.10' y='180.75' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>370</text>
+<text x='382.10' y='82.67' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>380</text>
+<polyline points='384.29,471.96 387.03,471.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.29,373.88 387.03,373.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.29,275.80 387.03,275.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.29,177.72 387.03,177.72 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.29,79.65 387.03,79.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <text x='17.71' y='474.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
 <text x='17.71' y='357.29' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='17.71' y='239.60' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>

--- a/vignettes/advanced-visualization.Rmd
+++ b/vignettes/advanced-visualization.Rmd
@@ -70,13 +70,16 @@ spokes in the order of the angles:
 ggcircumplex(octants(), labels = PANO())
 ```
 
-If you are working with one of the instruments bundled with the package, you can
-pass it directly and the scale angles and abbreviations are taken from the
-instrument:
+The labels need not be abbreviations. The octant scales have full interpersonal
+names, and passing those labels the spokes with them instead:
 
-```{r canvas-instrument}
-ggcircumplex(instrument = csip)
+```{r canvas-descriptive}
+ggcircumplex(octants(), labels = csip$Scales$Label)
 ```
+
+If you are working with one of the instruments bundled with the package, you can
+pass it directly with `ggcircumplex(instrument = csip)`, and its scale angles and
+abbreviations are taken from the instrument rather than typed by hand.
 
 Throughout, displacement runs counterclockwise from the right, and the
 0/360 degree position is labeled 360.
@@ -85,29 +88,18 @@ Throughout, displacement runs counterclockwise from the right, and the
 
 `ggcircumplex()` is a convenience wrapper. Underneath it, the piece that makes a
 circumplex plot circular is `coord_circumplex()`, and you can add that to a bare
-`ggplot()` yourself when you want to build a figure from scratch:
+`ggplot()` yourself when you want to build a figure from scratch. On top of the
+coordinate system you supply three things: an x-scale carrying the spoke breaks
+and labels, a data layer, and the theme.
 
-```{r coord-bare}
+```{r coord-built}
 results <- ssm_analyze(
   jz2017,
   scales = PANO(),
   measures = c("NARPD", "ASPD")
 )
-results$results[, c("Label", "a_est", "d_est", "a_lci", "a_uci")]
+subset(results$results, select = c(Label, a_est, d_est, a_lci, a_uci))
 
-ggplot(results$results) +
-  coord_circumplex(amax = 0.3) +
-  geom_ssm_point(aes(amplitude = a_est, displacement = d_est, fill = Label)) +
-  theme_circumplex()
-```
-
-That is the minimum: a coordinate system and a layer. It is also visibly
-unfinished --- the spokes fall on `ggplot2`'s default axis breaks (0, 100, 200,
-300) rather than on the circumplex scale angles, because a bare coordinate
-system has not been told what the scales are. Supplying those breaks and labels
-is the missing piece:
-
-```{r coord-bare-scaled}
 ggplot(results$results) +
   coord_circumplex(amax = 0.3) +
   scale_x_continuous(breaks = octants(), labels = PANO()) +
@@ -115,11 +107,12 @@ ggplot(results$results) +
   theme_circumplex()
 ```
 
-The only difference between those two figures is that second line: the spoke
-breaks and their scale labels. Supplying them, along with the theme, is what
-`ggcircumplex()` does on top of the coordinate system. Build from the parts when
-you want to vary one of those pieces; reach for `ggcircumplex()` when you do
-not.
+The `scale_x_continuous()` line is the one that tells the coordinate system
+where the scale angles are; without it the spokes would fall on `ggplot2`'s
+default breaks rather than on the octants. Supplying those breaks and labels,
+along with the theme, is what `ggcircumplex()` does on top of the coordinate
+system. Build from the parts when you want to vary one of those pieces; reach
+for `ggcircumplex()` when you do not.
 
 Because the coordinate system owns the amplitude-to-radius mapping, `amax` is
 set exactly once per plot and the canvas and the data layers cannot disagree
@@ -232,43 +225,6 @@ ggcircumplex(octants(), labels = PANO(), amax = 0.3) +
   )
 ```
 
-## Extending the layers
-
-The `ggplot2` objects behind the layers and the coordinate system ---
-`GeomSsmPoint`, `GeomSsmArc`, and `CoordCircumplex` --- are exported, so you can
-subclass them the same way you would subclass any `ggplot2` geom. This is the
-route to a reusable layer with your own defaults, rather than repeating the same
-arguments at every call site.
-
-```{r subclass}
-GeomSsmStar <- ggproto("GeomSsmStar", GeomSsmPoint,
-  default_aes = modifyList(
-    GeomSsmPoint$default_aes,
-    list(shape = 23, size = 5, fill = "#D55E00", colour = "black")
-  )
-)
-
-geom_ssm_star <- function(mapping = NULL, data = NULL, ...) {
-  layer(
-    geom = GeomSsmStar, mapping = mapping, data = data,
-    stat = "identity", position = "identity",
-    inherit.aes = FALSE, params = list(...)
-  )
-}
-
-ggcircumplex(octants(), labels = PANO(), amax = 0.3) +
-  geom_ssm_star(
-    data = results$results,
-    mapping = aes(amplitude = a_est, displacement = d_est)
-  )
-```
-
-Everything the parent geom does --- mapping amplitude and displacement onto the
-positional aesthetics, and dropping profiles with no defined location --- is
-inherited; only the defaults change. The polar transform itself is not part of
-the geom: as above, `coord_circumplex()` owns it, which is why the subclass
-needs no circular arithmetic of its own.
-
 ## Composing custom layers
 
 Because the canvas and geoms are ordinary `ggplot2` objects, you can add
@@ -286,7 +242,7 @@ people <- ssm_score(
   scales = PANO(),
   append = FALSE
 )
-people <- people[!is.na(people$Disp), ]
+people <- subset(people, !is.na(Disp))
 
 # Group-level profile for the same subset
 group <- ssm_analyze(jz2017[1:100, ], scales = PANO())
@@ -327,36 +283,41 @@ data) estimates one SSM profile per occasion, resampling persons so that
 within-person dependence across occasions is respected.
 `ssm_plot_trajectory()` then draws each SSM parameter against time.
 
-Here is a small simulated three-wave data set whose group profile rotates
-counterclockwise across the 0/360 degree boundary, which is the case worth
-seeing drawn:
+Here is a small simulated three-wave data set, `long`, whose group profile
+rotates counterclockwise across the 0/360 degree boundary --- the case worth
+seeing drawn. (The code that simulates it is omitted; it is not the point here.
+The data frame has one row per person per wave, the eight `PANO()` scale
+columns, an `id`, and a `wave` label.) We estimate one profile per wave with
+`ssm_analyze_long()`:
 
-```{r occasions-data}
+```{r occasions-data-sim, echo = FALSE}
+# Simulation machinery, hidden: each wave is the group cosine signal at a known
+# displacement, plus a stable per-person offset and fresh noise.
 angles <- octants()
 n <- 200
-waves <- c(T1 = 330, T2 = 355, T3 = 20) # true displacement at each wave
-elevation <- rnorm(n) * 0.5 # per-person offset, stable across waves
-
-long <- do.call(rbind, lapply(names(waves), function(w) {
-  # Group signal at this wave, plus the stable person offset and fresh noise
+waves <- c(T1 = 330, T2 = 355, T3 = 20)
+elevation <- rnorm(n) * 0.5
+make_wave <- function(w) {
   signal <- 0.6 * cos((angles - waves[[w]]) * pi / 180)
-  scores <- matrix(signal, nrow = n, ncol = length(angles), byrow = TRUE) +
-    elevation +
-    matrix(rnorm(n * length(angles), sd = 0.5), nrow = n)
+  scores <- matrix(signal, n, length(angles), byrow = TRUE) +
+    elevation + matrix(rnorm(n * length(angles), sd = 0.5), n)
   out <- as.data.frame(scores)
   names(out) <- PANO()
   out$id <- seq_len(n)
   out$wave <- w
   out
-}))
+}
+long <- rbind(make_wave("T1"), make_wave("T2"), make_wave("T3"))
+```
 
+```{r occasions-data}
 results_long <- ssm_analyze_long(
   long,
   scales = PANO(),
   id = "id",
   occasion = "wave"
 )
-results_long$results[, c("Occasion", "a_est", "d_est", "d_lci", "d_uci")]
+subset(results_long$results, select = c(Occasion, a_est, d_est, d_lci, d_uci))
 ```
 
 ```{r occasions-plot, fig.height = 6}

--- a/vignettes/advanced-visualization.Rmd
+++ b/vignettes/advanced-visualization.Rmd
@@ -70,8 +70,8 @@ spokes in the order of the angles:
 ggcircumplex(octants(), labels = PANO())
 ```
 
-The labels need not be abbreviations. The octant scales have full interpersonal
-names, and passing those labels the spokes with them instead:
+The labels need not be abbreviations. The octant scales also have full
+interpersonal names, which you can put on the spokes instead:
 
 ```{r canvas-descriptive}
 ggcircumplex(octants(), labels = csip$Scales$Label)
@@ -367,7 +367,7 @@ amplitude and displacement of a single occasion are split across two panels.
 change in (amplitude, displacement) reads as movement through circumplex space.
 
 ```{r occasions-path}
-ggcircumplex(angles, amax = 0.8) +
+ggcircumplex(octants(), amax = 0.8) +
   geom_ssm_point(
     data = results_long$results,
     mapping = aes(amplitude = a_est, displacement = d_est),


### PR DESCRIPTION
Reworks `vignettes/advanced-visualization.Rmd` for non-expert readers and fixes the trajectory panel-label crowding it surfaced.

- Descriptive full scale-name spokes replace the identical-labels `instrument = csip` example
- Cut the deliberately-broken default-breaks coordinate figure; lead with the correct construction
- Remove the "Extending the layers" ggproto-subclass section
- Simplify visible base-R (`subset()`); hide the occasions simulation in a non-echoed chunk
- `ssm_trajectory_ggplot()` gains `panel.spacing.x` so free-y panel axis labels clear their neighbours (5 vdiffr baselines regenerated)

Local `devtools::check(args = "--no-manual")`: 0 errors / 0 warnings / 0 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)