### PR TITLE
M55: Axes-Reliability vignette — teaching axes_reliability()

### DIFF
--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |
-| M55 | Axes-Reliability vignette — teaching `axes_reliability()` | planned | M54 | normal | milestones/M55-axes-reliability-vignette.md |
+| M55 | Axes-Reliability vignette — teaching `axes_reliability()` | in-progress | M54 | normal | milestones/M55-axes-reliability-vignette.md |
 | M54 | Axes-reliability (Strack 2013) build — `axes_reliability()` | done | — | normal | milestones/archive/M54-axes-reliability-build.md |
 | M53 | Axes-reliability (Strack 2013) — design spec + GO/NO-GO | done | — | normal | milestones/archive/M53-axes-reliability-design.md |
 | M52 | Trim brms/Stan from CI dependency installs | done | — | normal | milestones/archive/M52-ci-install-trim-brms.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |
-| M55 | Axes-Reliability vignette — teaching `axes_reliability()` | in-progress | M54 | normal | milestones/M55-axes-reliability-vignette.md |
+| M55 | Axes-Reliability vignette — teaching `axes_reliability()` | review | M54 | normal | milestones/M55-axes-reliability-vignette.md |
 | M54 | Axes-reliability (Strack 2013) build — `axes_reliability()` | done | — | normal | milestones/archive/M54-axes-reliability-build.md |
 | M53 | Axes-reliability (Strack 2013) — design spec + GO/NO-GO | done | — | normal | milestones/archive/M53-axes-reliability-design.md |
 | M52 | Trim brms/Stan from CI dependency installs | done | — | normal | milestones/archive/M52-ci-install-trim-brms.md |

--- a/cairn/milestones/M55-axes-reliability-vignette.md
+++ b/cairn/milestones/M55-axes-reliability-vignette.md
@@ -1,6 +1,6 @@
 # M55: Axes-Reliability vignette — teaching `axes_reliability()`
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** M54
 - **Driving RR:** —
@@ -69,12 +69,13 @@ cross-references them.
 - [x] T2: Worked-example section — `data("simulated_items")`, build the items list (`split(names(simulated_items), rep(1:8, each = 4))`), call `axes_reliability(..., angles = octants())`, show `res`; cross-reference the `instrument =` convenience path without running it (no 500-row registered instrument in the package).
 - [x] T3: Interpretation section — `summary(res)` (variance components + global fit), reading the per-axis reliability, SEm, and `nb_reliability` table; why X and Y match for a balanced octant instrument (differ only via `item_n`).
 - [x] T4: Caveats section — the three doc-level caveats (AC4) in precise prose, each naming its source (Strack et al. 2013; Cudeck 1989); no significance-test language for any CI (CLAUDE.md style; DECISIONS.md D-entry on vignette wording).
-- [ ] T5: Build + register — knit locally, confirm lavaan-absent build path, `tools::buildVignettes()` + `devtools::check(args = "--no-manual")` clean; confirm pkgdown auto-discovers the article (no `_pkgdown.yml` articles list to edit).
+- [x] T5: Build + register — knit locally, confirm lavaan-absent build path, `tools::buildVignettes()` + `devtools::check(args = "--no-manual")` clean; confirm pkgdown auto-discovers the article (no `_pkgdown.yml` articles list to edit).
 
 ## Work log
 
 - 2026-07-23: created by /milestone-plan (focused scope: teach `axes_reliability()`; lineage D-025 → D-026 → M53 design → M54 build → M55 docs).
 - 2026-07-23: T1–T4 — wrote `vignettes/axes-reliability.Rmd` (motivation, worked example on `simulated_items`, component/NB interpretation, three caveats). Knits clean with lavaan present (23 KB) and with lavaan forced absent (note shown, no fit output leaked).
+- 2026-07-23: T5 — `devtools::check(args = "--no-manual")` clean (0 errors, 0 warnings, 0 notes; 6m28s); vignette builds under R CMD check and is auto-registered (no `_pkgdown.yml` edit needed). All tasks done → status `review`.
 
 ## Decisions
 

