### PR TITLE
Speed up CI: concurrency cancel, paths-ignore, slimmed PR matrix

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,10 +5,18 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+    paths-ignore:
+      - 'cairn/**'
+      - 'man/**'
+      - 'README.md'
 
 name: R-CMD-check.yaml
 
 permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   R-CMD-check:
@@ -19,12 +27,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
+        # On pull_request run a single fast Ubuntu/release job; the full
+        # platform/version matrix runs on push to main/master (see M51).
+        config: ${{ github.event_name == 'pull_request'
+          && fromJSON('[{"os":"ubuntu-latest","r":"release"}]')
+          || fromJSON('[{"os":"macos-latest","r":"release"},{"os":"windows-latest","r":"release"},{"os":"ubuntu-latest","r":"devel","http-user-agent":"release"},{"os":"ubuntu-latest","r":"release"},{"os":"ubuntu-latest","r":"oldrel-1"}]') }}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -5,10 +5,18 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+    paths-ignore:
+      - 'cairn/**'
+      - 'man/**'
+      - 'README.md'
 
 name: test-coverage.yaml
 
 permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-coverage:

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38 | high | milestones/M7-v2-release-prep.md |
-| M51 | Speed up CI — concurrency, paths-ignore, slimmed PR matrix | in-progress | — | normal | milestones/M51-ci-speedup.md |
+| M51 | Speed up CI — concurrency, paths-ignore, slimmed PR matrix | review | — | normal | milestones/M51-ci-speedup.md |
 | M50 | Advanced Visualization vignette — rework for a less-advanced audience | done | — | normal | milestones/archive/M50-viz-vignette-approachable.md |
 | M49 | Fit-index guidance — the two source-backed caveats | done | — | normal | milestones/archive/M49-fitindex-source-caveats.md |
 | M47 | SSM estimator source notes (Wright 2009 + defining Gurtman) | done | — | normal | milestones/archive/M47-estimator-source-notes.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38 | high | milestones/M7-v2-release-prep.md |
-| M51 | Speed up CI — concurrency, paths-ignore, slimmed PR matrix | planned | — | normal | milestones/M51-ci-speedup.md |
+| M51 | Speed up CI — concurrency, paths-ignore, slimmed PR matrix | in-progress | — | normal | milestones/M51-ci-speedup.md |
 | M50 | Advanced Visualization vignette — rework for a less-advanced audience | done | — | normal | milestones/archive/M50-viz-vignette-approachable.md |
 | M49 | Fit-index guidance — the two source-backed caveats | done | — | normal | milestones/archive/M49-fitindex-source-caveats.md |
 | M47 | SSM estimator source notes (Wright 2009 + defining Gurtman) | done | — | normal | milestones/archive/M47-estimator-source-notes.md |

--- a/cairn/milestones/M51-ci-speedup.md
+++ b/cairn/milestones/M51-ci-speedup.md
@@ -2,12 +2,12 @@
      section ownership". A phase skill never rewrites another phase's section. -->
 # M51: Speed up CI — concurrency cancel, paths-ignore, slimmed PR matrix
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** m51-ci-speedup
+- **Branch/PR:** m51-ci-speedup · https://github.com/jmgirard/circumplex/pull/77
 
 ## Goal
 
@@ -66,7 +66,7 @@ No package code, no dependency add/remove/re-pin.
       expression (PR → 1 config; else the current 5).
 - [x] T2 `test-coverage.yaml`: add the same `paths-ignore` to its
       `pull_request` trigger and the same top-level `concurrency` block.
-- [ ] T3 Validate: `yaml::read_yaml()` each of the four workflow files clean;
+- [x] T3 Validate: `yaml::read_yaml()` each of the four workflow files clean;
       confirm `git diff` is scoped to the intended lines only; open the PR.
 
 ## Work log
