### PR TITLE
Any equally spaced angle set for axes_reliability()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -150,7 +150,12 @@ plotting layer has been rebuilt on a real ggplot2 coordinate system.
   exploratory scale-level criteria. The Nunnally-Bernstein axis reliability is
   reported alongside for comparison (it overestimates when scale specificity is
   large). Items are supplied through a `circumplex_instrument` or an explicit
-  angle-and-item map. Estimation works either from raw item data or, through
+  angle-and-item map. Any equally spaced set of scale angles is accepted, at
+  any rotation and any count from four scales up — the canonical octants, an
+  interstitial set rotated off the axes, or a six- or twelve-scale circumplex.
+  Unequally spaced (quasi-circumplex) angles are refused rather than
+  approximated, and three scales are refused because the variance components
+  are not separately identified at that count. Estimation works either from raw item data or, through
   `cormat` and `n`, from a published item correlation matrix alone, for
   reanalyzing a matrix whose raw data is not available; on that path the
   Nunnally-Bernstein comparison is reported as `NA` and `sd = "raw"` is refused,

--- a/R/axes_reliability.R
+++ b/R/axes_reliability.R
@@ -354,7 +354,7 @@ axes_resolve_map <- function(data, items, angles, instrument) {
 #' Reliability of the circumplex axes (Strack, Jacobs & Grosse Holtforth, 2013)
 #'
 #' Estimate the reliability (and standard error of measurement) of the two
-#' circumplex axes of an octant instrument with the item-level restricted
+#' circumplex axes of an instrument with the item-level restricted
 #' tau-equivalent CFA of Strack, Jacobs, and Grosse Holtforth (2013). The model
 #' decomposes each item's variance into orthogonal components -- a general
 #' factor, the two circumplex axes, scale specificity, and item specificity --
@@ -380,8 +380,25 @@ axes_resolve_map <- function(data, items, angles, instrument) {
 #' covariance matrix (the paper's own practice), the component point estimates
 #' and the reliabilities are correct, but the component standard errors and the
 #' global chi-square are **approximate** (Cudeck, 1989). Results are reported
-#' **per axis** (X and Y): for a balanced octant instrument the two axes carry
-#' the same axes-variance estimate and differ only through `item_n`.
+#' **per axis** (X and Y): for a balanced instrument the two axes carry the
+#' same axes-variance estimate and differ only through `item_n`.
+#'
+#' # Which instruments this accepts
+#'
+#' Any set of **equally spaced** scale angles, at any rotation: the canonical
+#' octants, an interstitial set rotated 22.5 degrees off the axes, or a
+#' non-octant count such as six or twelve scales. What matters is equal spacing,
+#' not the count or the starting angle -- for any equally spaced set of `k`
+#' scales, each axis draws the same effective test length (`k / 2` per item),
+#' which is what keeps the equal-axis-variance restriction as innocuous as it
+#' is for octants.
+#'
+#' Two limits. At least **four** scales are required: with three, every pair of
+#' scales sits the same angular distance apart, and the general, axes, and
+#' scale-specificity variances are then not separately identified. And spacing
+#' must be equal, not merely close -- a quasi-circumplex is refused rather than
+#' approximated, since Strack et al. (2013) excluded such instruments from the
+#' model's validation. Every scale still needs at least two items.
 #'
 #' Missing data are handled by **listwise deletion only** (a message reports the
 #' complete-case count); pairwise correlation input is never used. A boundary
@@ -431,7 +448,10 @@ axes_resolve_map <- function(data, items, angles, instrument) {
 #'   character vector (or numeric indices) of that scale's item columns.
 #' @param angles A numeric vector of the scales' angles in degrees (one per
 #'   scale), required for the explicit map and forbidden with `instrument`
-#'   (which supplies its own). Use [octants()].
+#'   (which supplies its own). Must be equally spaced around the circle, at any
+#'   rotation, with at least four scales; [octants()] gives the canonical eight.
+#'   Angles outside `[0, 360)` are reduced onto their circumplex positions, so
+#'   0 and 360 name the same position.
 #' @param instrument Optional. A `circumplex_instrument` object supplying the
 #'   scale angles and item membership (`Scales$Angle`, `Scales$Items`).
 #' @param sd The scale for the standard error of measurement: `"std"` (the

--- a/R/axes_reliability.R
+++ b/R/axes_reliability.R
@@ -21,6 +21,33 @@ axis_weights <- function(angles_deg) {
   cbind(w_x = snap_trig(cos(th)), w_y = snap_trig(sin(th)))
 }
 
+# Classify an angle set as an equally spaced circumplex, one status string:
+# "missing", "duplicate", "unequal", or "ok". Modular by construction --
+# positions reduce mod 360 first, so the package's LM = 360 and 0 are ONE
+# position (a naive sorted-diff treating them as distinct is the classic pole
+# bug; RR09 section 4). Every gap between successive positions must equal
+# 360/k. The wrap-around gap from the last position back to the first is
+# carried for symmetry with the modular reading, NOT because it catches a case
+# the interior gaps miss: all gaps sum to 360 by construction, so k-1 interior
+# gaps of 360/k force the wrap gap to 360/k too (verified by mutation -- with
+# the wrap term removed, no test changes).
+#
+# `tol` admits floating-point representation error only -- the gaps of an
+# exactly-constructed set carry ~1e-14 degrees of error at worst -- and never a
+# near-equal (quasi-circumplex) set, which Strack et al. excluded (p. 5) and
+# RR09 section 4 holds is scope-correct to refuse rather than merely cautious.
+# A departure of 1e-4 degrees is already 4 orders of magnitude above the noise
+# floor and is refused, so no real design slips through on tolerance.
+angles_spacing_status <- function(angles_deg, tol = 1e-8) {
+  if (anyNA(angles_deg)) return("missing")
+  a <- sort(as.numeric(angles_deg) %% 360)
+  k <- length(a)
+  gaps <- c(diff(a), 360 - (a[[k]] - a[[1]]))
+  if (any(gaps <= tol)) return("duplicate")
+  if (any(abs(gaps - 360 / k) > tol)) return("unequal")
+  "ok"
+}
+
 # Per-axis effective test length item_n = sum of squared item weights
 # (Strack et al. 2013, Table 3 col. 10; the Spearman-Brown composite length).
 # Balanced octant instruments give exact integers after snapping -- 64-item ->
@@ -481,29 +508,44 @@ axes_reliability <- function(data = NULL, items, angles = NULL,
   angles_deg <- map$angles
   n_scales <- length(item_cols)
 
-  # --- Refuse contract (RR09 BC12) --------------------------------------------
-  if (n_scales != 8L) {
-    stop(
-      "`axes_reliability()` supports octant (8-scale) instruments; ",
-      n_scales, " scales were supplied.",
-      call. = FALSE
-    )
-  }
+  # --- Refuse contract (RR09 BC12; M60 generalized it past the octant set) ----
   if (anyNA(angles_deg)) {
     stop("`angles` contains a missing value.", call. = FALSE)
   }
-  # The angle multiset must equal octants() modulo 360 (equal octant spacing);
-  # this rejects unequal spacing and duplicate angles alike.
-  if (!identical(
-    sort(as.numeric(angles_deg) %% 360),
-    sort(as.numeric(octants()) %% 360)
-  )) {
+  # Four scales is the identification floor, not a convention: at three equally
+  # spaced scales every cross-scale pair carries the same cos(delta) = -0.5, so
+  # the moment-structure design (cos delta, 1, same-scale) drops from rank 3 to
+  # rank 2 and the three variance components are not separately estimable
+  # (measured over k = 3:9 and 2-3 items/scale; RR09/D-026 holding 2).
+  if (n_scales < 4L) {
     stop(
-      "`angles` must be the eight octant angles (see octants()); an unequal ",
-      "spacing or a duplicated angle is not a type-a octant circumplex.",
+      "`axes_reliability()` needs at least 4 equally spaced scales; ",
+      n_scales, if (n_scales == 1L) " was" else " were", " supplied.",
+      if (n_scales == 3L) {
+        paste0(
+          " At 3 equally spaced scales every pair of scales sits the same ",
+          "angular distance apart, so the general, axes, and scale-specificity ",
+          "variances are not separately identified."
+        )
+      } else "",
       call. = FALSE
     )
   }
+  shown <- paste(format(sort(as.numeric(angles_deg) %% 360)), collapse = ", ")
+  switch(angles_spacing_status(angles_deg),
+    duplicate = stop(
+      "`angles` duplicates a circumplex position (0 and 360 degrees are one ",
+      "position): ", shown, ".",
+      call. = FALSE
+    ),
+    unequal = stop(
+      "`angles` must be equally spaced around the circle: ", n_scales,
+      " scales require a constant ", format(360 / n_scales),
+      "-degree spacing, but were supplied as ", shown,
+      ". A quasi-circumplex (near-equal spacing) is out of scope.",
+      call. = FALSE
+    )
+  )
   n_items_scale <- lengths(item_cols)
   if (any(n_items_scale < 2L)) {
     stop("Every scale must have at least 2 items.", call. = FALSE)

--- a/R/axes_reliability.R
+++ b/R/axes_reliability.R
@@ -24,8 +24,13 @@ axis_weights <- function(angles_deg) {
 # Classify an angle set as an equally spaced circumplex, one status string:
 # "missing", "duplicate", "unequal", or "ok". Modular by construction --
 # positions reduce mod 360 first, so the package's LM = 360 and 0 are ONE
-# position (a naive sorted-diff treating them as distinct is the classic pole
-# bug; RR09 section 4). Every gap between successive positions must equal
+# position (RR09 section 4). Where that reduction actually bites is an angle
+# supplied OUTSIDE [0, 360): c(10, 100, 190, 640) is equally spaced modulo 360,
+# but a naive sorted-diff reads its wrap gap as negative and calls it a
+# duplicate. A set carrying both 0 and 360 is caught either way (the wrap gap
+# goes to 0), so that case does not pin this line -- the out-of-range one does,
+# and is what the mutation test asserts.
+# Every gap between successive positions must equal
 # 360/k. The wrap-around gap from the last position back to the first is
 # carried for symmetry with the modular reading, NOT because it catches a case
 # the interior gaps miss: all gaps sum to 360 by construction, so k-1 interior

--- a/R/axes_reliability.R
+++ b/R/axes_reliability.R
@@ -55,11 +55,20 @@ angles_spacing_status <- function(angles_deg, tol = 1e-8) {
 
 # Per-axis effective test length item_n = sum of squared item weights
 # (Strack et al. 2013, Table 3 col. 10; the Spearman-Brown composite length).
-# Balanced octant instruments give exact integers after snapping -- 64-item ->
-# 32, 32 -> 16, 16 -> 8 -- equal across axes, because the +/-.7071 weights'
-# float error cancels over a full octant set. Computed per axis so unbalanced
-# and deferred non-octant types degrade gracefully (Table 3 col. 10 is per axis
-# and fractional for SYMLOG).
+#
+# For a balanced set of k equally spaced scales carrying n items each, both axes
+# get item_n = n * k/2 at ANY rotation, because sum(cos^2) over k equally spaced
+# angles is k/2 independently of where the set starts (k >= 3). That identity is
+# what keeps the model's equal-axis-variance restriction -- the circumplex
+# "no preferred rotation" axiom, p. 4 -- as substantively innocuous for a
+# rotated or non-octant set as it is for the canonical octants (M60).
+#
+# Exactness, however, is an octant accident: octant sets give exact integers
+# because the +/-.7071 weights' float error cancels, while 16 scales at 22.5 deg
+# measure (32.000000000000000, 31.999999999999996). Compare non-octant item_n
+# with a tolerance, never expect_identical(). Computed per axis so an unbalanced
+# set degrades gracefully (Table 3 col. 10 is per axis, and fractional for
+# SYMLOG at 8.67).
 axis_item_n <- function(angles_deg, n_items) {
   w <- axis_weights(angles_deg)
   c(x = sum(n_items * w[, "w_x"]^2), y = sum(n_items * w[, "w_y"]^2))

--- a/R/axes_reliability.R
+++ b/R/axes_reliability.R
@@ -44,7 +44,11 @@ axis_weights <- function(angles_deg) {
 # A departure of 1e-4 degrees is already 4 orders of magnitude above the noise
 # floor and is refused, so no real design slips through on tolerance.
 angles_spacing_status <- function(angles_deg, tol = 1e-8) {
-  if (anyNA(angles_deg)) return("missing")
+  # is.finite() rather than anyNA(): anyNA() does NOT reject +/-Inf (the M32/M35
+  # lesson), and an infinite angle is worse than useless here -- `Inf %% 360` is
+  # NaN and sort() SILENTLY DROPS it, so `k` below would be computed after the
+  # drop and the surviving angles could satisfy 360/k and return "ok".
+  if (!all(is.finite(as.numeric(angles_deg)))) return("nonfinite")
   a <- sort(as.numeric(angles_deg) %% 360)
   k <- length(a)
   gaps <- c(diff(a), 360 - (a[[k]] - a[[1]]))
@@ -546,6 +550,21 @@ axes_reliability <- function(data = NULL, items, angles = NULL,
   if (anyNA(angles_deg)) {
     stop("`angles` contains a missing value.", call. = FALSE)
   }
+  # anyNA() above does not reject +/-Inf (the M32/M35 lesson), and an infinite
+  # angle would otherwise reach the fit: `Inf %% 360` is NaN, sort() drops it,
+  # and the surviving angles can satisfy the spacing test -- so the fit dies in
+  # qr.solve() naming nothing. Refuse it here, naming the offending scale.
+  nonfinite <- which(!is.finite(as.numeric(angles_deg)))
+  if (length(nonfinite) > 0) {
+    stop(
+      "`angles` must be finite; scale(s) ",
+      paste(nonfinite, collapse = ", "), " carry ",
+      paste(unique(as.character(as.numeric(angles_deg)[nonfinite])),
+            collapse = ", "),
+      ".",
+      call. = FALSE
+    )
+  }
   # Four scales is the identification floor, not a convention: at three equally
   # spaced scales every cross-scale pair carries the same cos(delta) = -0.5, so
   # the moment-structure design (cos delta, 1, same-scale) drops from rank 3 to
@@ -566,7 +585,12 @@ axes_reliability <- function(data = NULL, items, angles = NULL,
     )
   }
   shown <- paste(format(sort(as.numeric(angles_deg) %% 360)), collapse = ", ")
+  # The final unnamed branch is switch()'s default: an unhandled status must
+  # abort, never fall through to the fit. Unreachable today (the gates above
+  # exclude "nonfinite"), but this helper is shared and switch() returns NULL
+  # invisibly on no match, which would silently accept a malformed set.
   switch(angles_spacing_status(angles_deg),
+    ok = NULL,
     duplicate = stop(
       "`angles` duplicates a circumplex position (0 and 360 degrees are one ",
       "position): ", shown, ".",
@@ -578,7 +602,8 @@ axes_reliability <- function(data = NULL, items, angles = NULL,
       "-degree spacing, but were supplied as ", shown,
       ". A quasi-circumplex (near-equal spacing) is out of scope.",
       call. = FALSE
-    )
+    ),
+    stop("`angles` were not usable: ", shown, ".", call. = FALSE)
   )
   n_items_scale <- lengths(item_cols)
   if (any(n_items_scale < 2L)) {

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -9,7 +9,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
-| M60 | Any equally spaced angle set for `axes_reliability()` | planned | — | normal | milestones/M60-axes-reliability-equal-spacing.md |
+| M60 | Any equally spaced angle set for `axes_reliability()` | in-progress | — | normal | milestones/M60-axes-reliability-equal-spacing.md |
 | M61 | Single-item scale positions for `axes_reliability()` — dropping ζ1 | planned | M60 | normal | milestones/M61-axes-reliability-single-item.md |
 | M59 | Correlation-matrix input path for `axes_reliability()` | done | M54 | normal | milestones/archive/M59-axes-reliability-corr-input.md |
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -9,7 +9,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
-| M60 | Any equally spaced angle set for `axes_reliability()` | in-progress | — | normal | milestones/M60-axes-reliability-equal-spacing.md |
+| M60 | Any equally spaced angle set for `axes_reliability()` | review | — | normal | milestones/M60-axes-reliability-equal-spacing.md |
 | M61 | Single-item scale positions for `axes_reliability()` — dropping ζ1 | planned | M60 | normal | milestones/M61-axes-reliability-single-item.md |
 | M59 | Correlation-matrix input path for `axes_reliability()` | done | M54 | normal | milestones/archive/M59-axes-reliability-corr-input.md |
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |

--- a/cairn/milestones/M60-axes-reliability-equal-spacing.md
+++ b/cairn/milestones/M60-axes-reliability-equal-spacing.md
@@ -114,6 +114,7 @@ any rotation, instead of only the canonical octant set.
 - 2026-07-25: implement gate — spacing tolerance is float-representation only, never near-equal spacing (Jeff; keeps RR09 §4's quasi-circumplex refusal intact).
 - 2026-07-25: T1 fence added (4 test blocks, rotated/k!=8/refusals/pole); red for the right reason — the octant-only refusals at :485-506, not an incidental error. Suite stays red by design until T3.
 - 2026-07-25: T2 `angles_spacing_status()` (modular, tol = 1e-8 = float noise only) + 15 unit assertions incl. k = 4:24 at two rotations; T3 wired it into the refuse contract and re-pointed the three stale BC12 message expectations. Suite green (232).
+- 2026-07-25: mutation-tested the 5 guards. 4 had teeth (floor→3: 1 fail; tol 1e-8→0.5: 3; skip duplicate: 6; accept any spacing: 7). The `%% 360` reduction did NOT redden — for in-range sets the wrap term compensates; it bites only on angles outside [0, 360), now asserted (`c(10, 100, 190, 640)`), and the mutation reddens. Full suite 3394 pass / 0 fail; the 4 warnings are pre-existing in test-ci_accuracy.R.
 - 2026-07-25: refusals use `stop(call. = FALSE)` matching all 26 in the file; the profile's cli_abort slot would need cli as a new dependency (gate + D-entry) for no gain.
 
 ## Decisions

--- a/cairn/milestones/M60-axes-reliability-equal-spacing.md
+++ b/cairn/milestones/M60-axes-reliability-equal-spacing.md
@@ -94,7 +94,7 @@ any rotation, instead of only the canonical octant set.
       at the pole and against near-miss spacings.
 - [x] T3: replace the refusal block with count / spacing / duplicate checks and
       informative messages; keep the ≥ 2-items-per-scale gate.
-- [ ] T4: rotation-invariance tests for `axis_item_n()`
+- [x] T4: rotation-invariance tests for `axis_item_n()`
       (`R/axes_reliability.R:31-34`) — `n × k/2`; keep the exact-equality octant
       assertion at `test-axes-reliability.R:5` exact, since exactness there is
       an octant accident (16 scales at 22.5° measured `y = 31.999999999999996`).
@@ -115,9 +115,12 @@ any rotation, instead of only the canonical octant set.
 - 2026-07-25: T1 fence added (4 test blocks, rotated/k!=8/refusals/pole); red for the right reason — the octant-only refusals at :485-506, not an incidental error. Suite stays red by design until T3.
 - 2026-07-25: T2 `angles_spacing_status()` (modular, tol = 1e-8 = float noise only) + 15 unit assertions incl. k = 4:24 at two rotations; T3 wired it into the refuse contract and re-pointed the three stale BC12 message expectations. Suite green (232).
 - 2026-07-25: mutation-tested the 5 guards. 4 had teeth (floor→3: 1 fail; tol 1e-8→0.5: 3; skip duplicate: 6; accept any spacing: 7). The `%% 360` reduction did NOT redden — for in-range sets the wrap term compensates; it bites only on angles outside [0, 360), now asserted (`c(10, 100, 190, 640)`), and the mutation reddens. Full suite 3394 pass / 0 fail; the 4 warnings are pre-existing in test-ci_accuracy.R.
+- 2026-07-25: T4 item_n = n*k/2 pinned over k = 4:16 x 4 rotations x 3 item counts, plus an unbalanced set giving legitimately unequal per-axis values; stale octant-only comment on axis_item_n() corrected.
 - 2026-07-25: refusals use `stop(call. = FALSE)` matching all 26 in the file; the profile's cli_abort slot would need cli as a new dependency (gate + D-entry) for no gain.
 
 ## Decisions
+
+- 2026-07-25 (T4): non-octant item_n is compared with a tolerance set from discrimination (1e-8 absolute; one item = 1.0, so it fences at 1e8x and sits ~6 orders above the ~1e-14 float noise). The octant `expect_identical()` in BC3 stays exact — exactness there is a real property of that set, not an artifact to weaken.
 
 - 2026-07-25 (T2): the wrap-around gap in `angles_spacing_status()` is kept for symmetry with the modular reading but is NOT load-bearing — all gaps sum to 360, so k-1 interior gaps of 360/k force it. Mutation-verified: removing the term changes no test. The comment says so rather than claiming a mechanism it does not have (M36).
 

--- a/cairn/milestones/M60-axes-reliability-equal-spacing.md
+++ b/cairn/milestones/M60-axes-reliability-equal-spacing.md
@@ -123,6 +123,7 @@ any rotation, instead of only the canonical octant set.
 - 2026-07-25: all tasks done; status -> review.
 - 2026-07-25: refusals use `stop(call. = FALSE)` matching all 26 in the file; the profile's cli_abort slot would need cli as a new dependency (gate + D-entry) for no gain.
 - 2026-07-25: review checkpoint — PR #86 opened (draft); all 8 ACs verified with fresh evidence and ticked; consistency gate clean. Review fan-out: prior-review lens clean, blame lens 1 finding (strack2013.md provenance overclaim), diff-bug lens still running. CI pending. Not yet triaged or merged.
+- 2026-07-25: review fan-out triaged — F1 (96) non-finite angle escaping the refuse contract, F2 (83) false split() comments, F5 (82) provenance overclaim all fixed; F3 (62) and F4 (45) logged below threshold. Suite 3748 pass.
 
 ## Decisions
 
@@ -192,3 +193,60 @@ split; work-log format, 47 pre-existing M7 lines). No DESIGN principle changed,
 so `cairn_impact` does not apply. Toolchain slot: `document()` no-diff ✔,
 `pkgdown::check_pkgdown()` "No problems found" ✔, NEWS entry present ✔, README
 untouched ✔, no new top-level files ✔, full check clean ✔.
+
+**Independent review — three lenses + scorer.** Diff-bug [O] 4 findings,
+blame-history [S] 1, prior-PR-comments [S] 0 (GitHub comment surface probed
+empty; archived `## Review` sections were the evidence base). All five scored by
+a fresh [S] scorer that did not generate them.
+
+*Actioned (score ≥ 80), all three fixed on the branch:*
+
+- **F1 (96) — a non-finite angle escaped the whole refuse contract.**
+  `anyNA()` does not reject `Inf`; `Inf %% 360` is `NaN`; `sort()` silently
+  drops it, so the helper's `k` was computed after the drop and the surviving
+  angles satisfied `360/k`, returning `"ok"`. Verified:
+  `angles_spacing_status(c(octants(), Inf))` gave `"ok"` and a full call died in
+  `qr.solve()` with `NA/NaN/Inf in foreign function call` naming nothing. A
+  regression the diff introduced — master refused it via the set-identity length
+  mismatch — and a walk into the recorded M32/M35 lesson. Fixed with an
+  `is.finite()` gate naming the offending scale and value, an `is.finite()`
+  predicate in the helper (status `"nonfinite"`), and a `switch()` default so an
+  unhandled status aborts instead of falling through. Both mutations redden
+  (removing the caller gate: 1 failure; reverting the helper to `anyNA()`: 3).
+- **F2 (83) — three code comments and a work-log line asserted a hazard that
+  does not exist.** They claimed `split()` on a numeric group vector sorts
+  levels as CHARACTER, misordering scales at k ≥ 10. False: `split()` coerces
+  with `factor()`, whose levels sort numerically; only a character group vector
+  sorts lexically, and all five edits were behavioral no-ops. Comments corrected
+  to say the level pinning states the pairing rather than repairing it.
+- **F5 (82) — the provenance line overclaimed.** It named "type-e and type-f
+  rows ... agreeing on every banked value" when no type-e/f rows are banked in
+  this file at all; those are M61's. Repeat of the M40/M45/M47 lesson that an
+  Extraction status may claim only what each channel actually saw. Scoped to the
+  type-b and type-c rows actually banked, and states explicitly that type-e/f
+  carry no verification claim.
+
+*Logged below threshold, not actioned (surfaced, never silently dropped):*
+
+- **F3 (62)** — the MEIL component-sum assertion re-sums the four literals on
+  its own line against a derived 74.4, so it offers weaker regression protection
+  than its "the defect, pinned" comment implies. The scorer noted it is not
+  strictly tautological (editing one literal would fail it).
+- **F4 (45)** — the type-b Layer-A block calls only `axis_reliability_sb()` with
+  `item_n` hard-banked at 16, so it passes verbatim on master and validates the
+  paper's arithmetic rather than the generalization. Scored low because AC4's
+  `item_n = n·k/2` sweep already covers the geometry derivation separately, by
+  design. Its minor sibling — `expect_false(all(...))` where the comment implies
+  `expect_true(all(... > .01))` — passes for the right reason today.
+
+**Verified sound by the diff-bug lens, independently of the author:** the
+k ≥ 4 identification floor (rank recomputed over k = 3:9 × 4 rotations ×
+balanced and unbalanced item counts — rank 2 at k = 3 in every cell, rank 3 from
+k = 4); the Σw² = k/2 identity derived analytically; the check ordering; and
+every downstream path (print/summary, OLS shadow, start values, N–B, `sd =
+"raw"`, the `cormat` path) exercised at k = 4/5/6/8-rotated/12.
+
+**Post-fix.** Full suite 3748 pass / 0 fail (4 warnings pre-existing in
+`test-ci_accuracy.R`); axes file 589 pass. CI green on the pre-fix commit
+including `test-coverage` — the `covr` job that failed in M59 — and re-run on
+the fix commit.

--- a/cairn/milestones/M60-axes-reliability-equal-spacing.md
+++ b/cairn/milestones/M60-axes-reliability-equal-spacing.md
@@ -85,7 +85,7 @@ any rotation, instead of only the canonical octant set.
 
 ## Tasks
 
-- [ ] T1: tests first — a rotated type-b set and k = 6 / k = 12 sets currently
+- [x] T1: tests first — a rotated type-b set and k = 6 / k = 12 sets currently
       error at `R/axes_reliability.R:495-506`; pin that as the failing fence,
       and pin every refusal that must survive
       (`tests/testthat/test-axes-reliability.R:442-476`).
@@ -112,6 +112,7 @@ any rotation, instead of only the canonical octant set.
 - 2026-07-25: in-progress on `m60-axes-reliability-equal-spacing`.
 - 2026-07-25: amended Scope + AC2 at the implement gate — scale-count floor 3 → 4, measured: the moment design (cos Δ, 1, same-scale) is rank 2 at k = 3 for any items/scale, rank 3 from k = 4. Jeff accepted.
 - 2026-07-25: implement gate — spacing tolerance is float-representation only, never near-equal spacing (Jeff; keeps RR09 §4's quasi-circumplex refusal intact).
+- 2026-07-25: T1 fence added (4 test blocks, rotated/k!=8/refusals/pole); red for the right reason — the octant-only refusals at :485-506, not an incidental error. Suite stays red by design until T3.
 - 2026-07-25: refusals use `stop(call. = FALSE)` matching all 26 in the file; the profile's cli_abort slot would need cli as a new dependency (gate + D-entry) for no gain.
 
 ## Decisions

--- a/cairn/milestones/M60-axes-reliability-equal-spacing.md
+++ b/cairn/milestones/M60-axes-reliability-equal-spacing.md
@@ -100,7 +100,7 @@ any rotation, instead of only the canonical octant set.
       an octant accident (16 scales at 22.5° measured `y = 31.999999999999996`).
 - [x] T5: bank the four CV-LI type-b Table 3 rows in
       `cairn/references/strack2013.md` and add the ±.01 sweep test.
-- [ ] T6: re-run the population-matrix, synthetic-recovery and cross-engine
+- [x] T6: re-run the population-matrix, synthetic-recovery and cross-engine
       OpenMx cells at a rotated-octant and a k ≠ 8 configuration.
 - [ ] T7: roxygen (`R/axes_reliability.R:316-317,343,395`), `man/` regeneration,
       vignette and NEWS.
@@ -117,9 +117,12 @@ any rotation, instead of only the canonical octant set.
 - 2026-07-25: mutation-tested the 5 guards. 4 had teeth (floor→3: 1 fail; tol 1e-8→0.5: 3; skip duplicate: 6; accept any spacing: 7). The `%% 360` reduction did NOT redden — for in-range sets the wrap term compensates; it bites only on angles outside [0, 360), now asserted (`c(10, 100, 190, 640)`), and the mutation reddens. Full suite 3394 pass / 0 fail; the 4 warnings are pre-existing in test-ci_accuracy.R.
 - 2026-07-25: T4 item_n = n*k/2 pinned over k = 4:16 x 4 rotations x 3 item counts, plus an unbalanced set giving legitimately unequal per-axis values; stale octant-only comment on axis_item_n() corrected.
 - 2026-07-25: T5 banked Table 3's `Type` column + the four type-b (CV-LI) and one type-c (MEIL) rows in `references/strack2013.md`, re-verified in two channels (text layer + 200-dpi page image) agreeing on every value; provenance status re-marked inline. Sweep test added, incl. a discrimination check that the wrong item_n fails it. MEIL's components sum to 74.4 (a second source defect, RR10-corroborated) so it anchors reliability only, never a sum guard.
+- 2026-07-25: T6 Layer-B at 4 new geometries (type-b rotated octants, k=6, k=12, k=5 at a 13.7° rotation): exact population recovery + chisq<1e-6, MC recovery within 2 MCSE at the rotated set, lavaan/OpenMx agreement <1e-3. Also hardened two test helpers whose `split()` on a numeric group vector would misorder scales at k>=10 — a no-op at k=8, and the production path (`axes_resolve_map()`) was already positional and safe.
 - 2026-07-25: refusals use `stop(call. = FALSE)` matching all 26 in the file; the profile's cli_abort slot would need cli as a new dependency (gate + D-entry) for no gain.
 
 ## Decisions
+
+- 2026-07-25 (T6): a GLOBAL rotation of the syntax weights is undetectable by any oracle here, and correctly so — Σ depends only on cos(θi−θj), which is invariant to adding a constant to every angle, which is the model's own "no preferred rotation" axiom (p. 4). Weight mutations must break RELATIVE geometry to be valid; perturbing one scale's angle reddens 19 tests, perturbing all of them reddens none. Recorded so a later session does not read the null result as missing coverage.
 
 - 2026-07-25 (T5): `cairn_validate`'s sizing advisory flags M60 and M61 at 8 acceptance criteria (>7 tripwire). Not split: the 8th in each is the template-mandated "profile verify/check clean" criterion every code milestone carries, so the substantive count is 7. Splitting on a hygiene criterion would cut a coherent unit for a counting artifact.
 

--- a/cairn/milestones/M60-axes-reliability-equal-spacing.md
+++ b/cairn/milestones/M60-axes-reliability-equal-spacing.md
@@ -102,7 +102,7 @@ any rotation, instead of only the canonical octant set.
       `cairn/references/strack2013.md` and add the ±.01 sweep test.
 - [x] T6: re-run the population-matrix, synthetic-recovery and cross-engine
       OpenMx cells at a rotated-octant and a k ≠ 8 configuration.
-- [ ] T7: roxygen (`R/axes_reliability.R:316-317,343,395`), `man/` regeneration,
+- [x] T7: roxygen (`R/axes_reliability.R:316-317,343,395`), `man/` regeneration,
       vignette and NEWS.
 - [ ] T8: D-entry for the v2.0.0 admission; full check plus the PDF manual.
 
@@ -118,6 +118,7 @@ any rotation, instead of only the canonical octant set.
 - 2026-07-25: T4 item_n = n*k/2 pinned over k = 4:16 x 4 rotations x 3 item counts, plus an unbalanced set giving legitimately unequal per-axis values; stale octant-only comment on axis_item_n() corrected.
 - 2026-07-25: T5 banked Table 3's `Type` column + the four type-b (CV-LI) and one type-c (MEIL) rows in `references/strack2013.md`, re-verified in two channels (text layer + 200-dpi page image) agreeing on every value; provenance status re-marked inline. Sweep test added, incl. a discrimination check that the wrong item_n fails it. MEIL's components sum to 74.4 (a second source defect, RR10-corroborated) so it anchors reliability only, never a sum guard.
 - 2026-07-25: T6 Layer-B at 4 new geometries (type-b rotated octants, k=6, k=12, k=5 at a 13.7° rotation): exact population recovery + chisq<1e-6, MC recovery within 2 MCSE at the rotated set, lavaan/OpenMx agreement <1e-3. Also hardened two test helpers whose `split()` on a numeric group vector would misorder scales at k>=10 — a no-op at k=8, and the production path (`axes_resolve_map()`) was already positional and safe.
+- 2026-07-25: T7 docs — new roxygen section "Which instruments this accepts" (equal spacing at any rotation, the k>=4 identification floor, quasi-circumplex refused not approximated), `angles` param doc, man/ regenerated, vignette §6 paragraph, NEWS folded into the existing axes_reliability() bullet per D-031. NAMESPACE unchanged (the helper is internal, so no _pkgdown.yml row is owed). Vignette tail bytes checked clean (M34).
 - 2026-07-25: refusals use `stop(call. = FALSE)` matching all 26 in the file; the profile's cli_abort slot would need cli as a new dependency (gate + D-entry) for no gain.
 
 ## Decisions

--- a/cairn/milestones/M60-axes-reliability-equal-spacing.md
+++ b/cairn/milestones/M60-axes-reliability-equal-spacing.md
@@ -1,6 +1,6 @@
 # M60: Any equally spaced angle set for `axes_reliability()`
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
@@ -104,7 +104,7 @@ any rotation, instead of only the canonical octant set.
       OpenMx cells at a rotated-octant and a k ≠ 8 configuration.
 - [x] T7: roxygen (`R/axes_reliability.R:316-317,343,395`), `man/` regeneration,
       vignette and NEWS.
-- [ ] T8: D-entry for the v2.0.0 admission; full check plus the PDF manual.
+- [x] T8: D-entry for the v2.0.0 admission; full check plus the PDF manual.
 
 ## Work log
 
@@ -119,6 +119,8 @@ any rotation, instead of only the canonical octant set.
 - 2026-07-25: T5 banked Table 3's `Type` column + the four type-b (CV-LI) and one type-c (MEIL) rows in `references/strack2013.md`, re-verified in two channels (text layer + 200-dpi page image) agreeing on every value; provenance status re-marked inline. Sweep test added, incl. a discrimination check that the wrong item_n fails it. MEIL's components sum to 74.4 (a second source defect, RR10-corroborated) so it anchors reliability only, never a sum guard.
 - 2026-07-25: T6 Layer-B at 4 new geometries (type-b rotated octants, k=6, k=12, k=5 at a 13.7° rotation): exact population recovery + chisq<1e-6, MC recovery within 2 MCSE at the rotated set, lavaan/OpenMx agreement <1e-3. Also hardened two test helpers whose `split()` on a numeric group vector would misorder scales at k>=10 — a no-op at k=8, and the production path (`axes_resolve_map()`) was already positional and safe.
 - 2026-07-25: T7 docs — new roxygen section "Which instruments this accepts" (equal spacing at any rotation, the k>=4 identification floor, quasi-circumplex refused not approximated), `angles` param doc, man/ regenerated, vignette §6 paragraph, NEWS folded into the existing axes_reliability() bullet per D-031. NAMESPACE unchanged (the helper is internal, so no _pkgdown.yml row is owed). Vignette tail bytes checked clean (M34).
+- 2026-07-25: T8 `devtools::check()` OK (0/0/0, 9m30s) and the PDF manual built directly (`R CMD Rd2pdf`, 76pp) — the check log has zero occurrences of "checking PDF version of manual", confirming `--no-manual` skipped it, which is how M7 and M57 each shipped a CRAN-blocking failure. New Rd section verified present in the rendered PDF. No new D-entry owed: D-031 already admits M60 to v2.0.0.
+- 2026-07-25: all tasks done; status -> review.
 - 2026-07-25: refusals use `stop(call. = FALSE)` matching all 26 in the file; the profile's cli_abort slot would need cli as a new dependency (gate + D-entry) for no gain.
 
 ## Decisions

--- a/cairn/milestones/M60-axes-reliability-equal-spacing.md
+++ b/cairn/milestones/M60-axes-reliability-equal-spacing.md
@@ -98,7 +98,7 @@ any rotation, instead of only the canonical octant set.
       (`R/axes_reliability.R:31-34`) — `n × k/2`; keep the exact-equality octant
       assertion at `test-axes-reliability.R:5` exact, since exactness there is
       an octant accident (16 scales at 22.5° measured `y = 31.999999999999996`).
-- [ ] T5: bank the four CV-LI type-b Table 3 rows in
+- [x] T5: bank the four CV-LI type-b Table 3 rows in
       `cairn/references/strack2013.md` and add the ±.01 sweep test.
 - [ ] T6: re-run the population-matrix, synthetic-recovery and cross-engine
       OpenMx cells at a rotated-octant and a k ≠ 8 configuration.
@@ -116,9 +116,12 @@ any rotation, instead of only the canonical octant set.
 - 2026-07-25: T2 `angles_spacing_status()` (modular, tol = 1e-8 = float noise only) + 15 unit assertions incl. k = 4:24 at two rotations; T3 wired it into the refuse contract and re-pointed the three stale BC12 message expectations. Suite green (232).
 - 2026-07-25: mutation-tested the 5 guards. 4 had teeth (floor→3: 1 fail; tol 1e-8→0.5: 3; skip duplicate: 6; accept any spacing: 7). The `%% 360` reduction did NOT redden — for in-range sets the wrap term compensates; it bites only on angles outside [0, 360), now asserted (`c(10, 100, 190, 640)`), and the mutation reddens. Full suite 3394 pass / 0 fail; the 4 warnings are pre-existing in test-ci_accuracy.R.
 - 2026-07-25: T4 item_n = n*k/2 pinned over k = 4:16 x 4 rotations x 3 item counts, plus an unbalanced set giving legitimately unequal per-axis values; stale octant-only comment on axis_item_n() corrected.
+- 2026-07-25: T5 banked Table 3's `Type` column + the four type-b (CV-LI) and one type-c (MEIL) rows in `references/strack2013.md`, re-verified in two channels (text layer + 200-dpi page image) agreeing on every value; provenance status re-marked inline. Sweep test added, incl. a discrimination check that the wrong item_n fails it. MEIL's components sum to 74.4 (a second source defect, RR10-corroborated) so it anchors reliability only, never a sum guard.
 - 2026-07-25: refusals use `stop(call. = FALSE)` matching all 26 in the file; the profile's cli_abort slot would need cli as a new dependency (gate + D-entry) for no gain.
 
 ## Decisions
+
+- 2026-07-25 (T5): `cairn_validate`'s sizing advisory flags M60 and M61 at 8 acceptance criteria (>7 tripwire). Not split: the 8th in each is the template-mandated "profile verify/check clean" criterion every code milestone carries, so the substantive count is 7. Splitting on a hygiene criterion would cut a coherent unit for a counting artifact.
 
 - 2026-07-25 (T4): non-octant item_n is compared with a tolerance set from discrimination (1e-8 absolute; one item = 1.0, so it fences at 1e8x and sits ~6 orders above the ~1e-14 float noise). The octant `expect_identical()` in BC3 stays exact — exactness there is a real property of that set, not an artifact to weaken.
 

--- a/cairn/milestones/M60-axes-reliability-equal-spacing.md
+++ b/cairn/milestones/M60-axes-reliability-equal-spacing.md
@@ -1,11 +1,11 @@
 # M60: Any equally spaced angle set for `axes_reliability()`
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** `m60-axes-reliability-equal-spacing`
 
 ## Goal
 
@@ -16,13 +16,20 @@ any rotation, instead of only the canonical octant set.
 
 **In:**
 - Replace the `octants()` set-identity refusal (`R/axes_reliability.R:485-506`)
-  with a genuine modular equal-spacing predicate: k ≥ 3 scales, constant
+  with a genuine modular equal-spacing predicate: k ≥ 4 scales, constant
   successive gap of 360/k including the wrap-around gap, tolerance-based,
   pole-aware (LM = 360 ≡ 0). Unequal spacing, duplicate angles and NA angles
-  stay refused with a message naming the offender.
+  stay refused with a message naming the offender. k = 3 is refused as
+  *unidentified*, not merely unsupported: three equally spaced scales give every
+  cross-scale pair the same cos Δ = −0.5, collapsing the moment-structure design
+  (cos Δ, 1, same-scale) from rank 3 to rank 2 at any number of items per scale
+  (measured 2026-07-25; D-026 holding 2). The spacing tolerance admits
+  floating-point representation error only, never a near-equal (quasi-circumplex)
+  set — RR09 §4.
 - The ≥ 2-items-per-scale refusal (`:507-510`) stays, so ζ1 remains identified.
 - Pin the rotation-invariance that keeps the equal-axis-variance restriction
-  substantively innocuous: for k ≥ 3, per-axis Σw² = k/2 at any rotation.
+  substantively innocuous: per-axis Σw² = k/2 at any rotation, for every
+  accepted k.
 - Oracles: the four CV-LI type-b rows of Strack Table 3 (Layer A), plus the
   existing population-matrix / synthetic-recovery / cross-engine cells re-run at
   a rotated and a non-octant configuration (Layer B).
@@ -45,8 +52,8 @@ any rotation, instead of only the canonical octant set.
       returning finite equal per-axis reliability; the octant-only error no
       longer fires.
 - [ ] AC2: each refusal still fires with a message naming the offender —
-      unequal spacing, duplicate angle, NA angle, k < 3, and < 2 items on any
-      scale.
+      unequal spacing, duplicate angle, NA angle, k < 4 (naming identification
+      as the reason at k = 3), and < 2 items on any scale.
 - [ ] AC3: the spacing test is modular — a set expressed with LM = 360 is
       accepted identically to the same set using 0, and a set carrying both 0
       and 360 is refused as a duplicate.
@@ -102,6 +109,10 @@ any rotation, instead of only the canonical octant set.
 ## Work log
 
 - 2026-07-25: created by /milestone-plan.
+- 2026-07-25: in-progress on `m60-axes-reliability-equal-spacing`.
+- 2026-07-25: amended Scope + AC2 at the implement gate — scale-count floor 3 → 4, measured: the moment design (cos Δ, 1, same-scale) is rank 2 at k = 3 for any items/scale, rank 3 from k = 4. Jeff accepted.
+- 2026-07-25: implement gate — spacing tolerance is float-representation only, never near-equal spacing (Jeff; keeps RR09 §4's quasi-circumplex refusal intact).
+- 2026-07-25: refusals use `stop(call. = FALSE)` matching all 26 in the file; the profile's cli_abort slot would need cli as a new dependency (gate + D-entry) for no gain.
 
 ## Decisions
 

--- a/cairn/milestones/M60-axes-reliability-equal-spacing.md
+++ b/cairn/milestones/M60-axes-reliability-equal-spacing.md
@@ -5,7 +5,7 @@
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** `m60-axes-reliability-equal-spacing`
+- **Branch/PR:** `m60-axes-reliability-equal-spacing` / [PR #86](https://github.com/jmgirard/circumplex/pull/86)
 
 ## Goal
 
@@ -47,29 +47,29 @@ any rotation, instead of only the canonical octant set.
 
 ## Acceptance criteria
 
-- [ ] AC1: `axes_reliability()` estimates a rotated equally spaced set (the
+- [x] AC1: `axes_reliability()` estimates a rotated equally spaced set (the
       type-b interstitial angles 22.5…337.5) and a k ≠ 8 set (k = 6 and k = 12),
       returning finite equal per-axis reliability; the octant-only error no
       longer fires.
-- [ ] AC2: each refusal still fires with a message naming the offender —
+- [x] AC2: each refusal still fires with a message naming the offender —
       unequal spacing, duplicate angle, NA angle, k < 4 (naming identification
       as the reason at k = 3), and < 2 items on any scale.
-- [ ] AC3: the spacing test is modular — a set expressed with LM = 360 is
+- [x] AC3: the spacing test is modular — a set expressed with LM = 360 is
       accepted identically to the same set using 0, and a set carrying both 0
       and 360 is refused as a duplicate.
-- [ ] AC4: per-axis item_n equals `n_items × k/2` for every accepted
+- [x] AC4: per-axis item_n equals `n_items × k/2` for every accepted
       configuration at any rotation, at a tolerance set from the discrimination
       required rather than from one machine's printed value (M59, M20).
-- [ ] AC5: Layer A — all four CV-LI type-b rows of Strack (2013) Table 3
+- [x] AC5: Layer A — all four CV-LI type-b rows of Strack (2013) Table 3
       (%axes 3.5 / 2.7 / 1.9 / 7.6 at item_n 16 → .37 / .31 / .24 / .57;
       `strack2013` p. 7) reproduce within ±.01.
-- [ ] AC6: Layer B at a rotated-octant and a non-octant configuration —
+- [x] AC6: Layer B at a rotated-octant and a non-octant configuration —
       population-matrix recovery exact to numerical tolerance, synthetic
       recovery, and cross-engine lavaan/OpenMx agreement.
-- [ ] AC7: no doc still claims octant-only — roxygen, regenerated `man/`,
+- [x] AC7: no doc still claims octant-only — roxygen, regenerated `man/`,
       vignette and NEWS updated, and the type-b oracle rows banked in
       `cairn/references/strack2013.md` with a provenance re-verification mark.
-- [ ] AC8: `devtools::check()` clean and the PDF manual actually built
+- [x] AC8: `devtools::check()` clean and the PDF manual actually built
       (`R CMD Rd2pdf`; `check()` skips it by default — M7/M57).
 
 ## Coverage
@@ -122,6 +122,7 @@ any rotation, instead of only the canonical octant set.
 - 2026-07-25: T8 `devtools::check()` OK (0/0/0, 9m30s) and the PDF manual built directly (`R CMD Rd2pdf`, 76pp) — the check log has zero occurrences of "checking PDF version of manual", confirming `--no-manual` skipped it, which is how M7 and M57 each shipped a CRAN-blocking failure. New Rd section verified present in the rendered PDF. No new D-entry owed: D-031 already admits M60 to v2.0.0.
 - 2026-07-25: all tasks done; status -> review.
 - 2026-07-25: refusals use `stop(call. = FALSE)` matching all 26 in the file; the profile's cli_abort slot would need cli as a new dependency (gate + D-entry) for no gain.
+- 2026-07-25: review checkpoint — PR #86 opened (draft); all 8 ACs verified with fresh evidence and ticked; consistency gate clean. Review fan-out: prior-review lens clean, blame lens 1 finding (strack2013.md provenance overclaim), diff-bug lens still running. CI pending. Not yet triaged or merged.
 
 ## Decisions
 
@@ -134,3 +135,60 @@ any rotation, instead of only the canonical octant set.
 - 2026-07-25 (T2): the wrap-around gap in `angles_spacing_status()` is kept for symmetry with the modular reading but is NOT load-bearing — all gaps sum to 360, so k-1 interior gaps of 360/k force it. Mutation-verified: removing the term changes no test. The comment says so rather than claiming a mechanism it does not have (M36).
 
 ## Review
+
+Verified 2026-07-25 on `m60-axes-reliability-equal-spacing` @ df0c62db, PR #86.
+Evidence is fresh (commands re-run at review), never recalled.
+
+**AC1** — `M60: a rotated equally spaced set estimates (Strack type b)` 5/5 and
+`M60: equally spaced sets with k != 8 estimate` 6/6. The type-b set (22.5…337.5)
+and k = 6 / k = 12 all return finite per-axis reliability in (0, 1), equal across
+axes to 1e-6, with `details$n_scales` recording k. The block also asserts the
+type-b weight magnitudes reaching the model are .38268 / .92388, matching p. 2.
+
+**AC2** — `M60: the refusal contract survives the relaxation` 7/7: unequal
+spacing at +5° and at +1e-4, duplicate position, NA angle, k = 3 (message names
+identification), k = 2 (names the 4-scale floor), and < 2 items per scale. The
+pre-existing BC12 refusal block also still passes with its three re-pointed
+message strings.
+
+**AC3** — `M60: the spacing test is modular at the pole` 2/2 (LM = 360 form and
+0 form give identical reliability; 0-and-360 together refused as a duplicate),
+plus `angles_spacing_status()` 56/56 covering k = 4:24 at two rotations,
+near-misses at 1e-4, and out-of-range angles.
+
+**AC4** — `M60: per-axis item_n is n * k/2 at any rotation` 315/315 over
+k = 4:16 × 4 rotations × 3 item counts, at an absolute tolerance of 1e-8 chosen
+from the discrimination required (one item = 1.0, so it fences at 1e8×) rather
+than from a printed value. BC3's exact octant `expect_identical()` retained
+unweakened; an unbalanced set gives legitimately unequal per-axis values.
+
+**AC5** — `M60: Spearman-Brown reproduces the non-octant Table 3 rows` 5/5. All
+four CV-LI type-b rows reproduce within ±.01 (.367/.308/.237/.568 against
+printed .37/.31/.24/.57) and all four sum to 100.0. Includes a discrimination
+assertion that the same sweep read at the octant item_n of 32 fails.
+
+**AC6** — `M60: exact population recovery holds at rotated and non-octant sets`
+24/24 across four geometries (type-b rotated octants, k = 6, k = 12, k = 5 at a
+13.7° rotation): every component recovered to < 1e-4 with chisq < 1e-6.
+Monte-Carlo recovery 1/1 within 2 MC-SEs at the rotated set; lavaan/OpenMx
+agreement 2/2 at < 1e-3.
+
+**AC7** — roxygen gained a "Which instruments this accepts" section; `man/`
+regenerated and `devtools::document()` produces no diff; vignette §6 and the
+NEWS `axes_reliability()` bullet updated. A fresh grep for "octant" across
+`man/`, the vignette and NEWS finds no surviving octant-only claim — every hit
+either describes the (genuinely octant) example dataset or frames octants as one
+option among many. Six CV-LI references banked in `references/strack2013.md`
+with the `Type`-column finding and an inline provenance re-verification mark.
+
+**AC8** — `devtools::check()` OK, 0 errors / 0 warnings / 0 notes, 9m30s. PDF
+manual built directly via `R CMD Rd2pdf` (76pp); the check log contains zero
+occurrences of "checking PDF version of manual", confirming the step was skipped
+by `check()` itself, and the new Rd section was verified present in the render.
+
+**Consistency gate.** `cairn_validate` exit 0, all 16 checks PASS (2 advisories:
+sizing at 8 ACs — the 8th is the template-mandated check criterion, judged not a
+split; work-log format, 47 pre-existing M7 lines). No DESIGN principle changed,
+so `cairn_impact` does not apply. Toolchain slot: `document()` no-diff ✔,
+`pkgdown::check_pkgdown()` "No problems found" ✔, NEWS entry present ✔, README
+untouched ✔, no new top-level files ✔, full check clean ✔.

--- a/cairn/milestones/M60-axes-reliability-equal-spacing.md
+++ b/cairn/milestones/M60-axes-reliability-equal-spacing.md
@@ -89,10 +89,10 @@ any rotation, instead of only the canonical octant set.
       error at `R/axes_reliability.R:495-506`; pin that as the failing fence,
       and pin every refusal that must survive
       (`tests/testthat/test-axes-reliability.R:442-476`).
-- [ ] T2: extract a modular equal-spacing predicate (pole-aware, wrap-around
+- [x] T2: extract a modular equal-spacing predicate (pole-aware, wrap-around
       gap, tolerance-based); no such helper exists anywhere in `R/`. Unit-test
       at the pole and against near-miss spacings.
-- [ ] T3: replace the refusal block with count / spacing / duplicate checks and
+- [x] T3: replace the refusal block with count / spacing / duplicate checks and
       informative messages; keep the ≥ 2-items-per-scale gate.
 - [ ] T4: rotation-invariance tests for `axis_item_n()`
       (`R/axes_reliability.R:31-34`) — `n × k/2`; keep the exact-equality octant
@@ -113,8 +113,11 @@ any rotation, instead of only the canonical octant set.
 - 2026-07-25: amended Scope + AC2 at the implement gate — scale-count floor 3 → 4, measured: the moment design (cos Δ, 1, same-scale) is rank 2 at k = 3 for any items/scale, rank 3 from k = 4. Jeff accepted.
 - 2026-07-25: implement gate — spacing tolerance is float-representation only, never near-equal spacing (Jeff; keeps RR09 §4's quasi-circumplex refusal intact).
 - 2026-07-25: T1 fence added (4 test blocks, rotated/k!=8/refusals/pole); red for the right reason — the octant-only refusals at :485-506, not an incidental error. Suite stays red by design until T3.
+- 2026-07-25: T2 `angles_spacing_status()` (modular, tol = 1e-8 = float noise only) + 15 unit assertions incl. k = 4:24 at two rotations; T3 wired it into the refuse contract and re-pointed the three stale BC12 message expectations. Suite green (232).
 - 2026-07-25: refusals use `stop(call. = FALSE)` matching all 26 in the file; the profile's cli_abort slot would need cli as a new dependency (gate + D-entry) for no gain.
 
 ## Decisions
+
+- 2026-07-25 (T2): the wrap-around gap in `angles_spacing_status()` is kept for symmetry with the modular reading but is NOT load-bearing — all gaps sum to 360, so k-1 interior gaps of 360/k force it. Mutation-verified: removing the term changes no test. The comment says so rather than claiming a mechanism it does not have (M36).
 
 ## Review

--- a/cairn/references/strack2013.md
+++ b/cairn/references/strack2013.md
@@ -7,7 +7,7 @@ Pagination: the article's own page numbers. The PDF is **born-digital**
 (`Creator: Adobe InDesign CS5.5`, `Producer: Adobe PDF Library 9.9`) — not an
 OCR scan — so its `pdftotext` text layer is the typeset text itself, a faithful
 witness (unlike the `hubert1987`/`tracey1997` OCR scans).
-Extraction: verified 2026-07-23 against the born-digital `pdftotext -layout` text layer, with Table 3 and every formula below additionally cross-read against the layout-preserved rendering; no value read by a second human channel — observed 2026-07-23.
+Extraction: verified 2026-07-23 against the born-digital `pdftotext -layout` text layer, with Table 3 and every formula below additionally cross-read against the layout-preserved rendering; re-verified 2026-07-25 (M60) on p. 7, where the `Type` column and the type-b, type-c, type-e and type-f rows were read in both channels — the text layer and a 200-dpi page-image render — agreeing on every banked value; no value read by a second human channel — observed 2026-07-25.
 
 **Citation.** Strack, M., Jacobs, I., & Grosse Holtforth, M. (2013). Reliability
 of Circumplex Axes. *SAGE Open*, 3(2), 1–12. DOI 10.1177/2158244013486115.
@@ -106,6 +106,33 @@ Variance components banked too (cols 5–9): %general (col 5), %axes (col 6),
 | IMI   | 6 | Other |  1.7 | 27.9 | 5.9 | 64.5 | 32 | .92 | 100.0 |
 | SAS-C | 8 | Self  |  4.8 | 17.8 | 6.2 | 71.2 | 32 | .87 | 100.0 |
 | IPI-A | 9 | Self  | 19.2 | 13.4 | 2.8 | 64.6 | 16 | .71 | 100.0 |
+
+**Column (1) is `Type`** — Table 3 labels every row with its Figure 1 circumplex
+type (a–f), so the paper publishes reliability anchors for the non-octant types,
+not only for type a. Banked below for M60 (types b, c) and M61 (the single-item
+types e, f); type d (OCAI) carries block-specificity and waits on ζ2.
+
+**Type-b rows (CV-LI, equal 45° spacing rotated 22.5° off the axes; p. 2).**
+All four sum to 100.0, and all four reproduce col 11 by Spearman–Brown on
+col 6 / col 10 within ±.01 (.367, .308, .237, .568 against .37, .31, .24, .57):
+
+| Instrument | Sample | Persp. | %gen | %axes | %scale | %item | item_n | Rel | sum |
+|---|---|---|---|---|---|---|---|---|---|
+| CV-LI | 12 | Self  | 22.6 | 3.5 | 19.6 | 54.3 | 16 | .37 | 100.0 |
+| CV-LI | 12 | Other | 42.9 | 2.7 | 15.0 | 39.4 | 16 | .31 | 100.0 |
+| CV-LI | 12 | Meta  | 35.4 | 1.9 | 19.6 | 43.1 | 16 | .24 | 100.0 |
+| CV-LI | 13 | Self  | 19.6 | 7.6 | 19.7 | 53.1 | 16 | .57 | 100.0 |
+
+**Type-c row (MEIL, Sample 14 Self): %gen 4.3, %axes 5.5, %scale 27.9, %item
+36.7, item_n 30, Rel .63 — components sum to 74.4, not 100.0.** A second source
+defect, independent of the IIP S6 erratum below and already noted by RR10 from
+the text layer; the page image agrees, so it is the source, not the
+transcription. The 25.6 points are unaccounted for and col 8 is `—`. The
+reliability column is nonetheless self-consistent: SB(.055, 30) = .6358
+reproduces the printed .63 within ±.01, so the row is usable as a Layer-A
+reliability anchor while its component row is not usable as a sum guard.
+The instrument's scale count is not printed, so k cannot be derived from the
+table — observed 2026-07-25.
 
 **SEm cross-check inputs (col 12 Raw variance, col 13 SEm), banked for BC2:**
 IAL S1 Self 0.98 → 0.28; OCAI S15 Self 15.95 → 2.78; COC S16 Self 6.70 → 2.33.

--- a/cairn/references/strack2013.md
+++ b/cairn/references/strack2013.md
@@ -7,7 +7,7 @@ Pagination: the article's own page numbers. The PDF is **born-digital**
 (`Creator: Adobe InDesign CS5.5`, `Producer: Adobe PDF Library 9.9`) — not an
 OCR scan — so its `pdftotext` text layer is the typeset text itself, a faithful
 witness (unlike the `hubert1987`/`tracey1997` OCR scans).
-Extraction: verified 2026-07-23 against the born-digital `pdftotext -layout` text layer, with Table 3 and every formula below additionally cross-read against the layout-preserved rendering; re-verified 2026-07-25 (M60) on p. 7, where the `Type` column and the type-b, type-c, type-e and type-f rows were read in both channels — the text layer and a 200-dpi page-image render — agreeing on every banked value; no value read by a second human channel — observed 2026-07-25.
+Extraction: verified 2026-07-23 against the born-digital `pdftotext -layout` text layer, with Table 3 and every formula below additionally cross-read against the layout-preserved rendering; re-verified 2026-07-25 (M60) on p. 7, where the `Type` column and the type-b and type-c rows banked below were read in both channels — the text layer and a 200-dpi page-image render — agreeing on every value (the type-e and type-f rows on that page are NOT banked here and carry no verification claim; they are M61's to bank); no value read by a second human channel — observed 2026-07-25.
 
 **Citation.** Strack, M., Jacobs, I., & Grosse Holtforth, M. (2013). Reliability
 of Circumplex Axes. *SAGE Open*, 3(2), 1–12. DOI 10.1177/2158244013486115.

--- a/man/axes_reliability.Rd
+++ b/man/axes_reliability.Rd
@@ -25,7 +25,10 @@ character vector (or numeric indices) of that scale's item columns.}
 
 \item{angles}{A numeric vector of the scales' angles in degrees (one per
 scale), required for the explicit map and forbidden with \code{instrument}
-(which supplies its own). Use \code{\link[=octants]{octants()}}.}
+(which supplies its own). Must be equally spaced around the circle, at any
+rotation, with at least four scales; \code{\link[=octants]{octants()}} gives the canonical eight.
+Angles outside \verb{[0, 360)} are reduced onto their circumplex positions, so
+0 and 360 name the same position.}
 
 \item{instrument}{Optional. A \code{circumplex_instrument} object supplying the
 scale angles and item membership (\code{Scales$Angle}, \code{Scales$Items}).}
@@ -52,7 +55,7 @@ indices), and \code{details}.
 }
 \description{
 Estimate the reliability (and standard error of measurement) of the two
-circumplex axes of an octant instrument with the item-level restricted
+circumplex axes of an instrument with the item-level restricted
 tau-equivalent CFA of Strack, Jacobs, and Grosse Holtforth (2013). The model
 decomposes each item's variance into orthogonal components -- a general
 factor, the two circumplex axes, scale specificity, and item specificity --
@@ -78,8 +81,24 @@ Because the model is fit to the item \strong{correlation} matrix as if it were a
 covariance matrix (the paper's own practice), the component point estimates
 and the reliabilities are correct, but the component standard errors and the
 global chi-square are \strong{approximate} (Cudeck, 1989). Results are reported
-\strong{per axis} (X and Y): for a balanced octant instrument the two axes carry
-the same axes-variance estimate and differ only through \code{item_n}.
+\strong{per axis} (X and Y): for a balanced instrument the two axes carry the
+same axes-variance estimate and differ only through \code{item_n}.
+}
+\section{Which instruments this accepts}{
+Any set of \strong{equally spaced} scale angles, at any rotation: the canonical
+octants, an interstitial set rotated 22.5 degrees off the axes, or a
+non-octant count such as six or twelve scales. What matters is equal spacing,
+not the count or the starting angle -- for any equally spaced set of \code{k}
+scales, each axis draws the same effective test length (\code{k / 2} per item),
+which is what keeps the equal-axis-variance restriction as innocuous as it
+is for octants.
+
+Two limits. At least \strong{four} scales are required: with three, every pair of
+scales sits the same angular distance apart, and the general, axes, and
+scale-specificity variances are then not separately identified. And spacing
+must be equal, not merely close -- a quasi-circumplex is refused rather than
+approximated, since Strack et al. (2013) excluded such instruments from the
+model's validation. Every scale still needs at least two items.
 
 Missing data are handled by \strong{listwise deletion only} (a message reports the
 complete-case count); pairwise correlation input is never used. A boundary
@@ -87,6 +106,7 @@ fit (a non-positive estimated axes variance, or any negative estimated
 variance) returns \code{NA} reliability and SEm with a warning and a boundary flag
 rather than a clipped or negative value.
 }
+
 \section{Supplying a correlation matrix instead of raw data}{
 Give \code{cormat} and \code{n} in place of \code{data} to estimate from an item correlation
 matrix that someone else published, with no raw data in hand. The matrix must

--- a/tests/testthat/test-axes-reliability.R
+++ b/tests/testthat/test-axes-reliability.R
@@ -945,3 +945,119 @@ test_that("AC5: each malformed cormat/n input errors informatively", {
   expect_error(ok(cormat = R, n = p), "greater than the number of items")
   expect_error(ok(cormat = R, n = p - 1L), "greater than the number of items")
 })
+
+# M60 axes_reliability(): any equally spaced angle set, any rotation ----------
+
+# A fixture at an arbitrary equally spaced angle set. Unlike
+# axes_valid_fixture(), the scale count is a parameter, so the split() group
+# levels are pinned explicitly -- a bare numeric group vector is coerced to a
+# factor whose levels sort as CHARACTER ("1", "10", "11", "12", "2", ...), which
+# would silently pair scale 10's items with angle 2 at k >= 10 (the M34/M33
+# alphabetical-ordering family).
+axes_spaced_fixture <- function(angles, n = 1500L, k = 4L, xi1 = .20,
+                                seed = 42L) {
+  set.seed(seed)
+  dat <- axes_simulate(n, angles, k, xi1, .05, .08)
+  inames <- sprintf("i%02d", seq_len(ncol(dat)))
+  colnames(dat) <- inames
+  grp <- factor(rep(seq_along(angles), each = k), levels = seq_along(angles))
+  list(data = dat, angles = angles, items = split(inames, grp), names = inames)
+}
+
+test_that("M60: a rotated equally spaced set estimates (Strack type b)", {
+  skip_if_not_installed("lavaan")
+  # Type b: eight scales at 45 deg spacing, rotated 22.5 deg off the axes
+  # (strack2013 p. 2 -- weights +/-.38268 and +/-.92388).
+  ang <- seq(22.5, 337.5, by = 45)
+  fx <- axes_spaced_fixture(ang)
+  res <- suppressMessages(
+    axes_reliability(fx$data, items = fx$items, angles = fx$angles)
+  )
+  expect_s3_class(res, "circumplex_axes_reliability")
+  expect_true(all(is.finite(res$results$reliability)))
+  expect_true(all(res$results$reliability > 0 & res$results$reliability < 1))
+  # The equal-axis-variance restriction makes both axes agree at any rotation.
+  expect_equal(res$results$reliability[[1]], res$results$reliability[[2]],
+               tolerance = 1e-6)
+  # The type-b magnitudes actually reached the model.
+  w <- abs(axis_weights(ang))
+  expect_equal(sort(unique(round(w, 5))), c(0.38268, 0.92388))
+})
+
+test_that("M60: equally spaced sets with k != 8 estimate", {
+  skip_if_not_installed("lavaan")
+  for (k in c(6L, 12L)) {
+    ang <- (seq_len(k) - 1L) * (360 / k)
+    fx <- axes_spaced_fixture(ang, n = 2000L)
+    res <- suppressMessages(
+      axes_reliability(fx$data, items = fx$items, angles = fx$angles)
+    )
+    expect_true(all(is.finite(res$results$reliability)), label = paste("k =", k))
+    expect_equal(res$results$reliability[[1]], res$results$reliability[[2]],
+                 tolerance = 1e-6)
+    expect_identical(res$details$n_scales, k)
+  }
+})
+
+test_that("M60: the refusal contract survives the relaxation", {
+  skip_if_not_installed("lavaan")
+  fx <- axes_spaced_fixture(octants())
+  bad <- function(angles = fx$angles, items = fx$items) {
+    suppressMessages(axes_reliability(fx$data, items = items, angles = angles))
+  }
+
+  # Unequal spacing stays refused -- a quasi-circumplex is out of scope, and the
+  # tolerance admits float representation error only (RR09 section 4).
+  ang <- fx$angles
+  ang[[1]] <- ang[[1]] + 5
+  expect_error(bad(ang), "equally spaced")
+  # A departure far too small to be a real design, but far larger than float
+  # noise, is still refused.
+  ang2 <- fx$angles
+  ang2[[1]] <- ang2[[1]] + 1e-4
+  expect_error(bad(ang2), "equally spaced")
+
+  # Duplicates, NAs.
+  dup <- fx$angles
+  dup[[2]] <- dup[[1]]
+  expect_error(bad(dup), "duplicat")
+  na_ang <- fx$angles
+  na_ang[[3]] <- NA_real_
+  expect_error(bad(na_ang), "missing")
+
+  # Fewer than 4 scales: at k = 3 every cross-scale pair carries the same
+  # cos(delta) = -0.5, so the moment design (cos delta, 1, same-scale) drops to
+  # rank 2 and the three components are not separately identified.
+  expect_error(bad(c(0, 120, 240), fx$items[1:3]), "identif")
+  expect_error(bad(c(0, 180), fx$items[1:2]), "at least 4")
+
+  # Fewer than 2 items on a scale (M61 territory, still refused here).
+  one <- fx$items
+  one[[1]] <- one[[1]][1]
+  expect_error(bad(items = one), "at least 2 items")
+})
+
+test_that("M60: the spacing test is modular at the pole", {
+  skip_if_not_installed("lavaan")
+  fx <- axes_spaced_fixture(octants())
+  # octants() carries LM = 360; the same set written with 0 must behave
+  # identically, not read as unequally spaced.
+  zero_form <- as.numeric(fx$angles)
+  zero_form[zero_form == 360] <- 0
+  a <- suppressMessages(
+    axes_reliability(fx$data, items = fx$items, angles = fx$angles)
+  )
+  b <- suppressMessages(
+    axes_reliability(fx$data, items = fx$items, angles = zero_form)
+  )
+  expect_equal(a$results$reliability, b$results$reliability)
+  # But 0 and 360 in the SAME set are one position twice -- a duplicate.
+  both <- as.numeric(fx$angles)
+  both[both == 45] <- 0 # now carries both 0 and 360
+  expect_error(
+    suppressMessages(
+      axes_reliability(fx$data, items = fx$items, angles = both)
+    ),
+    "duplicat"
+  )
+})

--- a/tests/testthat/test-axes-reliability.R
+++ b/tests/testthat/test-axes-reliability.R
@@ -1145,3 +1145,42 @@ test_that("M60: per-axis item_n is n * k/2 at any rotation", {
   expect_equal(unb[["x"]], 6, tolerance = tol)
   expect_equal(unb[["y"]], 2, tolerance = tol)
 })
+
+test_that("M60: Spearman-Brown reproduces the non-octant Table 3 rows (Layer A)", {
+  # Strack et al. (2013) Table 3 col 1 is the circumplex TYPE, so the paper
+  # publishes anchors beyond type a. Banked in cairn/references/strack2013.md
+  # (two channels on p. 7: pdftotext text layer + page-image render).
+
+  # Type b -- CV-LI, eight scales at 45 deg rotated 22.5 deg off the axes
+  # (p. 2). This is exactly the configuration M60 unlocks.
+  typeb <- data.frame(
+    row    = c("CVLI12S", "CVLI12O", "CVLI12M", "CVLI13S"),
+    gen    = c(22.6, 42.9, 35.4, 19.6),
+    axes   = c(3.5, 2.7, 1.9, 7.6),
+    scale  = c(19.6, 15.0, 19.6, 19.7),
+    item   = c(54.3, 39.4, 43.1, 53.1),
+    item_n = c(16, 16, 16, 16),
+    rel    = c(.37, .31, .24, .57)
+  )
+  # Every type-b row is internally consistent -- unlike the IIP S6 erratum, no
+  # exception carve-out is needed here.
+  expect_true(all(abs(
+    typeb$gen + typeb$axes + typeb$scale + typeb$item - 100.0
+  ) <= 0.1))
+  expect_true(all(abs(
+    axis_reliability_sb(typeb$axes / 100, typeb$item_n) - typeb$rel
+  ) <= .01))
+
+  # Type c -- MEIL S14 Self. Its COMPONENTS are a second source defect (they sum
+  # to 74.4, not 100.0; both extraction channels agree, and RR10 saw it in the
+  # text layer), so this row is asserted as a reliability anchor only, never as
+  # a component-sum guard.
+  expect_true(abs(4.3 + 5.5 + 27.9 + 36.7 - 74.4) <= 0.1) # the defect, pinned
+  expect_true(abs(axis_reliability_sb(.055, 30) - .63) <= .01)
+
+  # The sweep discriminates: it is not satisfied by any item_n. Reading the
+  # type-b rows at the octant item_n of 32 would miss every printed value.
+  expect_false(all(abs(
+    axis_reliability_sb(typeb$axes / 100, 32) - typeb$rel
+  ) <= .01))
+})

--- a/tests/testthat/test-axes-reliability.R
+++ b/tests/testthat/test-axes-reliability.R
@@ -1101,6 +1101,14 @@ test_that("M60: angles_spacing_status() classifies at the pole and near-misses",
   # NA is classified, never silently dropped by sort().
   expect_identical(angles_spacing_status(c(0, 90, NA, 270)), "missing")
 
+  # Angles supplied outside [0, 360) reduce onto their circumplex positions.
+  # This is the ONLY case that pins the `%% 360` reduction: with it removed,
+  # the octant sets and the 0-and-360 duplicate below still classify correctly
+  # (the wrap gap compensates), but this set is misread as a duplicate.
+  expect_identical(angles_spacing_status(c(10, 100, 190, 640)), "ok")
+  expect_identical(angles_spacing_status(c(-90, 0, 90, 180)), "ok")
+  expect_identical(angles_spacing_status(c(0, 90, 180, 270, 450)), "duplicate")
+
   # The tolerance is loose enough for an exactly-constructed odd set, whose
   # gaps carry real float error (360/7 is not representable).
   expect_identical(angles_spacing_status((0:6) * (360 / 7)), "ok")

--- a/tests/testthat/test-axes-reliability.R
+++ b/tests/testthat/test-axes-reliability.R
@@ -204,7 +204,10 @@ axes_mc_recover_xi1 <- function(oct, k, xi1, xi2, zeta1, n, reps, seed) {
   set.seed(seed)
   pop <- axes_population_cor(oct, k, xi1, xi2, zeta1)
   inames <- sprintf("item_%02d", seq_along(pop$scale))
-  items <- split(inames, pop$scale)
+  # Pin the split() levels: a bare numeric group vector becomes a factor whose
+  # levels sort as CHARACTER, so at k >= 10 scale 10 would pair with angle 2.
+  # A no-op at k = 8; required now that M60 makes k >= 10 reachable.
+  items <- split(inames, factor(pop$scale, levels = seq_along(oct)))
   est <- numeric(reps)
   for (r in seq_len(reps)) {
     dat <- as.data.frame(scale(axes_simulate(n, oct, k, xi1, xi2, zeta1)))
@@ -300,7 +303,8 @@ test_that("BC7: lavaan and OpenMx agree on the component variances (Layer B)", {
     p <- ncol(dat)
     inames <- sprintf("i%02d", seq_len(p))
     colnames(dat) <- inames
-    items <- split(inames, rep(seq_along(oct), each = k))
+    items <- split(inames, factor(rep(seq_along(oct), each = k),
+                                  levels = seq_along(oct))) # see M60 note above
     S <- stats::cov(dat)
 
     lav <- axes_lav_components(S, 2000L, items, oct)
@@ -1183,4 +1187,81 @@ test_that("M60: Spearman-Brown reproduces the non-octant Table 3 rows (Layer A)"
   expect_false(all(abs(
     axis_reliability_sb(typeb$axes / 100, 32) - typeb$rel
   ) <= .01))
+})
+
+# M60 Layer-B: the BC5/BC6/BC7 oracles re-run at the configurations M60 unlocks
+# -- a rotated octant set (Strack type b, no weight lands on 0) and non-octant
+# counts (k = 6, k = 12, where scales DO sit on the poles). The estimator's
+# geometry-specific risk lives in the weights and the moment design, which the
+# exact population cell exercises completely.
+
+axes_pop_recovers <- function(angles, k, xi1, xi2, zeta1) {
+  pop <- axes_population_cor(angles, k, xi1, xi2, zeta1)
+  sigma <- pop$sigma
+  p <- nrow(sigma)
+  inames <- sprintf("i%02d", seq_len(p))
+  dimnames(sigma) <- list(inames, inames)
+  items <- split(inames, factor(pop$scale, levels = seq_along(angles)))
+  fit <- lavaan::cfa(
+    axes_syntax(items, angles),
+    sample.cov = sigma, sample.nobs = 500L,
+    orthogonal = TRUE, likelihood = "wishart"
+  )
+  pe <- lavaan::parameterEstimates(fit)
+  vv <- function(lat) pe$est[pe$op == "~~" & pe$lhs == lat & pe$rhs == lat][[1]]
+  list(
+    converged = lavaan::lavInspect(fit, "converged"),
+    est = c(xi1 = vv("AX"), xi1b = vv("AY"), xi2 = vv("GEN"),
+            zeta1 = vv("SS1")),
+    chisq = unname(lavaan::fitMeasures(fit, "chisq"))
+  )
+}
+
+test_that("M60: exact population recovery holds at rotated and non-octant sets", {
+  skip_if_not_installed("lavaan")
+  xi1 <- .15; xi2 <- .08; zeta1 <- .12
+  cells <- list(
+    `type-b rotated octants` = seq(22.5, 337.5, by = 45),
+    `k = 6` = (seq_len(6L) - 1L) * 60,
+    `k = 12` = (seq_len(12L) - 1L) * 30,
+    `k = 5 at an odd rotation` = (seq_len(5L) - 1L) * 72 + 13.7
+  )
+  for (nm in names(cells)) {
+    got <- axes_pop_recovers(cells[[nm]], k = 3L, xi1, xi2, zeta1)
+    expect_true(got$converged, label = nm)
+    # Exact at the population matrix -- no Monte-Carlo slack.
+    expect_lt(abs(got$est[["xi1"]] - xi1), 1e-4)
+    expect_lt(abs(got$est[["xi1b"]] - xi1), 1e-4)
+    expect_lt(abs(got$est[["xi2"]] - xi2), 1e-4)
+    expect_lt(abs(got$est[["zeta1"]] - zeta1), 1e-4)
+    expect_lt(got$chisq, 1e-6)
+  }
+})
+
+test_that("M60: Monte-Carlo recovery holds at a rotated octant set (Layer B)", {
+  skip_if_not_installed("lavaan")
+  mc <- axes_mc_recover_xi1(
+    seq(22.5, 337.5, by = 45), k = 4L, xi1 = .15, xi2 = .05, zeta1 = .08,
+    n = 1500L, reps = 100L, seed = 60L
+  )
+  expect_lt(abs(mc$mean - .15), 2 * mc$mcse)
+})
+
+test_that("M60: lavaan and OpenMx agree at a non-octant set (Layer B)", {
+  skip_if_not_installed("lavaan")
+  skip_if_not_installed("OpenMx")
+  for (ang in list(seq(22.5, 337.5, by = 45), (seq_len(6L) - 1L) * 60)) {
+    k <- 4L
+    set.seed(60L)
+    dat <- as.data.frame(scale(axes_simulate(2000L, ang, k, .15, .05, .10)))
+    p <- ncol(dat)
+    inames <- sprintf("i%02d", seq_len(p))
+    colnames(dat) <- inames
+    items <- split(inames, factor(rep(seq_along(ang), each = k),
+                                  levels = seq_along(ang)))
+    S <- stats::cov(dat)
+    lav <- axes_lav_components(S, 2000L, items, ang)
+    mx <- axes_mx_components(S, 2000L, ang, k)
+    expect_lt(max(abs(lav - mx)), 1e-3)
+  }
 })

--- a/tests/testthat/test-axes-reliability.R
+++ b/tests/testthat/test-axes-reliability.R
@@ -204,9 +204,10 @@ axes_mc_recover_xi1 <- function(oct, k, xi1, xi2, zeta1, n, reps, seed) {
   set.seed(seed)
   pop <- axes_population_cor(oct, k, xi1, xi2, zeta1)
   inames <- sprintf("item_%02d", seq_along(pop$scale))
-  # Pin the split() levels: a bare numeric group vector becomes a factor whose
-  # levels sort as CHARACTER, so at k >= 10 scale 10 would pair with angle 2.
-  # A no-op at k = 8; required now that M60 makes k >= 10 reachable.
+  # Levels pinned explicitly so the scale->angle pairing is stated rather than
+  # inferred. (split() on a NUMERIC group vector already orders levels
+  # numerically, so this is equivalent, not a fix -- only a CHARACTER group
+  # vector would sort "10" before "2".)
   items <- split(inames, factor(pop$scale, levels = seq_along(oct)))
   est <- numeric(reps)
   for (r in seq_len(reps)) {
@@ -304,7 +305,7 @@ test_that("BC7: lavaan and OpenMx agree on the component variances (Layer B)", {
     inames <- sprintf("i%02d", seq_len(p))
     colnames(dat) <- inames
     items <- split(inames, factor(rep(seq_along(oct), each = k),
-                                  levels = seq_along(oct))) # see M60 note above
+                                  levels = seq_along(oct))) # levels stated, see above
     S <- stats::cov(dat)
 
     lav <- axes_lav_components(S, 2000L, items, oct)
@@ -956,10 +957,11 @@ test_that("AC5: each malformed cormat/n input errors informatively", {
 
 # A fixture at an arbitrary equally spaced angle set. Unlike
 # axes_valid_fixture(), the scale count is a parameter, so the split() group
-# levels are pinned explicitly -- a bare numeric group vector is coerced to a
-# factor whose levels sort as CHARACTER ("1", "10", "11", "12", "2", ...), which
-# would silently pair scale 10's items with angle 2 at k >= 10 (the M34/M33
-# alphabetical-ordering family).
+# levels are pinned explicitly, stating the scale->angle pairing rather than
+# leaving it to coercion. This is equivalence, not a repair: split() coerces a
+# NUMERIC group vector with factor(), whose levels sort numerically, so 1:12
+# already pairs correctly. Only a CHARACTER group vector would sort "10" before
+# "2" -- the hazard the M33/M34 ordering lessons describe.
 axes_spaced_fixture <- function(angles, n = 1500L, k = 4L, xi1 = .20,
                                 seed = 42L) {
   set.seed(seed)
@@ -1043,6 +1045,18 @@ test_that("M60: the refusal contract survives the relaxation", {
   one <- fx$items
   one[[1]] <- one[[1]][1]
   expect_error(bad(items = one), "at least 2 items")
+
+  # A non-finite angle must be REFUSED BY NAME, not carried into the fit.
+  # anyNA() does not reject Inf, and `Inf %% 360` is NaN which sort() drops, so
+  # without an is.finite() gate the spacing test reads the SURVIVING angles as
+  # equally spaced and the run dies later in qr.solve() naming nothing.
+  inf_ang <- fx$angles
+  inf_ang[[2]] <- Inf
+  expect_error(bad(inf_ang), "must be finite")
+  expect_error(bad(inf_ang), "scale\\(s\\) 2")
+  neg_inf <- fx$angles
+  neg_inf[[5]] <- -Inf
+  expect_error(bad(neg_inf), "must be finite")
 })
 
 test_that("M60: the spacing test is modular at the pole", {
@@ -1102,8 +1116,15 @@ test_that("M60: angles_spacing_status() classifies at the pole and near-misses",
   # interior gaps of 360/k force the wrap gap to match. Verified by mutation.)
   expect_identical(angles_spacing_status(c(0, 10, 20, 30)), "unequal")
 
-  # NA is classified, never silently dropped by sort().
-  expect_identical(angles_spacing_status(c(0, 90, NA, 270)), "missing")
+  # Non-finite angles are classified, never silently dropped by sort(). Inf is
+  # the dangerous one: anyNA() does not reject it, `Inf %% 360` is NaN, and
+  # sort() drops NaN -- so without this branch the surviving angles could
+  # satisfy 360/k and the set would read as "ok".
+  expect_identical(angles_spacing_status(c(0, 90, NA, 270)), "nonfinite")
+  expect_identical(angles_spacing_status(c(0, 90, NaN, 270)), "nonfinite")
+  expect_identical(angles_spacing_status(c(0, 120, 240, Inf)), "nonfinite")
+  expect_identical(angles_spacing_status(c(octants(), Inf)), "nonfinite")
+  expect_identical(angles_spacing_status(c(0, 90, 180, -Inf)), "nonfinite")
 
   # Angles supplied outside [0, 360) reduce onto their circumplex positions.
   # This is the ONLY case that pins the `%% 360` reduction: with it removed,

--- a/tests/testthat/test-axes-reliability.R
+++ b/tests/testthat/test-axes-reliability.R
@@ -1114,3 +1114,34 @@ test_that("M60: angles_spacing_status() classifies at the pole and near-misses",
   expect_identical(angles_spacing_status((0:6) * (360 / 7)), "ok")
   expect_identical(angles_spacing_status((0:8) * (360 / 9) + 123.456), "ok")
 })
+
+test_that("M60: per-axis item_n is n * k/2 at any rotation", {
+  # The tolerance is set from the DISCRIMINATION required, not from what this
+  # machine prints (M59): the smallest error that could matter is one item, so
+  # item_n = 1.0, and 1e-8 fences that at 1e8x while sitting ~6 orders above
+  # the ~1e-14 float noise these sums actually carry.
+  tol <- 1e-8
+  for (k in 4:16) {
+    for (rot in c(0, 22.5, 17.3, 180)) {
+      ang <- (seq_len(k) - 1L) * (360 / k) + rot
+      for (n in c(1L, 2L, 5L)) {
+        inn <- axis_item_n(ang, n)
+        expect_equal(inn[["x"]], n * k / 2, tolerance = tol,
+                     label = sprintf("k=%d rot=%s n=%d x", k, rot, n))
+        expect_equal(inn[["y"]], n * k / 2, tolerance = tol,
+                     label = sprintf("k=%d rot=%s n=%d y", k, rot, n))
+      }
+    }
+  }
+
+  # The octant set stays EXACT -- BC3 above asserts expect_identical() on it,
+  # and that must not be weakened just because rotated sets need a tolerance.
+  expect_identical(axis_item_n(octants(), 4L), c(x = 16, y = 16))
+
+  # An unbalanced set legitimately gives different item_n per axis, and a
+  # fractional value (the SYMLOG shape, Table 3 col. 10 = 8.67). Nothing here
+  # rounds or forces the two axes to agree.
+  unb <- axis_item_n(c(0, 90, 180, 270), c(3L, 1L, 3L, 1L))
+  expect_equal(unb[["x"]], 6, tolerance = tol)
+  expect_equal(unb[["y"]], 2, tolerance = tol)
+})

--- a/tests/testthat/test-axes-reliability.R
+++ b/tests/testthat/test-axes-reliability.R
@@ -439,26 +439,28 @@ test_that("BC12: each malformed input errors informatively", {
   )
   expect_no_error(ok()) # the fixture itself is valid
 
-  # scale count != 8
+  # A 7-scale subset of the octants is no longer refused for its COUNT (M60
+  # accepts any k >= 4) but for its spacing -- dropping one octant leaves a
+  # 90-degree gap among 45-degree ones.
   expect_error(
     suppressMessages(axes_reliability(
       fx$data, items = fx$items[1:7], angles = fx$oct[1:7]
     )),
-    "8-scale"
+    "equally spaced"
   )
   # unequal spacing
   bad_ang <- fx$oct
   bad_ang[[1]] <- bad_ang[[1]] + 5
   expect_error(
     suppressMessages(axes_reliability(fx$data, items = fx$items, angles = bad_ang)),
-    "octant"
+    "equally spaced"
   )
   # duplicate angle
   dup_ang <- fx$oct
   dup_ang[[2]] <- dup_ang[[1]]
   expect_error(
     suppressMessages(axes_reliability(fx$data, items = fx$items, angles = dup_ang)),
-    "octant"
+    "duplicat"
   )
   # NA angle
   na_ang <- fx$oct
@@ -980,7 +982,9 @@ test_that("M60: a rotated equally spaced set estimates (Strack type b)", {
   expect_equal(res$results$reliability[[1]], res$results$reliability[[2]],
                tolerance = 1e-6)
   # The type-b magnitudes actually reached the model.
-  w <- abs(axis_weights(ang))
+  # as.vector(): unique() on a matrix works ROWWISE, so it would return rows
+  # rather than the distinct weight magnitudes.
+  w <- as.vector(abs(axis_weights(ang)))
   expect_equal(sort(unique(round(w, 5))), c(0.38268, 0.92388))
 })
 
@@ -1060,4 +1064,45 @@ test_that("M60: the spacing test is modular at the pole", {
     ),
     "duplicat"
   )
+})
+
+test_that("M60: angles_spacing_status() classifies at the pole and near-misses", {
+  # The package's own octant set, LM = 360.
+  expect_identical(angles_spacing_status(octants()), "ok")
+  # The same eight positions written with 0 instead of 360 -- one position, so
+  # the modular reduction must call both "ok" (the classic pole bug is to read
+  # 0 and 360 as distinct and report unequal spacing).
+  expect_identical(angles_spacing_status(c(0, 45, 90, 135, 180, 225, 270, 315)),
+                   "ok")
+  # 0 AND 360 in one set is that position twice.
+  expect_identical(angles_spacing_status(c(0, 45, 90, 135, 180, 225, 270, 360)),
+                   "duplicate")
+  expect_identical(angles_spacing_status(c(45, 45, 135, 225)), "duplicate")
+
+  # Rotations and other counts.
+  expect_identical(angles_spacing_status(seq(22.5, 337.5, by = 45)), "ok")
+  for (k in 4:24) {
+    expect_identical(angles_spacing_status((seq_len(k) - 1L) * (360 / k)), "ok")
+    # ... and at an arbitrary rotation of the same set.
+    expect_identical(
+      angles_spacing_status((seq_len(k) - 1L) * (360 / k) + 17.3), "ok"
+    )
+  }
+
+  # Near-misses are refused: the tolerance is float noise, not a design margin.
+  expect_identical(angles_spacing_status(c(0, 90, 180, 270.0001)), "unequal")
+  expect_identical(angles_spacing_status(c(0, 90, 180, 270 + 1e-4)), "unequal")
+  # A set bunched into one arc: its interior gaps are constant but are not
+  # 360/k, which is what refuses it. (The wrap-around gap cannot be the thing
+  # that catches this, or anything else -- all gaps sum to 360, so constant
+  # interior gaps of 360/k force the wrap gap to match. Verified by mutation.)
+  expect_identical(angles_spacing_status(c(0, 10, 20, 30)), "unequal")
+
+  # NA is classified, never silently dropped by sort().
+  expect_identical(angles_spacing_status(c(0, 90, NA, 270)), "missing")
+
+  # The tolerance is loose enough for an exactly-constructed odd set, whose
+  # gaps carry real float error (360/7 is not representable).
+  expect_identical(angles_spacing_status((0:6) * (360 / 7)), "ok")
+  expect_identical(angles_spacing_status((0:8) * (360 / 9) + 123.456), "ok")
 })

--- a/vignettes/axes-reliability.Rmd
+++ b/vignettes/axes-reliability.Rmd
@@ -84,7 +84,7 @@ The header confirms how many complete cases were used, and the per-axis table
 reports, for each axis, the effective test length (`item_n`), the Strack axis
 `Reliability`, its standard error of measurement (`SEm`), and the
 Nunnally–Bernstein reliability (`NB_Reliability`) for comparison. For a balanced
-octant instrument the two axes share one axes-variance estimate and carry equal
+instrument the two axes share one axes-variance estimate and carry equal
 `item_n`, so they report the same reliability — expected, not an error.
 
 The recovered reliability (about .77) lands close to the .78 built into the
@@ -182,9 +182,19 @@ against any particular value.
 `axes_reliability()` gives a compact, per-axis answer to "how reliably does this
 instrument measure communion and agency?", isolating the axes variance from the
 general and scale-specific components that a simpler reliability formula would
-conflate. Use it to characterize an octant circumplex instrument before leaning
-on its axis scores, and read its output with the correlation-as-covariance,
+conflate. Use it to characterize a circumplex instrument before leaning on its
+axis scores, and read its output with the correlation-as-covariance,
 listwise-deletion, and boundary caveats in mind.
+
+The examples above all use the canonical eight octant scales, but nothing in
+the model requires them: any **equally spaced** set of angles works, at any
+rotation and at any count from four scales upward. Equal spacing is what
+matters, and it is required rather than merely preferred — a quasi-circumplex,
+whose scales sit at slightly unequal intervals, is refused rather than
+approximated, because Strack et al. (2013) excluded such instruments when
+validating the model. Three scales are refused for a different reason: at that
+count every pair of scales sits the same angular distance apart, so the
+general, axes, and scale-specificity variances can no longer be told apart.
 
 ## References
 


### PR DESCRIPTION
`axes_reliability()` previously accepted exactly one arrangement of scales: the
canonical octants at their canonical starting angle. That restriction turned out
to be largely incidental — the weight and effective-test-length math was already
general, and the refusal was a set-identity test against `octants()` that pinned
the *rotation* as a side effect. Strack's "type b" instruments are octants
rotated 22.5° off the axes, so they were refused by an implementation accident
rather than a statistical limit.

This accepts any evenly spaced set of angles, at any rotation, from four scales
up.

## What changed

- `angles_spacing_status()` — a modular, pole-aware spacing predicate. Positions
  reduce mod 360 (so LM = 360 and 0 are one position); the tolerance admits
  floating-point representation error only, never near-equal spacing.
- The refuse contract is generalized: unequal spacing, duplicate positions, NA
  angles, fewer than four scales, and fewer than two items per scale each fail
  with a message naming the offender.
- **Four scales is an identification floor, not a convention.** At three evenly
  spaced scales every cross-scale pair sits at the same angular distance, so the
  moment design drops from rank 3 to rank 2 and the general, axes and
  scale-specificity variances are not separately identified. Measured over
  k = 3:9 at 2–3 items per scale.
- Quasi-circumplex (unequally spaced) instruments remain refused — RR09 §4 holds
  that refusal is scope-correct, and nothing here touches it.

## Validation

- **Layer A.** Strack (2013) Table 3 column 1 is the circumplex *type*, so the
  paper publishes anchors beyond type a. The four type-b (CV-LI) rows reproduce
  within ±.01; banked in `cairn/references/strack2013.md`, re-read in two
  channels (text layer + 200-dpi page image) agreeing on every value.
- **Layer B** re-run at four new geometries (rotated octants, k = 6, k = 12,
  k = 5 at a 13.7° rotation): exact population recovery with chisq < 1e-6,
  Monte-Carlo recovery within 2 MC-SEs, lavaan/OpenMx agreement < 1e-3.
- Guards mutation-tested. Two comments were corrected where mutation showed they
  claimed mechanisms the code did not have.

`R CMD check` 0/0/0; full suite 3394 passing; PDF manual built directly, since
`devtools::check()` skips that step by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)