--- a/cairn/milestones/M55-axes-reliability-vignette.md
+++ b/cairn/milestones/M55-axes-reliability-vignette.md
@@ -1,6 +1,6 @@
 # M55: Axes-Reliability vignette — teaching `axes_reliability()`
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** M54
 - **Driving RR:** —
@@ -65,15 +65,16 @@ cross-references them.
 
 ## Tasks
 
-- [ ] T1: Create `vignettes/axes-reliability.Rmd` — YAML + `VignetteIndexEntry{Axes Reliability}`, the lavaan-gating setup chunk and absent-lavaan note copied from `sem-based-ssm-analysis.Rmd:10-25`, and the opening motivation (what axis reliability is; when to reach for it vs. `fit_structure()`/`ssm_sem()`).
-- [ ] T2: Worked-example section — `data("simulated_items")`, build the items list (`split(names(simulated_items), rep(1:8, each = 4))`), call `axes_reliability(..., angles = octants())`, show `res`; cross-reference the `instrument =` convenience path without running it (no 500-row registered instrument in the package).
-- [ ] T3: Interpretation section — `summary(res)` (variance components + global fit), reading the per-axis reliability, SEm, and `nb_reliability` table; why X and Y match for a balanced octant instrument (differ only via `item_n`).
-- [ ] T4: Caveats section — the three doc-level caveats (AC4) in precise prose, each naming its source (Strack et al. 2013; Cudeck 1989); no significance-test language for any CI (CLAUDE.md style; DECISIONS.md D-entry on vignette wording).
+- [x] T1: Create `vignettes/axes-reliability.Rmd` — YAML + `VignetteIndexEntry{Axes Reliability}`, the lavaan-gating setup chunk and absent-lavaan note copied from `sem-based-ssm-analysis.Rmd:10-25`, and the opening motivation (what axis reliability is; when to reach for it vs. `fit_structure()`/`ssm_sem()`).
+- [x] T2: Worked-example section — `data("simulated_items")`, build the items list (`split(names(simulated_items), rep(1:8, each = 4))`), call `axes_reliability(..., angles = octants())`, show `res`; cross-reference the `instrument =` convenience path without running it (no 500-row registered instrument in the package).
+- [x] T3: Interpretation section — `summary(res)` (variance components + global fit), reading the per-axis reliability, SEm, and `nb_reliability` table; why X and Y match for a balanced octant instrument (differ only via `item_n`).
+- [x] T4: Caveats section — the three doc-level caveats (AC4) in precise prose, each naming its source (Strack et al. 2013; Cudeck 1989); no significance-test language for any CI (CLAUDE.md style; DECISIONS.md D-entry on vignette wording).
 - [ ] T5: Build + register — knit locally, confirm lavaan-absent build path, `tools::buildVignettes()` + `devtools::check(args = "--no-manual")` clean; confirm pkgdown auto-discovers the article (no `_pkgdown.yml` articles list to edit).
 
 ## Work log
 
 - 2026-07-23: created by /milestone-plan (focused scope: teach `axes_reliability()`; lineage D-025 → D-026 → M53 design → M54 build → M55 docs).
+- 2026-07-23: T1–T4 — wrote `vignettes/axes-reliability.Rmd` (motivation, worked example on `simulated_items`, component/NB interpretation, three caveats). Knits clean with lavaan present (23 KB) and with lavaan forced absent (note shown, no fit output leaked).
 
 ## Decisions
 

--- a/cairn/milestones/M55-axes-reliability-vignette.md
+++ b/cairn/milestones/M55-axes-reliability-vignette.md
@@ -34,24 +34,24 @@ cross-references them.
 
 ## Acceptance criteria
 
-- [ ] `vignettes/axes-reliability.Rmd` exists with a `%\VignetteIndexEntry{}`,
+- [x] `vignettes/axes-reliability.Rmd` exists with a `%\VignetteIndexEntry{}`,
       the `knitr::rmarkdown` engine, and UTF-8 encoding, and knits without error
       when lavaan is installed.
-- [ ] The vignette builds when lavaan is **not** installed — model-fitting
+- [x] The vignette builds when lavaan is **not** installed — model-fitting
       chunks are gated on `requireNamespace("lavaan")` and a fallback note is
       shown, mirroring `sem-based-ssm-analysis.Rmd:10-25`.