@@ -74,6 +74,7 @@ No package code, no dependency add/remove/re-pin.
 - 2026-07-21: created by /milestone-plan.
 - 2026-07-21: T1 — R-CMD-check.yaml gets concurrency (cancel-in-progress:true), paths-ignore [cairn/**,man/**,README.md] on pull_request, and github.event_name-conditional matrix (PR=1 ubuntu/release; else full 5). yaml::read_yaml() parses clean; folded matrix scalar verified.
 - 2026-07-21: T2 — test-coverage.yaml gets the same concurrency block and paths-ignore; push trigger and job body unchanged. yaml::read_yaml() clean.
+- 2026-07-21: T3 — all four workflows parse; diff scoped to concurrency/paths-ignore/matrix only (pkgdown/pr-commands untouched). Branch pushed; PR #77 opened. Status → review.
 
 ## Decisions
 

--- a/cairn/milestones/M51-ci-speedup.md
+++ b/cairn/milestones/M51-ci-speedup.md
@@ -64,7 +64,7 @@ No package code, no dependency add/remove/re-pin.
       add the top-level `concurrency` block, and replace the static
       `matrix.config` with the `github.event_name`-conditional `fromJSON`
       expression (PR → 1 config; else the current 5).
-- [ ] T2 `test-coverage.yaml`: add the same `paths-ignore` to its
+- [x] T2 `test-coverage.yaml`: add the same `paths-ignore` to its
       `pull_request` trigger and the same top-level `concurrency` block.
 - [ ] T3 Validate: `yaml::read_yaml()` each of the four workflow files clean;
       confirm `git diff` is scoped to the intended lines only; open the PR.
@@ -73,6 +73,7 @@ No package code, no dependency add/remove/re-pin.
 
 - 2026-07-21: created by /milestone-plan.
 - 2026-07-21: T1 — R-CMD-check.yaml gets concurrency (cancel-in-progress:true), paths-ignore [cairn/**,man/**,README.md] on pull_request, and github.event_name-conditional matrix (PR=1 ubuntu/release; else full 5). yaml::read_yaml() parses clean; folded matrix scalar verified.
+- 2026-07-21: T2 — test-coverage.yaml gets the same concurrency block and paths-ignore; push trigger and job body unchanged. yaml::read_yaml() clean.
 
 ## Decisions
 

--- a/cairn/milestones/M51-ci-speedup.md
+++ b/cairn/milestones/M51-ci-speedup.md
@@ -60,7 +60,7 @@ No package code, no dependency add/remove/re-pin.
 
 ## Tasks
 
-- [ ] T1 `R-CMD-check.yaml`: add `paths-ignore` to the `pull_request` trigger,
+- [x] T1 `R-CMD-check.yaml`: add `paths-ignore` to the `pull_request` trigger,
       add the top-level `concurrency` block, and replace the static
       `matrix.config` with the `github.event_name`-conditional `fromJSON`
       expression (PR → 1 config; else the current 5).
@@ -72,6 +72,7 @@ No package code, no dependency add/remove/re-pin.
 ## Work log
 
 - 2026-07-21: created by /milestone-plan.
+- 2026-07-21: T1 — R-CMD-check.yaml gets concurrency (cancel-in-progress:true), paths-ignore [cairn/**,man/**,README.md] on pull_request, and github.event_name-conditional matrix (PR=1 ubuntu/release; else full 5). yaml::read_yaml() parses clean; folded matrix scalar verified.
 
 ## Decisions
 

--- a/cairn/milestones/M51-ci-speedup.md
+++ b/cairn/milestones/M51-ci-speedup.md
@@ -35,18 +35,18 @@ No package code, no dependency add/remove/re-pin.
 
 ## Acceptance criteria
 
-- [ ] AC1 `R-CMD-check.yaml` and `test-coverage.yaml` each carry a top-level
+- [x] AC1 `R-CMD-check.yaml` and `test-coverage.yaml` each carry a top-level
       `concurrency` block with `group: ${{ github.workflow }}-${{ github.ref }}`
       and `cancel-in-progress: true`. Evidence: grep both files.
-- [ ] AC2 Both workflows' `pull_request:` trigger carries
+- [x] AC2 Both workflows' `pull_request:` trigger carries
       `paths-ignore: ['cairn/**', 'man/**', 'README.md']` (and `**/*.Rmd` is
       absent). Evidence: grep both files.
-- [ ] AC3 `R-CMD-check.yaml`'s `matrix.config` resolves to exactly one config
+- [x] AC3 `R-CMD-check.yaml`'s `matrix.config` resolves to exactly one config
       (`ubuntu-latest`, `release`) when `github.event_name == 'pull_request'`
       and to the original 5-config list otherwise. Evidence: the conditional
       expression in the file, plus this milestone's own PR showing a single
       `R-CMD-check` job while a full run appears on the post-merge master push.
-- [ ] AC4 All four `.github/workflows/*.yaml` parse as valid YAML and the diff
+- [x] AC4 All four `.github/workflows/*.yaml` parse as valid YAML and the diff
       changes only the concurrency / trigger / matrix lines (every existing
       step, `permissions`, and env unchanged). Evidence: `yaml::read_yaml()`
       on each file clean + scoped `git diff`.
@@ -79,3 +79,17 @@ No package code, no dependency add/remove/re-pin.
 ## Decisions
 
 ## Review
+
+_2026-07-21 (/milestone-review). Branch `m51-ci-speedup` cut from master 241eb107; master == origin/master (not stale)._
+
+**Acceptance criteria — fresh evidence:**
+- AC1 ✓ `concurrency` block (`group: ${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`) present in both `R-CMD-check.yaml:17-19` and `test-coverage.yaml:17-19` (grep).
+- AC2 ✓ `paths-ignore: [cairn/**, man/**, README.md]` under the `pull_request` trigger of both workflows (`:8-11`); `Rmd` grep count = 0 in both (the deliberately-dropped `**/*.Rmd`).
+- AC3 ✓ Conditional `matrix.config` expression present (`R-CMD-check.yaml:32`); parsed folded scalar resolves to 1 config on PR / the original 5 otherwise. **Live confirmation:** PR #77 CI spawned exactly one R-CMD-check job, `ubuntu-latest (release)` — no macOS/Windows/devel/oldrel. Post-merge full matrix is the `|| fromJSON(5-config)` branch (verified by parse + reviewer), manifesting on the merge push.
+- AC4 ✓ All four `.github/workflows/*.yaml` parse under `yaml::read_yaml()`; branch diff scoped to only the 2 workflows + ROADMAP + milestone file; every existing step/`permissions`/env unchanged.
+
+**Consistency gate:**
+- Universal: `cairn_validate` exit 0 — all checks PASS (incl. `coverage complete`, `mirror agreement`, `at most one in-progress`, `weight caps`). 47 WARNs are M7's pre-existing work-log-format advisories, untouched. No IP/GP change → `cairn_impact` skipped.
+- Toolchain (r-package `consistency-gate`): `.github` is `.Rbuildignore`d (`^\.github$`), so the built package tarball is byte-identical to master — `document()` no-diff, generated-files, pkgdown, and README-knit checks are provably unaffected (no R/roxygen/data in the diff). No user-visible change → no NEWS entry owed. Authoritative full `R CMD check` = PR #77's own R-CMD-check CI, required green before merge.
+
+**Fresh-context review (scoped):** 2-file Rbuildignored YAML diff. Ran the substantive **[O] diff-bug lens** (Opus, fresh context) — **no defects**; independently verified the folded conditional-matrix scalar, the concurrency group (distinct refs → no cross-cancellation of push vs PR runs), paths-ignore placement, and that PR-config `http-user-agent` resolves empty exactly as 4/5 original configs already did. **Blame-history lens** handled inline: every changed line is net-new additive config; the full 5-config matrix is preserved on push, so no prior deliberate work is undone. **Prior-PR-comments lens** handled inline: documented permanent no-op in this repo (LESSONS M33; no archived `## Review` touches `.github/`). Zero findings → nothing to score or triage.

--- a/cairn/milestones/M51-ci-speedup.md
+++ b/cairn/milestones/M51-ci-speedup.md
@@ -2,12 +2,12 @@
      section ownership". A phase skill never rewrites another phase's section. -->
 # M51: Speed up CI — concurrency cancel, paths-ignore, slimmed PR matrix
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** m51-ci-speedup
 
 ## Goal
 


### PR DESCRIPTION
Three low-risk config changes to the two check workflows to cut redundant GitHub Actions runtime, without reducing what the default branch verifies.

## Changes
1. **Concurrency cancel** — `concurrency` block (`group: workflow-ref`, `cancel-in-progress: true`) on `R-CMD-check.yaml` and `test-coverage.yaml`, so a superseding push cancels the in-flight run instead of leaving stale runs burning.
2. **paths-ignore** on the `pull_request` trigger of both workflows: `['cairn/**', 'man/**', 'README.md']` — tracking-only and generated-doc commits no longer re-trigger the matrix. (`**/*.Rmd` deliberately excluded so vignette/README-source changes still get a full check pre-merge.)
3. **Slimmed PR matrix** — `R-CMD-check.yaml` runs a single `ubuntu-latest` / `release` job on `pull_request`; the full 5-config platform/version matrix is unchanged on push to `main`/`master`.

## Notes
- No package code, no dependency add/remove/re-pin. `pkgdown.yaml` and `pr-commands.yaml` untouched.
- `master` is not a protected branch, so `paths-ignore` carries no "required check never reports" risk.
- The per-run dependency-install cost (heavy Suggests via `needs: check`) is a separate, higher-risk follow-up, captured as a roadmap candidate rather than folded in here.
- This PR's own R-CMD-check run should show a **single** job, demonstrating change (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)