-- [ ] The vignette runs the primary workflow on `simulated_items`: it maps the
+- [x] The vignette runs the primary workflow on `simulated_items`: it maps the
       32 item columns to their 8 octant scales, calls `axes_reliability(...,
       angles = octants())`, and displays both `print()` and `summary()` output,
       naming the per-axis columns (reliability, SEm, `nb_reliability`).
-- [ ] The vignette states, in prose citing its source, each of the three caveats
+- [x] The vignette states, in prose citing its source, each of the three caveats
       the function documents: (a) `nb_reliability` **overestimates** when scale
       specificity is large (Strack et al. 2013, Fig. 3); (b) fitting the item
       **correlation** matrix as covariance makes component SEs and χ²
       **approximate** but point estimates and reliabilities correct (Cudeck,
       1989); (c) missing data are **listwise-only** and a boundary fit returns
       `NA` reliability/SEm, not a clipped value.
-- [ ] `R CMD build` / `tools::buildVignettes()` produces the vignette cleanly,
+- [x] `R CMD build` / `tools::buildVignettes()` produces the vignette cleanly,
       and `devtools::check(args = "--no-manual")` reports no new
       WARNING/NOTE attributable to it.
 
@@ -80,3 +80,22 @@ cross-references them.
 ## Decisions
 
 ## Review
+
+Reviewed 2026-07-23 on branch `m55-axes-reliability-vignette`, PR #81, base
+`master` (unmoved since cut; no merge needed).
+
+**Acceptance-criteria evidence (fresh):**
+- AC1 — `vignettes/axes-reliability.Rmd:1-8` carries `%\VignetteIndexEntry{Axes Reliability}`, `knitr::rmarkdown` engine, UTF-8. Rendered clean with lavaan present (23 KB HTML).
+- AC2 — gating at `axes-reliability.Rmd:15-16,23` (`requireNamespace`, `opts_chunk$set(eval = has_lavaan)`, note chunk `eval = !has_lavaan`). Rendered a copy with `has_lavaan` forced `FALSE`: builds, fallback note shown, no fit output leaked.
+- AC3 — workflow at `axes-reliability.Rmd:68-99`: `data("simulated_items")`, `split(names(...), rep(1:8, each = 4))`, `axes_reliability(..., angles = octants())`, `res`, `summary(res)`; per-axis columns named in prose (`item_n`, Reliability, SEm, `NB_Reliability`).
+- AC4 — three caveats with sources: NB overestimation (`:105-108`, Strack 2013 Fig. 3), correlation-as-covariance → approximate SEs/χ² (`:118-120`, Cudeck 1989), listwise-only + boundary→`NA` (`:123-131`). SEm framed as measurement imprecision, explicitly not a significance test (`:140-141`).
+- AC5 — `devtools::check(args = "--no-manual")` fresh: 0 errors, 0 warnings, 0 notes (6m26s). PR #81 CI: pkgdown pass; test-coverage + ubuntu-latest pending at review time (require green before merge).
+
+**Consistency gate:** `cairn_validate` exit 0, all checks pass (47 advisories are pre-existing wrapped work-log lines in M7, not M55). No DESIGN principle changed → `cairn_impact` skipped. `pkgdown::check_pkgdown()`: no problems found. Vignette's sole URL (Strack DOI) is byte-identical to the `\doi{}` in `R/axes_reliability.R` already validated in M54.
+
+**Independent review — three lenses, all zero findings:**
+- [O] diff-bug (Opus): ran the example live; every numeric claim matches (Reliability 0.773, NB 0.822/0.823, axes 0.175, SEm 0.476 = √(1−0.773)); all caveats reproduce the roxygen; angle convention and lavaan gating correct.
+- [S] blame-history (Sonnet): vignette faithfully restates D-025/D-026/M53/M54 decisions; `instrument=` claim does not overstate (all shipped instruments are octant); does not undo or contradict any recorded decision.
+- [S] prior-review (Sonnet): no prior-review evidence reintroduced/contradicted; M54 F2 print-note requirement (why the two axes rows match) is satisfied at `:86-88`; GitHub inline-comment probe empty.
+
+No findings surfaced → scorer/triage no-op. No follow-ups spawned.

--- a/cairn/milestones/M55-axes-reliability-vignette.md
+++ b/cairn/milestones/M55-axes-reliability-vignette.md
@@ -5,7 +5,7 @@
 - **Depends on:** M54
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** m55-axes-reliability-vignette / https://github.com/jmgirard/circumplex/pull/81
 
 ## Goal
 

--- a/vignettes/axes-reliability.Rmd
+++ b/vignettes/axes-reliability.Rmd
@@ -1,0 +1,158 @@
+---
+title: "Axes Reliability"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Axes Reliability}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+# This vignette uses lavaan, which circumplex only Suggests. The chunks that
+# fit the model are gated on lavaan being installed so the vignette still
+# builds without it; chunks that need no lavaan carry an explicit eval = TRUE.
+has_lavaan <- requireNamespace("lavaan", quietly = TRUE)
+knitr::opts_chunk$set(eval = has_lavaan)
+```
+
+```{r setup, eval = TRUE}
+library(circumplex)
+```
+
+```{r lavaan-note, eval = !has_lavaan, echo = FALSE, results = "asis"}
+cat(
+  "**Note:** The `lavaan` package is not installed, so the analysis below",
+  "is not evaluated. Install it with `install.packages(\"lavaan\")` to run",
+  "this vignette."
+)
+```
+
+## 1. What is axis reliability?
+
+A circumplex instrument places its scales around a circle and summarizes a
+person (or a profile of correlations) by their position on two orthogonal
+**axes** — here communion (the X axis, at 0°) and agency (the Y axis, at 90°).
+Because those axis scores drive everything downstream — a person's projected
+location, the displacement and amplitude of a Structural Summary Method
+profile — it is worth asking how *reliably* the instrument measures each axis.
+
+`axes_reliability()` answers that question with the estimator of Strack, Jacobs,
+and Grosse Holtforth (2013). It fits an item-level measurement model that
+decomposes each item's variance into four pieces — a general factor common to
+all items, the two circumplex **axes**, a scale-specificity component, and item
+error — and reads axis reliability off the **axes** component alone. Reliability
+is then the Spearman–Brown "list-length" reliability of a composite of that
+length built from items that share only their axes variance.
+
+This is a different question from the other reliability-adjacent tools in the
+package. `ssm_sem()` disattenuates a *scale-level* SSM profile for measurement
+error; `fit_structure()` evaluates whether a correlation matrix has circumplex
+*structure* at all. `axes_reliability()` instead reports a single, interpretable
+number per axis: how well the instrument measures communion and agency.
+
+## 2. A worked example
+
+The package ships `simulated_items`, a synthetic dataset of 1–7 Likert
+responses from 500 respondents on 32 items — four items on each of the eight
+octant scales, in the order that `octants()` returns. The items were drawn from
+a five-component population (a general factor, two equal axes with axes variance
+.18, a shared scale-specificity component of .10, and free item error) that
+implies an axis reliability of about .78.
+
+`axes_reliability()` needs three things: the data, a map from items to scales,
+and the scales' angles. The map is a list with one character vector of item
+names per scale, in the same angle order as the angles you pass:
+
+```{r map}
+data("simulated_items")
+
+# Four items per octant scale, in octants() order (PA, BC, DE, ..., NO).
+items <- split(names(simulated_items), rep(1:8, each = 4))
+
+res <- axes_reliability(simulated_items, items = items, angles = octants())
+res
+```
+
+If your items belong to one of the package's built-in instruments, you can pass
+the `instrument` object instead of `items` and `angles` — it supplies both the
+scale angles and the item membership, exactly as `score()` does. (The example
+above uses the explicit map because `simulated_items` is not a registered
+instrument.)
+
+The header confirms how many complete cases were used, and the per-axis table
+reports, for each axis, the effective test length (`item_n`), the Strack axis
+`Reliability`, its standard error of measurement (`SEm`), and the
+Nunnally–Bernstein reliability (`NB_Reliability`) for comparison. For a balanced
+octant instrument the two axes share one axes-variance estimate and carry equal
+`item_n`, so they report the same reliability — expected, not an error.
+
+The recovered reliability (about .77) lands close to the .78 built into the
+simulated population, and the axes-variance estimate (below) recovers the
+population value of .18.
+
+## 3. Reading the components
+
+`summary()` adds the estimated variance components and the model's global fit:
+
+```{r summary}
+summary(res)
+```
+
+The **variance components** show the decomposition the reliability rests on:
+the `axes` component is the only one that feeds reliability, while `general`,
+`scale_specificity`, and item error are isolated from it. This is precisely why
+the Nunnally–Bernstein figure printed alongside runs **higher** than the Strack
+reliability: N–B charges scale-specificity variance to the axis rather than
+isolating it, so it **overestimates** axis reliability whenever scale
+specificity is non-trivial (Strack et al., 2013, Figure 3). The gap between the
+two numbers is a direct read-out of how much scale-specific variance the simpler
+formula would have miscredited to the axes.
+
+## 4. Caveats to keep in mind
+
+Three properties of the method shape how its output should be read.
+
+**The standard errors and global fit are approximate.** Following the paper's
+own practice, the model is fit to the item **correlation** matrix as though it
+were a covariance matrix. The component point estimates and the reliabilities
+are correct, but the component standard errors and the global chi-square are
+only approximate (Cudeck, 1989). Read the fit indices as a rough guide, not as
+an exact test.
+
+**Missing data are handled by listwise deletion only.** The header reports the
+complete-case count so you can see how many rows contributed; pairwise
+correlation input is never used. If listwise deletion discards a large share of
+your sample, address the missingness before interpreting the estimate.
+
+**A boundary fit returns `NA`, not a clipped value.** If the model estimates a
+non-positive axes variance (or any negative variance component), the reliability
+and SEm are reported as `NA` with a warning and a boundary flag, rather than a
+clipped or negative number. An `NA` here is a signal that the model did not
+identify a usable axes-variance component in your data — not a defect to be
+worked around.
+
+Finally, a note on the `SEm`. The standard error of measurement supports a
+location interval for a single profile (Strack et al., 2013, use ±1.65·SEm). By
+default `axes_reliability()` reports the z-standardized SEm, `sqrt(1 -
+reliability)`; pass `sd = "raw"` (or your own axis SDs) to put the SEm on the
+raw axis-score scale. Such an interval describes the measurement imprecision of
+one profile's axis position; it is not a significance test of that position
+against any particular value.
+
+## 5. Wrap-up
+
+`axes_reliability()` gives a compact, per-axis answer to "how reliably does this
+instrument measure communion and agency?", isolating the axes variance from the
+general and scale-specific components that a simpler reliability formula would
+conflate. Use it to characterize an octant circumplex instrument before leaning
+on its axis scores, and read its output with the correlation-as-covariance,
+listwise-deletion, and boundary caveats in mind.
+
+## References
+
+* Cudeck, R. (1989). Analysis of correlation matrices using covariance
+  structure models. _Psychological Bulletin, 105_(2), 317–327.
+
+* Strack, S., Jacobs, K. A., & Grosse Holtforth, M. (2013). The reliability of
+  circumplex axes. _SAGE Open, 3_(2). https://doi.org/10.1177/2158244013486115


### PR DESCRIPTION
Adds `vignettes/axes-reliability.Rmd`, a user-facing article teaching `axes_reliability()` (Strack, Jacobs & Grosse Holtforth, 2013), shipped in M54.

## What it covers
- What circumplex axis reliability is, and how it differs from `ssm_sem()` disattenuation and `fit_structure()` structure evaluation.
- Worked example on `simulated_items` (recovers the built-in ~.78 axis reliability and .18 axes variance).
- Reading the per-axis table, variance components, and why Nunnally–Bernstein runs higher.
- Three caveats: correlation-as-covariance → approximate SEs (Cudeck 1989), listwise-only missingness, boundary→`NA`.

lavaan-gated (Suggests) like `sem-based-ssm-analysis.Rmd`, so it still builds where lavaan is absent. Docs-only — no R/`src`/roxygen changes.

## Verification
- Knits clean with lavaan present and with lavaan forced absent (fallback note shown, no fit output leaked).
- `devtools::check(args = "--no-manual")`: 0 errors, 0 warnings, 0 notes.

Milestone: M55 (cairn). Lineage: D-025 → D-026 → M53 design → M54 build → M55 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)