### PR TITLE
M65 review fold-ins for the axes_reliability() FIML path

### DIFF
--- a/R/axes_fiml.R
+++ b/R/axes_fiml.R
@@ -78,10 +78,14 @@ axes_fiml_em_args <- function(cap = axes_fiml_em_iter_max) {
 # Did this warning report the unrestricted-moments EM hitting its cap? Two
 # independent substrings, because either alone is fragile. The DIAGNOSIS
 # sentence ("the sample moments using EM") is worded identically on both
-# generations, but lavaan hard-wraps its messages at getOption("width"), so the
-# phrase straddles a newline at the default 80 and a `fixed = TRUE` literal
-# never fires (measured on 0.6.21 AND 0.7.2 alike; it flips to TRUE only at
-# width = 300). Hence the whitespace-tolerant class rather than a literal space.
+# generations, but lavaan hard-wraps its messages at getOption("width")
+# (lav_msg(): split on whitespace, then prefix the chunk after a break with a
+# newline and three spaces), so WHERE the break lands moves with the width in
+# force at emission time. A `fixed = TRUE` literal "moments using EM" therefore
+# fails at exactly the two gaps separating its three words -- and one of those
+# is the break lavaan actually takes at the default width 80, measured on
+# 0.6.21 and 0.7.2 alike. Hence a whitespace class at BOTH gaps: making only
+# the first tolerant still leaves the `using`/`EM` gap fatal.
 # The REMEDY sentence names an `em.h1*` option, which is version-specific:
 # lavaan renamed the option once already at 0.7-1, and a further rename of the
 # stem would silence this predicate if it were the only clause. Deliberately
@@ -90,7 +94,7 @@ axes_fiml_em_args <- function(cap = axes_fiml_em_iter_max) {
 # converged-but-boundary fit into an EM refusal.
 axes_fiml_em_stalled <- function(w) {
   msg <- conditionMessage(w)
-  grepl("moments[[:space:]]+using EM", msg) || grepl("em\\.h1", msg)
+  grepl("moments[[:space:]]+using[[:space:]]+EM", msg) || grepl("em\\.h1", msg)
 }
 
 

--- a/R/axes_fiml.R
+++ b/R/axes_fiml.R
@@ -75,15 +75,22 @@ axes_fiml_em_args <- function(cap = axes_fiml_em_iter_max) {
 }
 
 
-# Did this warning report the unrestricted-moments EM hitting its cap? Both
-# lavaan generations word the message differently but both contain the literal
-# "moments using EM" and both name an `em.h1*` option in the remedy, so either
-# substring identifies it. Deliberately NARROW: the structured-fit call site
-# below muffles lavaan's boundary and optimizer warnings too, and matching one
-# of those would turn a converged-but-boundary fit into an EM refusal.
+# Did this warning report the unrestricted-moments EM hitting its cap? Two
+# independent substrings, because either alone is fragile. The DIAGNOSIS
+# sentence ("the sample moments using EM") is worded identically on both
+# generations, but lavaan hard-wraps its messages at getOption("width"), so the
+# phrase straddles a newline at the default 80 and a `fixed = TRUE` literal
+# never fires (measured on 0.6.21 AND 0.7.2 alike; it flips to TRUE only at
+# width = 300). Hence the whitespace-tolerant class rather than a literal space.
+# The REMEDY sentence names an `em.h1*` option, which is version-specific:
+# lavaan renamed the option once already at 0.7-1, and a further rename of the
+# stem would silence this predicate if it were the only clause. Deliberately
+# NARROW: the structured-fit call site below muffles lavaan's boundary and
+# optimizer warnings too, and matching one of those would turn a
+# converged-but-boundary fit into an EM refusal.
 axes_fiml_em_stalled <- function(w) {
   msg <- conditionMessage(w)
-  grepl("moments using EM", msg, fixed = TRUE) || grepl("em\\.h1", msg)
+  grepl("moments[[:space:]]+using EM", msg) || grepl("em\\.h1", msg)
 }
 
 

--- a/R/axes_reliability.R
+++ b/R/axes_reliability.R
@@ -1239,15 +1239,21 @@ axes_reliability <- function(data = NULL, items, angles = NULL,
       # no inferential meaning -- see axes_fiml_min_overlap.
       #
       # Both clauses are load-bearing. The second says the thinnest pair is
-      # thinner than the sample actually used, which is precisely "missingness
-      # thinned this pair": `min_coverage == n_used` holds if and only if every
-      # used row is complete. Without it the warning fired on any complete
-      # sample under 30, reporting missing-data thinness on a frame with no
-      # missing cell -- the sentence was then true of N and false of itself.
-      # Small N alone is not this function's business to remark on, and the
-      # listwise path does not remark on it either.
+      # thinner than the sample the CALLER SUPPLIED, which is precisely
+      # "missingness thinned this pair": equality holds if and only if the
+      # input frame had no missing cell at all. Without it the warning fired on
+      # any complete sample under 30, reporting missing-data thinness on a
+      # frame with no missing cell -- the sentence was then true of N and false
+      # of itself. Small N alone is not this function's business to remark on,
+      # and the listwise path does not remark on it either.
+      #
+      # The comparison is against `n_used + n_dropped` and NOT `n_used`, which
+      # is counted after axes_fiml_coverage() drops all-missing rows: under
+      # heavy unit nonresponse -- respondents who answered everything or
+      # nothing -- every surviving row is complete, so `n_used` alone equals
+      # min_coverage and silently suppressed a warning that was true.
       if (cvg$min_coverage < axes_fiml_min_overlap &&
-            cvg$min_coverage < cvg$n_used) {
+            cvg$min_coverage < cvg$n_used + cvg$n_dropped) {
         warning(
           "Some item pair(s) were jointly observed by as few as ",
           cvg$min_coverage, " respondent(s); the estimated correlation ",

--- a/R/axes_reliability.R
+++ b/R/axes_reliability.R
@@ -1237,7 +1237,17 @@ axes_reliability <- function(data = NULL, items, angles = NULL,
       # Thin, but not empty: a warning rather than a refusal (M65-D2). The
       # number is named so the user can judge it, and it is a convention with
       # no inferential meaning -- see axes_fiml_min_overlap.
-      if (cvg$min_coverage < axes_fiml_min_overlap) {
+      #
+      # Both clauses are load-bearing. The second says the thinnest pair is
+      # thinner than the sample actually used, which is precisely "missingness
+      # thinned this pair": `min_coverage == n_used` holds if and only if every
+      # used row is complete. Without it the warning fired on any complete
+      # sample under 30, reporting missing-data thinness on a frame with no
+      # missing cell -- the sentence was then true of N and false of itself.
+      # Small N alone is not this function's business to remark on, and the
+      # listwise path does not remark on it either.
+      if (cvg$min_coverage < axes_fiml_min_overlap &&
+            cvg$min_coverage < cvg$n_used) {
         warning(
           "Some item pair(s) were jointly observed by as few as ",
           cvg$min_coverage, " respondent(s); the estimated correlation ",
@@ -1637,13 +1647,21 @@ axes_reliability <- function(data = NULL, items, angles = NULL,
   # "srmr": the contract is the quantity, not lavaan's spelling of it.
   want <- c("chisq", "df", "pvalue", "rmsea", "cfi", "srmr_bentler_nomean")
   fm <- lavaan::fitMeasures(fit, want)
-  # lavaan DROPS a measure name it does not recognize -- silently, no warning,
-  # just a shorter vector (measured: two names, one bogus, returns one element).
+  # lavaan DROPS a measure name it does not recognize, returning a shorter
+  # vector rather than refusing (measured on BOTH generations: two names, one
+  # bogus, returns one element -- silently on 0.6.21, and on 0.7.2 with a
+  # `unknown fit measure: '<name>'` warning. The drop is what matters and is
+  # common to both; only the silence is version-specific).
   # `srmr_bentler_nomean` is an internal variant rather than a documented alias
   # and lavaan is a Suggests with no version floor, so a future rename would
   # otherwise delete `$fit$srmr` -- a documented @return field -- and leave the
   # object looking well formed. Refuse instead of shipping a hole.
-  if (!identical(names(fm), want)) {
+  #
+  # Keyed on MEMBERSHIP, then reordered here. `identical(names(fm), want)` also
+  # failed on order and on length, for which `setdiff()` reports nothing, so any
+  # mismatch that was not a dropped name refused with the degenerate message
+  # "(missing: )" -- a guard that fails safe while telling the user nothing.
+  if (!all(want %in% names(fm))) {
     stop(
       "The installed lavaan did not return the expected fit measures (missing: ",
       paste(setdiff(want, names(fm)), collapse = ", "),
@@ -1651,6 +1669,7 @@ axes_reliability <- function(data = NULL, items, angles = NULL,
       call. = FALSE
     )
   }
+  fm <- fm[want]
   names(fm)[names(fm) == "srmr_bentler_nomean"] <- "srmr"
   new_axes_reliability(
     results = results,

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -14,7 +14,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M64 | FIML on items for `axes_reliability()` — the estimator-metric question | done | — | normal | milestones/archive/M64-axes-reliability-fiml-review.md |
 | M65 | FIML item-level missing data for `axes_reliability()` — the build | done | — | normal | milestones/archive/M65-axes-reliability-fiml-build.md |
 | M66 | Corrected component standard errors for `axes_reliability()` | done | — | high | milestones/archive/M66-axes-reliability-corrected-se.md |
-| M67 | M65 review fold-ins for the `axes_reliability()` FIML path | planned | M66 | normal | milestones/M67-axes-reliability-m65-foldins.md |
+| M67 | M65 review fold-ins for the `axes_reliability()` FIML path | in-progress | M66 | normal | milestones/M67-axes-reliability-m65-foldins.md |
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |
 
 ## Candidates

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -14,7 +14,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M64 | FIML on items for `axes_reliability()` — the estimator-metric question | done | — | normal | milestones/archive/M64-axes-reliability-fiml-review.md |
 | M65 | FIML item-level missing data for `axes_reliability()` — the build | done | — | normal | milestones/archive/M65-axes-reliability-fiml-build.md |
 | M66 | Corrected component standard errors for `axes_reliability()` | done | — | high | milestones/archive/M66-axes-reliability-corrected-se.md |
-| M67 | M65 review fold-ins for the `axes_reliability()` FIML path | in-progress | M66 | normal | milestones/M67-axes-reliability-m65-foldins.md |
+| M67 | M65 review fold-ins for the `axes_reliability()` FIML path | review | M66 | normal | milestones/M67-axes-reliability-m65-foldins.md |
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |
 
 ## Candidates

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -14,7 +14,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M64 | FIML on items for `axes_reliability()` — the estimator-metric question | done | — | normal | milestones/archive/M64-axes-reliability-fiml-review.md |
 | M65 | FIML item-level missing data for `axes_reliability()` — the build | done | — | normal | milestones/archive/M65-axes-reliability-fiml-build.md |
 | M66 | Corrected component standard errors for `axes_reliability()` | done | — | high | milestones/archive/M66-axes-reliability-corrected-se.md |
-| M67 | M65 review fold-ins for the `axes_reliability()` FIML path | review | M66 | normal | milestones/M67-axes-reliability-m65-foldins.md |
+| M67 | M65 review fold-ins for the `axes_reliability()` FIML path | in-progress | M66 | normal | milestones/M67-axes-reliability-m65-foldins.md |
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |
 
 ## Candidates

--- a/cairn/milestones/M67-axes-reliability-m65-foldins.md
+++ b/cairn/milestones/M67-axes-reliability-m65-foldins.md
@@ -30,7 +30,7 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
 
 ## Acceptance criteria
 
-- [ ] **AC1 (EM-stall predicate fires on both lavaan generations, at every wrap
+- [x] **AC1 (EM-stall predicate fires on both lavaan generations, at every wrap
   position).** A test feeds `axes_fiml_em_stalled()` the real wrapped warning
   text from lavaan 0.6.21 and 0.7.2 (captured with `dput(conditionMessage(w))`,
   not retyped) and asserts the *first* disjunct matches on both. Because lavaan
@@ -43,7 +43,7 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
   generations, leaving detection there resting solely on
   `grepl("em\\.h1", msg)`, whose stem lavaan has already renamed once. Its
   comment is corrected to that measured behavior, not merely reworded.
-- [ ] **AC2 (fit-measure guard is honest on every mismatch).** The guard at
+- [x] **AC2 (fit-measure guard is honest on every mismatch).** The guard at
   `R/axes_reliability.R:1574-1590` names the actual problem for a non-drop
   mismatch (today `identical(names(fm), want)` with a `setdiff()` message
   degenerates to "(missing: )" when only the *order* differs); the six `$fit`
@@ -51,20 +51,20 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
   lavaan drop cannot leave a hole the current assertions pass over; and the
   "silently, no warning" comment is corrected — lavaan 0.7.2 emits
   `unknown fit measure`.
-- [ ] **AC3 (thin-overlap warning distinguishes thin from small).** On complete
+- [x] **AC3 (thin-overlap warning distinguishes thin from small).** On complete
   data with N < 30 the warning either does not fire or says what is actually
   true — today it reports "Some item pair(s) were jointly observed by as few as
   N respondent(s)" on data with no missing cells at all, because
   `min_coverage` equals N. A regression test covers complete data at N < 30 and
   genuinely thin overlap at N ≥ 30 separately.
-- [ ] **AC4 (`n_complete` documented as it behaves).** The `@return` text no
+- [x] **AC4 (`n_complete` documented as it behaves).** The `@return` text no
   longer implies `n_complete` is FIML-only; it is set on every path. Verified
   against the built Rd.
-- [ ] **AC5 (the FIML OLS shadow consumes R̂).** A suite assertion discriminates
+- [x] **AC5 (the FIML OLS shadow consumes R̂).** A suite assertion discriminates
   the FIML correlation matrix from an available-case correlation — discriminative
   only under an M2-style MAR mechanism, where the two differ; a complete-data or
   MCAR fixture cannot tell them apart and must not be used as the fence.
-- [ ] **AC6 (gate clean).** `devtools::test()` and
+- [x] **AC6 (gate clean).** `devtools::test()` and
   `devtools::check(args = "--no-manual")` clean, plus a built PDF manual since
   AC4 changes roxygen.
 
@@ -124,6 +124,7 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
 
 - 2026-08-02: checkpoint. T7-T9 verified on the one test file they touch (`test-axes-fiml.R`, 0 failures) plus the two mutation reversions; the full `devtools::test()` and the T10 re-gate (check, PDF manual) have NOT yet reported at this commit.
 - 2026-08-02: T10 done, status in-progress→review (second time). Full suite 0 failures / 4421 passing / 4 pre-existing warnings — 28 more assertions than the first pass's 4393, which is the 24-position gap sweep plus the third thin-overlap case. `devtools::document()` no diff (this pass changed no roxygen at all; the AC1 amendment is tracking-only). `devtools::check(args = "--no-manual")` Status OK, 0 errors / 0 warnings / 0 notes in 13m22s. PDF manual 78 pages, unchanged from the first pass, with no warning outside the pre-existing `Rfn.*` external-link class. NEWS still owes no entry, on the first pass's reasoning: the feature is unreleased, and F1/F4 correct guards that never shipped.
+- 2026-08-02: review second pass. All six criteria verified with fresh evidence and ticked; gates clean (cairn_validate 16/16, test 0/4421, check 0/0/0 in 18m08s, document() no diff, pkgdown clean, PDF 78pp). Fan-out returned 17 candidates from the diff-bug lens, one at or above 80: F18 (90), a false causal claim in the AC1 test comment about which lavaan rename broke CI, fixed in place at review. Not a return - a test comment is not a defect in what the package does for users, and AC1 own comment clause covers the source comment, which was already right. 16 findings logged below threshold, including F19 (42), the padded-frame asymmetry, which re-litigates the first pass F4 (92) holding rather than falsifying AC3 as written.
 
 ## Decisions
 
@@ -203,3 +204,139 @@ pre-existing; F15 (8) the reviewer's clean-bill note.
 does for its users, and F2 additionally falsifies AC1's own "its comment ... is
 corrected, not merely reworded" clause. First defect return for this milestone.
 
+
+### Second pass — 2026-08-02 (PR #93)
+
+**Outcome: all six criteria verified, one finding fixed in place, no return.**
+Every gate fresh by command. The independent fan-out returned 17 candidates
+from one lens; a fresh scorer put exactly one at or above 80.
+
+**Gates (all clean, all fresh).** `cairn_validate` exit 0, 16 of 16 CHECKs PASS
+— including `coverage complete` against the amended Coverage map and
+`binding criteria`; the 47 `work-log format` advisories are all pre-existing M7
+lines, none from this milestone. No DESIGN principle changed
+(`Principles touched: —`), so `cairn_impact` is skipped. Toolchain
+`consistency-gate`: `document()` no diff; `man/`, `NAMESPACE`, `src/` and
+`data/` untouched by the diff; README.Rmd/README.md untouched; no new
+top-level files, so no `.Rbuildignore` entry is owed; `pkgdown::check_pkgdown()`
+clean; `devtools::test()` 0 failures / 4421 passing / 4 pre-existing warnings;
+`devtools::check(args = "--no-manual")` Status OK, 0 errors / 0 warnings /
+0 notes in 18m08s. NEWS carries no entry and none is owed, verified rather than
+inherited: CRAN holds 1.2.0, so 2.0.0 and the whole `axes_reliability()` FIML
+path are unreleased.
+
+**AC1 — verified.** The predicate is
+`grepl("moments[[:space:]]+using[[:space:]]+EM", msg) || grepl("em\\.h1", msg)`
+(`R/axes_fiml.R:97`): both inter-word gaps whitespace-tolerant. The test sweeps
+every inter-word gap of each generation's diagnosis sentence
+(`tests/testthat/test-axes-fiml.R:824`) rather than pinning a captured width.
+Measured at review over all 12 gaps per generation: the old `fixed = TRUE`
+literal fails at 2 (gaps 11 and 12), the first pass's one-gap pattern at 1
+(gap 12), the shipped pattern at none — and the diff-bug lens independently
+drove the sentence through lavaan's own `lav_msg()` at every width 20-250 and
+found 0 failures. The source comment states that measured behavior.
+
+**AC2 — verified.** The guard keys on membership, `if (!all(want %in% names(fm)))`,
+then imposes the order itself with `fm <- fm[want]`, so the degenerate
+"(missing: )" message is unreachable for a non-drop mismatch. The six `$fit`
+names are pinned literally at `tests/testthat/test-axes-fiml.R:251`
+(`chisq`, `df`, `pvalue`, `rmsea`, `cfi`, `srmr`) and asserted on both the
+listwise and FIML objects. The former "silently, no warning" comment now
+records the measured version split — the drop is common to 0.6.21 and 0.7.2,
+only the silence is version-specific.
+
+**AC3 — verified.** The clause is
+`cvg$min_coverage < axes_fiml_min_overlap && cvg$min_coverage < cvg$n_used + cvg$n_dropped`
+(`R/axes_reliability.R:1255-1256`). Measured at review on four frames: complete
+N = 25 silent, complete N = 200 silent, thin overlap at N = 200 with one item
+held to 20 fires and names 20, and 120 respondents of whom 95 answered nothing
+fires and names 25. The regression test carries complete data at N < 30 and
+genuinely thin overlap at N >= 30 as separate assertions, plus a third case on
+the row-drop path. The diff-bug lens confirmed
+`n_used + n_dropped == nrow(mat)` is a guaranteed identity —
+`axes_fiml_coverage()` sets `keep <- rowSums(!is.na(mat)) > 0L` with
+`length(keep) == nrow(mat)` and no NA path — and that the clause can never
+suppress a genuinely thin pair.
+
+**AC4 — verified against the built Rd.** `man/axes_reliability.Rd:82-86` states
+that `n_complete` and `min_coverage` "are present on every path so that a
+caller can read them unconditionally", naming the NA cases explicitly. Measured
+at review on all three paths at this commit: listwise `n_complete = 200`,
+`min_coverage = NA`; fiml `89` / `89`; cormat `NA` / `NA`. The Rd says what the
+code does, and nothing in it implies `n_complete` is FIML-only.
+
+**AC5 — verified.** `tests/testthat/test-axes-fiml.R:1339-1349` recomputes the
+shadow from `axes_fiml_moments(mat_m2[keep_m2, ])$R` — mirroring the package's
+own row filter — and asserts it equals the shipped `details$ols_shadow`, with
+an `expect_gt` separation check against the available-case candidate so the
+equality cannot pass vacuously. The fence is discriminative by construction and
+by measurement: the two candidates separate by 6.18e-02 on xi1 under M2's MAR
+mechanism, where under MCAR they agree to ~1e-4, so no complete-data or MCAR
+fixture could carry the claim.
+
+**AC6 — verified.** `devtools::test()` 0 failures / 4421 passing / 4
+pre-existing warnings. `devtools::check(args = "--no-manual")` Status OK,
+0 errors / 0 warnings / 0 notes in 18m08s. PDF manual builds at 78 pages, with
+no warning outside the pre-existing `Rfn.*` external-link class.
+
+### Independent review — three lenses, then a scorer
+
+The **[S] blame-history** lens returned no regressions, re-deriving each check
+rather than trusting the work log: every touched line traces to `d2c48b446`
+(M65), M65-D2's warn-never-refuse holding survives (the site still only
+`warning()`s), BC7 clause (iii)'s hard zero-coverage refusal sits outside every
+diff hunk, and no test assertion was dropped without a replacement of equal or
+greater strength. The **[S] prior-review** lens returned no findings: F1, F2 and
+F4 are genuinely closed rather than restated in new form, the below-threshold
+F5-F16 code is untouched, and the GitHub inline-comment probe came back empty
+again, so archived `## Review` sections were the evidence base. The **[O]
+diff-bug** lens returned 17 findings, scored by a fresh **[S]** scorer that did
+not generate them and that held the diff and this plan.
+
+**Actioned (>= 80): one.**
+
+- **F18 (90) — a false causal claim in the AC1 test comment.** It read "an
+  option lavaan has already renamed once, and that rename is what broke this
+  path on CI during M65". Verified false against `cairn/LESSONS.md`: the 0.7-1
+  rename was `em.h1.iter.max` -> `em.h1.args$max_iter`, and BOTH spellings
+  contain `em.h1`, so that rename never touched detection; what it broke was
+  `axes_fiml_em_args()`, a different seam. Exactly the class this milestone's
+  Goal exists to close, and the same class as the first pass's F2 (90). Fixed
+  in place at review: the comment now names the rename, states that detection
+  survived it, names the seam that did break, and keeps the point that stands —
+  a FURTHER rename dropping the stem would silence detection outright. The
+  source comment at `R/axes_fiml.R:88-90` already had this right and is
+  unchanged. Comment-only, in a test file; `test-axes-fiml.R` re-run clean.
+
+**Not a return.** F18 is the sole actioned finding and clears neither branch of
+the return floor: a comment in a test file is not a defect in what the package
+does for its users, and AC1's "its comment is corrected" clause refers to the
+predicate's own comment, which the lens confirms is correct. Triage was
+therefore fix-now with no status change. The first pass's defect return remains
+the only one.
+
+**Below threshold — logged, not actioned (IP3): 16.** F19 (42) the new clause
+warns on a frame padded with all-NA rows where every used row is complete, so
+the warning tracks whether blank rows were left in rather than what the
+estimator sees — reproduced at review (29 complete + 6 all-NA warns; the same
+29 rows alone are silent), but this is the unit-nonresponse case the first
+pass's F4 (92) decided must warn, and AC3's clause is scoped to complete data;
+F20 (65) the mocked order-only test asserts names but not that values travelled
+with them, so `names(fm) <- want` would pass it (F11 restated); F21 (65) the AC5
+separation check still computes the available-case candidate on the unfiltered
+matrix while the FIML candidate is now filtered (F13 half-retired); F22 (60) the
+`em.h1` disjunct's remaining exposure is a false positive on any lavaan warning
+merely mentioning `em.h1.args`; F23 (55) the clause reconstructs `n_total`,
+already in scope at `R/axes_reliability.R:1120`; F24 (55) the "missing: )"
+assertion is tautological given the `expect_match` above it (F10); F25 (45)
+thin-overlap case (a) pins neither `min_coverage` nor the threshold constant
+(F12); F26 (45) the AC5 comment mixes a relative tolerance with an absolute bar
+(F14); F27 (42) the sweep's comment claims a finite-domain proof over break
+SETS that a single-break sweep does not deliver, harmless because the two
+clauses are independent; F28 (38) `axes_fiml_min_overlap`'s doc comment is stale
+on an unmodified line (F6); F29 (35) the "small N alone is not this function's
+business" comment reads oddly when `n_dropped > 0`; F30 (35) case (c) encodes
+F19's behavior as intended; F31 (35) `expect_gt(n_gap, 0L)` is near-vacuous;
+F32 (30) and F33 (30) the guard accepts a duplicate-named or over-long `fm`
+where `identical()` refused (F8/F16); F34 (15) the `p == 1` NA-propagation path
+is unreachable given `p >= n_scales >= 3`.

--- a/cairn/milestones/M67-axes-reliability-m65-foldins.md
+++ b/cairn/milestones/M67-axes-reliability-m65-foldins.md
@@ -1,11 +1,11 @@
 # M67: M65 review fold-ins for the `axes_reliability()` FIML path
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** M66
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** `m67-axes-m65-foldins`
 
 ## Goal
 

--- a/cairn/milestones/M67-axes-reliability-m65-foldins.md
+++ b/cairn/milestones/M67-axes-reliability-m65-foldins.md
@@ -1,6 +1,6 @@
 # M67: M65 review fold-ins for the `axes_reliability()` FIML path
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** M66
 - **Driving RR:** —
@@ -100,7 +100,7 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
   post-drop `n_used`; third regression case on the row-drop path.
 - [x] **T9 — F13 (review return): AC5 recomputation mirrors the package's row
   filter.**
-- [ ] **T10 — re-gate.** Tests, check, PDF manual.
+- [x] **T10 — re-gate.** Tests, check, PDF manual.
 
 ## Work log
 
@@ -123,6 +123,7 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
 - 2026-08-02: T9 done (F13, below threshold, actioned at the user's gate choice). The AC5 shadow is now recomputed from `mat_m2[axes_fiml_coverage(mat_m2)$keep, ]`, mirroring the package's own call. This is robustness, not a bug fix, and does not redden under mutation: `axes_mar_m2()` leaves no all-missing row, so both forms agree on this fixture — which is exactly the accident the fix removes, and the same row-filter accounting that made F4 real.
 
 - 2026-08-02: checkpoint. T7-T9 verified on the one test file they touch (`test-axes-fiml.R`, 0 failures) plus the two mutation reversions; the full `devtools::test()` and the T10 re-gate (check, PDF manual) have NOT yet reported at this commit.
+- 2026-08-02: T10 done, status in-progress→review (second time). Full suite 0 failures / 4421 passing / 4 pre-existing warnings — 28 more assertions than the first pass's 4393, which is the 24-position gap sweep plus the third thin-overlap case. `devtools::document()` no diff (this pass changed no roxygen at all; the AC1 amendment is tracking-only). `devtools::check(args = "--no-manual")` Status OK, 0 errors / 0 warnings / 0 notes in 13m22s. PDF manual 78 pages, unchanged from the first pass, with no warning outside the pre-existing `Rfn.*` external-link class. NEWS still owes no entry, on the first pass's reasoning: the feature is unreleased, and F1/F4 correct guards that never shipped.
 
 ## Decisions
 

--- a/cairn/milestones/M67-axes-reliability-m65-foldins.md
+++ b/cairn/milestones/M67-axes-reliability-m65-foldins.md
@@ -30,14 +30,19 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
 
 ## Acceptance criteria
 
-- [ ] **AC1 (EM-stall predicate fires on both lavaan generations).** A test
-  feeds `axes_fiml_em_stalled()` the real wrapped warning text from lavaan
-  0.6.21 and 0.7.2 (captured with `dput(conditionMessage(w))`, not retyped) and
-  asserts the *first* disjunct matches on both. The `fixed = TRUE` literal
-  `"moments using EM"` never fires — lavaan wraps at `getOption("width")`, so
-  the phrase straddles a newline — leaving detection resting solely on
+- [ ] **AC1 (EM-stall predicate fires on both lavaan generations, at every wrap
+  position).** A test feeds `axes_fiml_em_stalled()` the real wrapped warning
+  text from lavaan 0.6.21 and 0.7.2 (captured with `dput(conditionMessage(w))`,
+  not retyped) and asserts the *first* disjunct matches on both. Because lavaan
+  re-wraps at `getOption("width")` on emission, the test does not rest on the
+  captured width-80 break: it sweeps the break across every inter-word gap of
+  each diagnosis sentence — the full domain `lav_msg()` can break in — and
+  asserts the disjunct matches at all of them. The `fixed = TRUE` literal
+  `"moments using EM"` fails at exactly the two gaps separating its three
+  words, which includes the break lavaan takes at the default width 80 on both
+  generations, leaving detection there resting solely on
   `grepl("em\\.h1", msg)`, whose stem lavaan has already renamed once. Its
-  comment claiming the literal matches is corrected, not merely reworded.
+  comment is corrected to that measured behavior, not merely reworded.
 - [ ] **AC2 (fit-measure guard is honest on every mismatch).** The guard at
   `R/axes_reliability.R:1574-1590` names the actual problem for a non-drop
   mismatch (today `identical(names(fm), want)` with a `setdiff()` message
@@ -65,12 +70,12 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
 
 ## Coverage
 
-- AC1 → T1
+- AC1 → T1, T7
 - AC2 → T2
-- AC3 → T3
+- AC3 → T3, T8
 - AC4 → T4
-- AC5 → T5
-- AC6 → T6
+- AC5 → T5, T9
+- AC6 → T6, T10
 
 ## Tasks
 
@@ -86,6 +91,16 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
 - [x] **T4 — `@return` text for `n_complete`.**
 - [x] **T5 — OLS-shadow R̂ assertion**, on an M2-style MAR fixture.
 - [x] **T6 — gate.** Tests, check, PDF manual.
+- [x] **T7 — F1/F2/F3 (review return): wrap-position-proof EM-stall
+  predicate.** Both inter-word gaps whitespace-tolerant; the comment corrected
+  to the measured behavior; the AC1 test sweeps every gap instead of pinning
+  one width.
+- [x] **T8 — F4/F5 (review return): thin-overlap warning under unit
+  nonresponse.** Compare against the supplied respondent total, not the
+  post-drop `n_used`; third regression case on the row-drop path.
+- [x] **T9 — F13 (review return): AC5 recomputation mirrors the package's row
+  filter.**
+- [ ] **T10 — re-gate.** Tests, check, PDF manual.
 
 ## Work log
 
@@ -101,6 +116,13 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
 - 2026-08-02: T2–T5 share one gate run: full suite 0 failures / 4393 passing / 4 pre-existing warnings.
 - 2026-08-02: T6 done, status in-progress→review. `devtools::document()` no diff (no roxygen changed this milestone — T4 was verification only). Full suite 0 failures / 4393 passing / 4 pre-existing warnings. `devtools::check(args = "--no-manual")` 0 errors / 0 warnings / 0 notes in 13m35s. PDF manual builds, 78 pages, with only the pre-existing `Rfn.summary` pdftex cross-reference warning. No NEWS entry is owed: `axes_reliability()` and its FIML path are both unreleased (2.0.0 is the dev version), the existing NEWS text never promised the small-N warning this milestone stops, and every change here is to a guard message, a comment, or a warning's firing condition inside a feature NEWS already describes generically.
 - 2026-08-02: **returned by /milestone-review (first return).** Status review→in-progress. Every gate clean — `cairn_validate` 16/16 PASS, `check(args = "--no-manual")` 0/0/0, `document()` no diff, pkgdown clean, PDF manual 78 pages — and the blame-history and prior-review lenses both returned no findings. Three diff-bug findings clear the return floor: F1 (95) the EM-stall regex made only ONE of two inter-word gaps whitespace-tolerant, so it still fails at nine widths in 20–250 while the fully-tolerant pattern fails at none, leaving detection back on the `em.h1` stem AC1 exists to remove; F4 (92) the thin-overlap warning's new `min_coverage < n_used` clause suppresses the warning under heavy unit nonresponse, because `n_used` is counted after all-missing rows are dropped — reproduced at 120 respondents with 95 all-NA, where master warns and this branch is silent; F2 (90) the replacement comment claims the old literal "never fires", re-measured as firing at 209 of 231 widths. F3 (80) actioned with them: the AC1 test pins two width-80 strings and so could not catch either. No criterion ticked — the fixes change the code their evidence would come from.
+
+- 2026-08-02: substantive amendment to AC1, gated and accepted. Two clauses were false or too weak to hold their own fix: "The `fixed = TRUE` literal ... never fires" (F2's finding, inherited into the criterion), and a test bar of "asserts the first disjunct matches on both", which F3 showed is met by a test pinning one width. Amended to state the measured behavior — the literal fails at exactly the two gaps separating its three words, one of which is the width-80 break on both generations — and to require a sweep over every inter-word gap. Shown verbatim in chat before commit.
+- 2026-08-02: T7 done (F1, F2, F3). Break position, not width, is the thing the predicate is sensitive to: `lav_msg()` splits the message on whitespace and prefixes the chunk after a break with a newline and three spaces, so the break can land in any inter-word gap and only two of them can break this match. Measured exhaustively over all 12 gaps of each generation's diagnosis sentence: the old literal fails at 2 (gaps 11 and 12), the shipped one-gap pattern at 1 (gap 12, `using`/`EM`) — F1 — and `moments[[:space:]]+using[[:space:]]+EM` at none. That makes the test a 12-position sweep rather than a width sweep: finite, exhaustive over the domain `lav_msg` can break in, and independent of the installed lavaan's wrapping arithmetic. Mutation-verified — reverting to the one-gap pattern reddens the sweep with exactly two failures, one per generation. The comment's "never fires ... flips to TRUE only at width = 300" is replaced by that measurement, not reworded.
+- 2026-08-02: T8 done (F4, F5). The second clause now compares `min_coverage` against `n_used + n_dropped`, the respondent count the caller supplied, because `n_used` is counted after `axes_fiml_coverage()` drops all-missing rows: under heavy unit nonresponse every surviving row is complete, so `min_coverage == n_used` and the warning was suppressed where it was true. Reproduced at 120 respondents with 95 all-NA (`n_used` 25, `n_dropped` 95, `min_coverage` 25). The corrected form states the real invariant — equality holds if and only if the input frame had no missing cell at all — and discriminates all four cases: complete N=25 silent, complete N=200 silent, thin overlap at N=200 fires naming 20, unit nonresponse fires naming 25. Two candidates measured wrong and rejected: `nrow(mat)` (mat is row-filtered at R/axes_reliability.R:1162, so it equals `n_used` there) and `anyNA(mat)` (same reason). A third regression case on the row-drop path retires F5, which flagged that path as unexercised; mutation-verified, reverting to `n_used` reddens exactly that case.
+- 2026-08-02: T9 done (F13, below threshold, actioned at the user's gate choice). The AC5 shadow is now recomputed from `mat_m2[axes_fiml_coverage(mat_m2)$keep, ]`, mirroring the package's own call. This is robustness, not a bug fix, and does not redden under mutation: `axes_mar_m2()` leaves no all-missing row, so both forms agree on this fixture — which is exactly the accident the fix removes, and the same row-filter accounting that made F4 real.
+
+- 2026-08-02: checkpoint. T7-T9 verified on the one test file they touch (`test-axes-fiml.R`, 0 failures) plus the two mutation reversions; the full `devtools::test()` and the T10 re-gate (check, PDF manual) have NOT yet reported at this commit.
 
 ## Decisions
 

--- a/cairn/milestones/M67-axes-reliability-m65-foldins.md
+++ b/cairn/milestones/M67-axes-reliability-m65-foldins.md
@@ -1,6 +1,6 @@
 # M67: M65 review fold-ins for the `axes_reliability()` FIML path
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** M66
 - **Driving RR:** —
@@ -85,7 +85,7 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
   at `R/axes_reliability.R:1211-1221`, with the two-case regression test.
 - [x] **T4 — `@return` text for `n_complete`.**
 - [x] **T5 — OLS-shadow R̂ assertion**, on an M2-style MAR fixture.
-- [ ] **T6 — gate.** Tests, check, PDF manual.
+- [x] **T6 — gate.** Tests, check, PDF manual.
 
 ## Work log
 
@@ -99,6 +99,7 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
 - 2026-08-02: T4 done — verification only, no edit. M65's own T9 already corrected this text, and the shipped `man/axes_reliability.Rd:82-86` states both fields are present on every path with `min_coverage` NA outside FIML and both NA on `cormat`. Measured on all three paths at this commit: listwise 200/NA, fiml 144/189, cormat NA/NA. The Rd says what the code does.
 - 2026-08-02: T5 done. The live M2 replicate now makes one `axes_reliability()` call and asserts `details$ols_shadow` equals the shadow recomputed from `axes_fiml_moments(mat)$R` at 1e-8, against the available-case shadow measured 6.176e-02 away on ξ1 (0.3363 vs 0.2745) — reproducing RR12's 6.18e-02 and leaving the fence six orders inside the separation. Discriminative by construction: under MCAR the two candidates agree to ~1e-4, so no complete-data or MCAR fixture could carry this claim. Mutation-verified rather than assumed — substituting `stats::cor(mat, use = "pairwise.complete.obs")` for `mom$R` in the FIML branch reddens it (0.2745 against the expected 0.3363), then restored.
 - 2026-08-02: T2–T5 share one gate run: full suite 0 failures / 4393 passing / 4 pre-existing warnings.
+- 2026-08-02: T6 done, status in-progress→review. `devtools::document()` no diff (no roxygen changed this milestone — T4 was verification only). Full suite 0 failures / 4393 passing / 4 pre-existing warnings. `devtools::check(args = "--no-manual")` 0 errors / 0 warnings / 0 notes in 13m35s. PDF manual builds, 78 pages, with only the pre-existing `Rfn.summary` pdftex cross-reference warning. No NEWS entry is owed: `axes_reliability()` and its FIML path are both unreleased (2.0.0 is the dev version), the existing NEWS text never promised the small-N warning this milestone stops, and every change here is to a guard message, a comment, or a warning's firing condition inside a feature NEWS already describes generically.
 
 ## Decisions
 

--- a/cairn/milestones/M67-axes-reliability-m65-foldins.md
+++ b/cairn/milestones/M67-axes-reliability-m65-foldins.md
@@ -74,7 +74,7 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
 
 ## Tasks
 
-- [ ] **T1 — EM-stall predicate.** Capture the real warning text on both lavaan
+- [x] **T1 — EM-stall predicate.** Capture the real warning text on both lavaan
   generations, then replace the `fixed = TRUE` literal with
   `grepl("moments[[:space:]]+using EM", msg)` at `R/axes_fiml.R:86` and correct
   the comment at `R/axes_fiml.R:80`.
@@ -92,6 +92,8 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
 - 2026-07-27: created by /milestone-plan, from the seven findings the ROADMAP candidate row carried out of M65's third and fourth review passes (all sub-threshold, scored 36–78, logged in M65's archive with their scores).
 - 2026-07-27: plan gate chose to plan these as their own milestone over folding them into M66 and over leaving them as a candidate row, because M66 already sits at eight criteria and mixes a Fable-tier estimator change with Sonnet-tier cleanup; falsified by nothing measured — a scope judgment, reversible by dropping this file back to a candidate row.
 - 2026-07-27: `Depends on: M66` is a sequencing choice, not a logical dependency — the two are independent in substance but both edit `R/axes_reliability.R` near the components table and the caveat strings.
+- 2026-08-02: implement started; branch `m67-axes-m65-foldins` cut from `master` at 58afe1fa. Two plan items found already shipped by M65's own T9 (the third-pass gate): the `@return` `n_complete` claim (T4/AC4) and AC2's literal `$fit` name pinning (`tests/testthat/test-axes-fiml.R:249`). Both become verify-and-record rather than edits; no amendment, since each criterion is satisfiable as written.
+- 2026-08-02: T1 done. Warning text captured live with `dput(conditionMessage(w))` on both generations by squeezing the h1 EM cap to 10 (lavaan 0.7-2 installed into a scratch library, the M65 method): 0.6.21 emits from `lav_mvnorm_missing_h1_estimate_moments()` naming `em.h1.iter.max=`, 0.7.2 from `lav_mvn_mi_h1_est_moments()` naming `em.h1.args=` — different function, different remedy option, and both wrapping between `moments` and `using EM` at the default width 80. The test asserts the diagnosis half alone by stripping the remedy sentence at `EM;`, which reddened on both strings before the fix and is what pins detection off the version-specific `em.h1` stem; a boundary-warning negative fences the predicate's deliberate narrowness. Fix is the planned `grepl("moments[[:space:]]+using EM", msg)`, and the false comment claiming the literal matched both generations is replaced, not reworded. Full suite 0 failures / 4384 passing / 4 pre-existing warnings.
 
 ## Decisions
 

--- a/cairn/milestones/M67-axes-reliability-m65-foldins.md
+++ b/cairn/milestones/M67-axes-reliability-m65-foldins.md
@@ -1,11 +1,11 @@
 # M67: M65 review fold-ins for the `axes_reliability()` FIML path
 
-- **Status:** review
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** M66
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** `m67-axes-m65-foldins`
+- **Branch/PR:** `m67-axes-m65-foldins` / https://github.com/jmgirard/circumplex/pull/93
 
 ## Goal
 
@@ -100,7 +100,83 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
 - 2026-08-02: T5 done. The live M2 replicate now makes one `axes_reliability()` call and asserts `details$ols_shadow` equals the shadow recomputed from `axes_fiml_moments(mat)$R` at 1e-8, against the available-case shadow measured 6.176e-02 away on ξ1 (0.3363 vs 0.2745) — reproducing RR12's 6.18e-02 and leaving the fence six orders inside the separation. Discriminative by construction: under MCAR the two candidates agree to ~1e-4, so no complete-data or MCAR fixture could carry this claim. Mutation-verified rather than assumed — substituting `stats::cor(mat, use = "pairwise.complete.obs")` for `mom$R` in the FIML branch reddens it (0.2745 against the expected 0.3363), then restored.
 - 2026-08-02: T2–T5 share one gate run: full suite 0 failures / 4393 passing / 4 pre-existing warnings.
 - 2026-08-02: T6 done, status in-progress→review. `devtools::document()` no diff (no roxygen changed this milestone — T4 was verification only). Full suite 0 failures / 4393 passing / 4 pre-existing warnings. `devtools::check(args = "--no-manual")` 0 errors / 0 warnings / 0 notes in 13m35s. PDF manual builds, 78 pages, with only the pre-existing `Rfn.summary` pdftex cross-reference warning. No NEWS entry is owed: `axes_reliability()` and its FIML path are both unreleased (2.0.0 is the dev version), the existing NEWS text never promised the small-N warning this milestone stops, and every change here is to a guard message, a comment, or a warning's firing condition inside a feature NEWS already describes generically.
+- 2026-08-02: **returned by /milestone-review (first return).** Status review→in-progress. Every gate clean — `cairn_validate` 16/16 PASS, `check(args = "--no-manual")` 0/0/0, `document()` no diff, pkgdown clean, PDF manual 78 pages — and the blame-history and prior-review lenses both returned no findings. Three diff-bug findings clear the return floor: F1 (95) the EM-stall regex made only ONE of two inter-word gaps whitespace-tolerant, so it still fails at nine widths in 20–250 while the fully-tolerant pattern fails at none, leaving detection back on the `em.h1` stem AC1 exists to remove; F4 (92) the thin-overlap warning's new `min_coverage < n_used` clause suppresses the warning under heavy unit nonresponse, because `n_used` is counted after all-missing rows are dropped — reproduced at 120 respondents with 95 all-NA, where master warns and this branch is silent; F2 (90) the replacement comment claims the old literal "never fires", re-measured as firing at 209 of 231 widths. F3 (80) actioned with them: the AC1 test pins two width-80 strings and so could not catch either. No criterion ticked — the fixes change the code their evidence would come from.
 
 ## Decisions
 
 ## Review
+
+### First pass — 2026-08-02 (PR #93)
+
+**Outcome: returned to `in-progress`.** Every mechanical gate is clean, but three
+findings clear the return floor. No acceptance criterion is ticked: the fixes
+change the code each criterion's evidence would come from.
+
+**Gates (all clean, all fresh by command).** `cairn_validate` exit 0, 16 of 16
+CHECKs PASS (the 47 `work-log format` advisories are all pre-existing M7 lines,
+none from this milestone). No DESIGN principle changed, so `cairn_impact` is
+skipped. Toolchain `consistency-gate`: `document()` no diff; `man/`, `NAMESPACE`
+and `src/` untouched by the diff; README.Rmd/README.md untouched and unaffected;
+`pkgdown::check_pkgdown()` clean; `devtools::check(args = "--no-manual")`
+0 errors / 0 warnings / 0 notes in 18m06s; PDF manual builds at 78 pages. NEWS
+carries no entry, and none is owed — the whole feature is unreleased and NEWS
+never promised the behavior this milestone changes.
+
+### Independent review — three lenses, then a scorer
+
+The **[S] blame-history** lens returned no regressions: each change traces to a
+specific M65 finding logged as deferred to the milestone that next touches this
+code, M65-D2's warn-never-refuse holding survives, BC7 clause (iii)'s hard
+zero-coverage refusal is untouched, and the M65-D3 test lost no assertion when
+`est_of()` gave way to a direct call. The **[S] prior-review** lens returned no
+findings; the GitHub inline-comment probe came back empty, so archived
+`## Review` sections were the evidence base. The **[O] diff-bug** lens returned
+15 findings, scored by a fresh **[S]** scorer that did not generate them.
+
+**Actioned (>= 80): four.**
+
+- **F1 (95) — the EM-stall regex is still width-fragile, so AC1's whole point is
+  unmet.** Only one of the two inter-word gaps was made whitespace-tolerant:
+  `"moments[[:space:]]+using EM"` leaves `using EM` a literal space, and lavaan
+  re-wraps at `getOption("width")` at emission time, so the break lands in
+  either gap depending on width. Re-verified at review across widths 20-250: the
+  shipped pattern fails at nine of them while
+  `"moments[[:space:]]+using[[:space:]]+EM"` fails at none. An unmatched warning
+  is muffled and `converged` stays `TRUE`, so detection falls back to the
+  `em.h1` stem — the single point of failure AC1 exists to remove.
+- **F4 (92) — the new second clause suppresses the warning on heavy unit
+  nonresponse.** `n_used` is counted AFTER `axes_fiml_coverage()` drops
+  all-missing rows, so a frame whose respondents either answered everything or
+  answered nothing has every used row complete and `min_coverage == n_used`.
+  Reproduced at review: 120 respondents, 95 of them all-NA, 16 items -- `n_used`
+  25, `min_coverage` 25, and NO warning fires where master warns. The suppressed
+  sentence is true there.
+- **F2 (90) — the replacement comment states a measured fact that is false**, in
+  a milestone whose Goal is closing comments that say what the code does not do.
+  It claims the old literal "never fires ... flips to TRUE only at width = 300";
+  re-measured at review, the literal fires at 209 of 231 widths and fails at the
+  default 80, which is all the evidence supports. Repeated in the test comment
+  ("matched NEITHER generation") and inherited from AC1's own wording.
+- **F3 (80) — the AC1 test cannot catch F1 or F2.** It pins two frozen width-80
+  strings and calls the predicate directly, so it characterizes one width rather
+  than the wrap-sensitivity its own comment names as the subject.
+
+**Below threshold — logged, not actioned (IP3):** F5 (75) the AC3 test never
+exercises the row-drop path F4 lives in; F11 (68) the mocked order-only test
+asserts names but not that values travelled with them; F13 (62) the AC5
+recomputation calls `axes_fiml_moments()` on the unfiltered matrix while the
+package calls it on `mat[cvg$keep, ]`, safe only because `axes_mar_m2()` leaves
+no all-NA row; F10 (55) the `"missing: )"` assertion is tautological given the
+`expect_match` above it; F12 (45) thin-overlap case (a) has no error containment
+at N = 25 with p = 16; F14 (45) the AC5 comment mixes a relative tolerance with
+an absolute bar; F6 (35) `axes_fiml_min_overlap`'s doc comment is stale but sits
+on an unmodified line; F7 (30) AC2 is satisfied by dissolving the non-drop
+mismatch rather than naming it, which is the design T2 specified; F8 (30) and
+F16 (30) the guard now accepts an over-long or duplicate-named `fm` where
+`identical()` refused; F9 (20) the guard checks names but not finiteness,
+pre-existing; F15 (8) the reviewer's clean-bill note.
+
+**Return floor.** F1, F4 and F2 each score >= 90 on defects in what the package
+does for its users, and F2 additionally falsifies AC1's own "its comment ... is
+corrected, not merely reworded" clause. First defect return for this milestone.
+

--- a/cairn/milestones/M67-axes-reliability-m65-foldins.md
+++ b/cairn/milestones/M67-axes-reliability-m65-foldins.md
@@ -78,13 +78,13 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
   generations, then replace the `fixed = TRUE` literal with
   `grepl("moments[[:space:]]+using EM", msg)` at `R/axes_fiml.R:86` and correct
   the comment at `R/axes_fiml.R:80`.
-- [ ] **T2 — fit-measure guard.** `all(want %in% names(fm))` then
+- [x] **T2 — fit-measure guard.** `all(want %in% names(fm))` then
   `fm <- fm[want]`; pin the six names; correct the "silently, no warning"
   comment at `R/axes_reliability.R:1576`.
-- [ ] **T3 — thin-overlap warning.** Decide and implement the small-N behavior
+- [x] **T3 — thin-overlap warning.** Decide and implement the small-N behavior
   at `R/axes_reliability.R:1211-1221`, with the two-case regression test.
-- [ ] **T4 — `@return` text for `n_complete`.**
-- [ ] **T5 — OLS-shadow R̂ assertion**, on an M2-style MAR fixture.
+- [x] **T4 — `@return` text for `n_complete`.**
+- [x] **T5 — OLS-shadow R̂ assertion**, on an M2-style MAR fixture.
 - [ ] **T6 — gate.** Tests, check, PDF manual.
 
 ## Work log
@@ -94,6 +94,11 @@ and a discriminative suite assertion that the FIML OLS shadow consumes R̂.
 - 2026-07-27: `Depends on: M66` is a sequencing choice, not a logical dependency — the two are independent in substance but both edit `R/axes_reliability.R` near the components table and the caveat strings.
 - 2026-08-02: implement started; branch `m67-axes-m65-foldins` cut from `master` at 58afe1fa. Two plan items found already shipped by M65's own T9 (the third-pass gate): the `@return` `n_complete` claim (T4/AC4) and AC2's literal `$fit` name pinning (`tests/testthat/test-axes-fiml.R:249`). Both become verify-and-record rather than edits; no amendment, since each criterion is satisfiable as written.
 - 2026-08-02: T1 done. Warning text captured live with `dput(conditionMessage(w))` on both generations by squeezing the h1 EM cap to 10 (lavaan 0.7-2 installed into a scratch library, the M65 method): 0.6.21 emits from `lav_mvnorm_missing_h1_estimate_moments()` naming `em.h1.iter.max=`, 0.7.2 from `lav_mvn_mi_h1_est_moments()` naming `em.h1.args=` — different function, different remedy option, and both wrapping between `moments` and `using EM` at the default width 80. The test asserts the diagnosis half alone by stripping the remedy sentence at `EM;`, which reddened on both strings before the fix and is what pins detection off the version-specific `em.h1` stem; a boundary-warning negative fences the predicate's deliberate narrowness. Fix is the planned `grepl("moments[[:space:]]+using EM", msg)`, and the false comment claiming the literal matched both generations is replaced, not reworded. Full suite 0 failures / 4384 passing / 4 pre-existing warnings.
+- 2026-08-02: T2 done. The guard now keys on membership (`all(want %in% names(fm))`) and imposes the order itself with `fm <- fm[want]`, so the degenerate "(missing: )" message is unreachable: it fired for any mismatch that was not a dropped name, because `identical()` also fails on order and length while `setdiff()` reports neither. Test reddened on exactly that message before the fix. AC2's other two clauses were already met on arrival — the six literal `$fit` names are pinned at `tests/testthat/test-axes-fiml.R:249` (M65 T9) — and the false "silently, no warning" comment is corrected at both sites it appeared, against a measurement rather than a rewording: on a converged fit, requesting one real and one bogus measure returns one element silently on 0.6.21 and with a `simpleWarning` reading `unknown fit measure: 'srmr_bogus_name'` on 0.7.2. The drop is common to both generations; only the silence was version-specific.
+- 2026-08-02: T3 done. The warning gains a second clause, `min_coverage < n_used`, which is exactly "missingness thinned a pair": `min_coverage == n_used` holds if and only if every used row is complete. Complete data at N = 25 therefore draws no thin-overlap warning, where it used to report "as few as 25 respondent(s)" on a frame with no missing cell; genuinely thin overlap at N = 200 with one item held to 20 responses still fires and still names 20. The two cases are separate assertions in one regression test, collecting warnings rather than using `expect_no_warning()` so an unrelated boundary warning can neither stand in for this one nor mask its absence. Implement gate chose suppression over rewording: small N alone is not this function's business, and the listwise path does not remark on it either.
+- 2026-08-02: T4 done — verification only, no edit. M65's own T9 already corrected this text, and the shipped `man/axes_reliability.Rd:82-86` states both fields are present on every path with `min_coverage` NA outside FIML and both NA on `cormat`. Measured on all three paths at this commit: listwise 200/NA, fiml 144/189, cormat NA/NA. The Rd says what the code does.
+- 2026-08-02: T5 done. The live M2 replicate now makes one `axes_reliability()` call and asserts `details$ols_shadow` equals the shadow recomputed from `axes_fiml_moments(mat)$R` at 1e-8, against the available-case shadow measured 6.176e-02 away on ξ1 (0.3363 vs 0.2745) — reproducing RR12's 6.18e-02 and leaving the fence six orders inside the separation. Discriminative by construction: under MCAR the two candidates agree to ~1e-4, so no complete-data or MCAR fixture could carry this claim. Mutation-verified rather than assumed — substituting `stats::cor(mat, use = "pairwise.complete.obs")` for `mom$R` in the FIML branch reddens it (0.2745 against the expected 0.3363), then restored.
+- 2026-08-02: T2–T5 share one gate run: full suite 0 failures / 4393 passing / 4 pre-existing warnings.
 
 ## Decisions
 

--- a/tests/testthat/test-axes-fiml.R
+++ b/tests/testthat/test-axes-fiml.R
@@ -808,10 +808,14 @@ test_that("the EM-stall predicate fires on both lavaan generations", {
     # disjunct was a `fixed = TRUE` literal "moments using EM". It fails at the
     # two gaps separating its three words, and the width-80 break lavaan
     # actually takes lands in one of them on BOTH generations, leaving
-    # detection there resting solely on the `em.h1` stem in the remedy sentence
-    # -- an option lavaan has already renamed once, and that rename is what
-    # broke this path on CI during M65. Strip the remedy sentence and the
-    # predicate must still fire on the diagnosis alone.
+    # detection there resting solely on the `em.h1` stem in the remedy
+    # sentence. lavaan renamed that option once already, at 0.7-1
+    # (`em.h1.iter.max` -> `em.h1.args$max_iter`) -- which did NOT break
+    # detection, both spellings containing `em.h1`; what it broke was
+    # axes_fiml_em_args(), a different seam, and that is the M65 CI failure.
+    # A FURTHER rename dropping the stem would silence detection outright,
+    # which is why the diagnosis half has to carry it alone. Strip the remedy
+    # sentence and the predicate must still fire on the diagnosis alone.
     stripped <- paste0(strsplit(msg, "EM;", fixed = TRUE)[[1]][[1]], "EM.")
     expect_false(grepl("em\\.h1", stripped))
     expect_true(axes_fiml_em_stalled(simpleWarning(stripped)))

--- a/tests/testthat/test-axes-fiml.R
+++ b/tests/testthat/test-axes-fiml.R
@@ -698,6 +698,46 @@ test_that("M65-D5: a stalled structured-stage EM is refused, not muffled", {
                "unrestricted \\(EM\\) stage")
 })
 
+test_that("the EM-stall predicate fires on both lavaan generations", {
+  # Real wrapped warning text, captured with `dput(conditionMessage(w))` at the
+  # default getOption("width") = 80 by squeezing the h1 EM cap on each
+  # generation -- never retyped, because the WRAP POSITION is the thing under
+  # test. lavaan 0.6.21 and 0.7.2 differ in the emitting function's name and in
+  # the remedy option they name, and agree in wrapping between "moments" and
+  # "using EM".
+  msg_0621 <- paste0(
+    "lavaan->lav_mvnorm_missing_h1_estimate_moments():  \n   Maximum number ",
+    "of iterations reached when computing the sample moments \n   using EM; ",
+    "use the em.h1.iter.max= argument to increase the number of \n   iterations"
+  )
+  msg_072 <- paste0(
+    "lavaan->lav_mvn_mi_h1_est_moments():  \n   Maximum number of iterations ",
+    "reached when computing the sample moments \n   using EM; increase the ",
+    "max_iter element of the em.h1.args= argument to \n   increase the number ",
+    "of iterations"
+  )
+
+  for (msg in list(msg_0621, msg_072)) {
+    expect_true(axes_fiml_em_stalled(simpleWarning(msg)))
+    # The half that reddens, and the reason this test exists: the first
+    # disjunct was a `fixed = TRUE` literal "moments using EM", which matched
+    # NEITHER generation, leaving detection resting solely on the `em.h1` stem
+    # in the remedy sentence -- an option lavaan has already renamed once, and
+    # that rename is what broke this path on CI during M65. Strip the remedy
+    # sentence and the predicate must still fire on the diagnosis alone.
+    stripped <- paste0(strsplit(msg, "EM;", fixed = TRUE)[[1]][[1]], "EM.")
+    expect_false(grepl("em\\.h1", stripped))
+    expect_true(axes_fiml_em_stalled(simpleWarning(stripped)))
+  }
+
+  # Deliberately narrow, and asserted so: the call site muffles lavaan's
+  # boundary and optimizer warnings through this same predicate, and matching
+  # one of those would turn a converged-but-boundary fit into an EM refusal.
+  expect_false(axes_fiml_em_stalled(simpleWarning(
+    "lavaan->lav_object_post_check():  \n   some estimated ov variances are negative"
+  )))
+})
+
 
 # --- T4: reporting and derived quantities (BC8, BC9) --------------------------
 #

--- a/tests/testthat/test-axes-fiml.R
+++ b/tests/testthat/test-axes-fiml.R
@@ -572,9 +572,11 @@ test_that("the thin-overlap warning separates thin overlap from a small sample",
   # at M65 (scored 76, 78, and once as an unscored note).
   #
   # The warning now also requires the thinnest pair to be thinner than the
-  # sample actually used, which is exactly "some missingness thinned a pair":
-  # `min_coverage == n_used` holds if and only if every used row is complete.
+  # sample the CALLER SUPPLIED, which is exactly "some missingness thinned a
+  # pair": equality holds if and only if the input frame had no missing cell.
   # Small N alone stays unremarked, as it already is on the listwise path.
+  # Case (c) fences the half of that comparison that is easy to get wrong --
+  # rows axes_fiml_coverage() drops before `n_used` is counted.
   oct <- octants()
   thin_msg <- "jointly observed by as few as"
   warns_of <- function(dat, items) {
@@ -612,6 +614,20 @@ test_that("the thin-overlap warning separates thin overlap from a small sample",
   ws <- warns_of(wide, items)
   expect_true(any(grepl(thin_msg, ws, fixed = TRUE)))
   expect_true(any(grepl("as few as 20 respondent", ws, fixed = TRUE)))
+
+  # (c) Heavy UNIT nonresponse: 120 respondents of whom 95 answered nothing.
+  # axes_fiml_coverage() drops those 95 before `n_used` is counted, so every
+  # surviving row is complete and `min_coverage` equals `n_used` -- which is
+  # why the comparison is against the supplied total and not `n_used`. The
+  # thinness is real (25 of 120 supplied respondents), so the warning must
+  # fire and must name 25. Comparing against `n_used` alone silences it.
+  set.seed(69)
+  unit <- axes_simulate(120L, oct, 2L, xi1 = .15, xi2 = .05, zeta1 = .10)
+  colnames(unit) <- inames
+  unit[26:120, ] <- NA_real_
+  ws_unit <- warns_of(unit, items)
+  expect_true(any(grepl(thin_msg, ws_unit, fixed = TRUE)))
+  expect_true(any(grepl("as few as 25 respondent", ws_unit, fixed = TRUE)))
 })
 
 test_that("M60 re-assertion: the listwise refusals still fire on their own terms", {
@@ -772,17 +788,45 @@ test_that("the EM-stall predicate fires on both lavaan generations", {
     "of iterations"
   )
 
+  # lavaan's wrapper (lav_msg) splits the message on whitespace and, at a
+  # break, prefixes the following chunk with a newline and three spaces. So the
+  # break position is a function of the width in force when the warning is
+  # EMITTED, not of the width these strings were captured at, and pinning the
+  # two captured width-80 strings characterizes one width rather than the
+  # wrap-sensitivity under test. Re-break at each inter-word gap instead: that
+  # enumerates every position lav_msg can break in, so "matches at all widths"
+  # is asserted over a finite domain rather than sampled.
+  rewrap_at <- function(txt, i) {
+    w <- strsplit(txt, "[[:space:]]+")[[1]]
+    w[i + 1L] <- paste0("\n   ", w[i + 1L])
+    paste(w, collapse = " ")
+  }
+
   for (msg in list(msg_0621, msg_072)) {
     expect_true(axes_fiml_em_stalled(simpleWarning(msg)))
     # The half that reddens, and the reason this test exists: the first
-    # disjunct was a `fixed = TRUE` literal "moments using EM", which matched
-    # NEITHER generation, leaving detection resting solely on the `em.h1` stem
-    # in the remedy sentence -- an option lavaan has already renamed once, and
-    # that rename is what broke this path on CI during M65. Strip the remedy
-    # sentence and the predicate must still fire on the diagnosis alone.
+    # disjunct was a `fixed = TRUE` literal "moments using EM". It fails at the
+    # two gaps separating its three words, and the width-80 break lavaan
+    # actually takes lands in one of them on BOTH generations, leaving
+    # detection there resting solely on the `em.h1` stem in the remedy sentence
+    # -- an option lavaan has already renamed once, and that rename is what
+    # broke this path on CI during M65. Strip the remedy sentence and the
+    # predicate must still fire on the diagnosis alone.
     stripped <- paste0(strsplit(msg, "EM;", fixed = TRUE)[[1]][[1]], "EM.")
     expect_false(grepl("em\\.h1", stripped))
     expect_true(axes_fiml_em_stalled(simpleWarning(stripped)))
+
+    # ... and must still fire wherever the break falls. A pattern tolerant at
+    # only one of the two gaps passes the width-80 case above and fails here.
+    diagnosis <- paste(strsplit(stripped, "[[:space:]]+")[[1]], collapse = " ")
+    n_gap <- length(strsplit(diagnosis, " ", fixed = TRUE)[[1]]) - 1L
+    expect_gt(n_gap, 0L)
+    for (i in seq_len(n_gap)) {
+      expect_true(
+        axes_fiml_em_stalled(simpleWarning(rewrap_at(diagnosis, i))),
+        info = paste("break after word", i, "of", diagnosis)
+      )
+    }
   }
 
   # Deliberately narrow, and asserted so: the call site muffles lavaan's
@@ -1288,8 +1332,14 @@ test_that("M65-D3: stored seeds reproduce live, so the fixture is not stale", {
   # holding by construction -- construction is what a suite assertion is for.
   item_angle <- rep(oct, each = 3L)
   item_scale <- rep(seq_along(oct), each = 3L)
-  shadow_fiml <- axes_ols_shadow(axes_fiml_moments(mat_m2)$R,
-                                 item_angle, item_scale)
+  # Recomputed on the rows the package keeps, not on the raw matrix: the FIML
+  # path calls axes_fiml_moments() on mat[cvg$keep, ]. axes_mar_m2() happens to
+  # leave no all-missing row, so the two agree here -- which is precisely why
+  # the recomputation must not depend on that holding.
+  keep_m2 <- axes_fiml_coverage(mat_m2)$keep
+  shadow_fiml <- axes_ols_shadow(
+    axes_fiml_moments(mat_m2[keep_m2, , drop = FALSE])$R, item_angle, item_scale
+  )
   shadow_avail <- axes_ols_shadow(
     stats::cor(mat_m2, use = "pairwise.complete.obs"), item_angle, item_scale
   )

--- a/tests/testthat/test-axes-fiml.R
+++ b/tests/testthat/test-axes-fiml.R
@@ -238,8 +238,10 @@ test_that("on complete data EVERY reported fit measure agrees between paths", {
     axes_reliability(dat, items = items, angles = octants(), missing = "fiml")
   )
   # The names are pinned to LITERALS, not to each other. `fitMeasures()` drops a
-  # name it does not recognize -- silently, no warning, a shorter vector -- and
-  # the FIML path asks for `srmr_bentler_nomean`, which is one of lavaan's six
+  # name it does not recognize, returning a shorter vector rather than refusing
+  # (silently on lavaan 0.6.21; on 0.7.2 with an `unknown fit measure` warning,
+  # measured at M67 -- the drop is common to both generations, the silence is
+  # not). The FIML path asks for `srmr_bentler_nomean`, which is one of lavaan's six
   # internal SRMR variants rather than a documented alias, in a package that is
   # Suggests with no version floor. Compared to each other these two lists come
   # from ONE line of code, so a dropped name shortens both alike: the comparison
@@ -557,6 +559,59 @@ test_that("M65-D2: healthy overlap draws no warning", {
                        angles = octants(), missing = "fiml")
     )
   )
+})
+
+test_that("the thin-overlap warning separates thin overlap from a small sample", {
+  skip_if_not_installed("lavaan")
+  # Two cases, deliberately split, because the pre-M67 predicate
+  # `min_coverage < 30` could not tell them apart: on complete data
+  # `min_coverage` EQUALS the sample size, so every small complete sample drew
+  # "Some item pair(s) were jointly observed by as few as 25 respondent(s)" --
+  # a true statement about N dressed as a statement about missing data, on a
+  # frame with no missing cell at all. Found by three independent review lenses
+  # at M65 (scored 76, 78, and once as an unscored note).
+  #
+  # The warning now also requires the thinnest pair to be thinner than the
+  # sample actually used, which is exactly "some missingness thinned a pair":
+  # `min_coverage == n_used` holds if and only if every used row is complete.
+  # Small N alone stays unremarked, as it already is on the listwise path.
+  oct <- octants()
+  thin_msg <- "jointly observed by as few as"
+  warns_of <- function(dat, items) {
+    ws <- character(0)
+    withCallingHandlers(
+      suppressMessages(
+        axes_reliability(as.data.frame(dat), items = items, angles = oct,
+                         missing = "fiml")
+      ),
+      warning = function(w) {
+        ws <<- c(ws, conditionMessage(w))
+        invokeRestart("muffleWarning")
+      }
+    )
+    ws
+  }
+
+  # (a) Complete data, N = 25 < 30. Collected rather than `expect_no_warning()`
+  # so an unrelated boundary or optimizer warning cannot be mistaken for this
+  # one, or mask its absence.
+  set.seed(67)
+  small <- axes_simulate(25L, oct, 2L, xi1 = .15, xi2 = .05, zeta1 = .10)
+  inames <- sprintf("t%02d", seq_len(ncol(small)))
+  colnames(small) <- inames
+  items <- split(inames, rep(seq_along(oct), each = 2L))
+  expect_false(any(grepl(thin_msg, warns_of(small, items), fixed = TRUE)))
+
+  # (b) Genuinely thin overlap at N = 200: one item answered by 20 respondents,
+  # so every pair it belongs to rests on 20 while the sample is 200. The
+  # warning must still fire, and still name the count.
+  set.seed(68)
+  wide <- axes_simulate(200L, oct, 2L, xi1 = .15, xi2 = .05, zeta1 = .10)
+  colnames(wide) <- inames
+  wide[21:nrow(wide), 1L] <- NA_real_
+  ws <- warns_of(wide, items)
+  expect_true(any(grepl(thin_msg, ws, fixed = TRUE)))
+  expect_true(any(grepl("as few as 20 respondent", ws, fixed = TRUE)))
 })
 
 test_that("M60 re-assertion: the listwise refusals still fire on their own terms", {
@@ -1214,7 +1269,32 @@ test_that("M65-D3: stored seeds reproduce live, so the fixture is not stale", {
   # three. Those come from the stored file; what is re-derived here is that the
   # code still produces the per-replicate xi1 AND SE values in it.
   seed_m2 <- fx$provenance$seeds$m2[[1]]
-  live_m2 <- est_of(axes_mar_m2(draw(2000L, seed_m2), 3L), missing = "fiml")
-  expect_equal(unname(live_m2[["xi1"]]), unname(fx$m2[1, "shipped"]),
+  mat_m2 <- axes_mar_m2(draw(2000L, seed_m2), 3L)
+  res_m2 <- suppressMessages(suppressWarnings(
+    axes_reliability(as.data.frame(mat_m2), items = items(mat_m2),
+                     angles = oct, missing = "fiml")
+  ))
+  expect_equal(unname(res_m2$results$xi1[[1]]), unname(fx$m2[1, "shipped"]),
                tolerance = tol)
+
+  # The OLS shadow consumes R-hat, not an available-case correlation. Fenced on
+  # THIS replicate because the fence has to be discriminative: under MCAR the
+  # two candidate matrices agree to about 1e-4 (0.3562 against 0.3563, measured
+  # at M65), so an MCAR or complete-data fixture cannot tell them apart and
+  # would pass whichever matrix the code used. M2 is MAR, where they separate.
+  #
+  # Asserted on the shipped `details$ols_shadow` against both candidates
+  # recomputed here, rather than on the single shared `R <- mom$R` assignment
+  # holding by construction -- construction is what a suite assertion is for.
+  item_angle <- rep(oct, each = 3L)
+  item_scale <- rep(seq_along(oct), each = 3L)
+  shadow_fiml <- axes_ols_shadow(axes_fiml_moments(mat_m2)$R,
+                                 item_angle, item_scale)
+  shadow_avail <- axes_ols_shadow(
+    stats::cor(mat_m2, use = "pairwise.complete.obs"), item_angle, item_scale
+  )
+  expect_equal(res_m2$details$ols_shadow, shadow_fiml, tolerance = 1e-8)
+  # And the two candidates really are distinguishable here, so the assertion
+  # above is not vacuously satisfied by both.
+  expect_gt(abs(shadow_fiml[["xi1"]] - shadow_avail[["xi1"]]), 1e-3)
 })

--- a/tests/testthat/test-axes-reliability.R
+++ b/tests/testthat/test-axes-reliability.R
@@ -417,6 +417,63 @@ test_that("BC11: small positive xi1 gives a small reliability, not a boundary", 
   expect_lt(res$results$reliability[[1]], .40)
 })
 
+test_that("the fit-measure guard names the actual problem on every mismatch", {
+  skip_if_not_installed("lavaan")
+  # The guard exists because `fitMeasures()` DROPS a name it does not
+  # recognize and returns a shorter vector, so a future lavaan retiring
+  # `srmr_bentler_nomean` would delete `$fit$srmr` -- a documented @return
+  # field -- and leave the object looking well formed. Measured on both
+  # generations at M67, since the guard's own comment used to assert this
+  # wrongly: requesting one real and one bogus measure returns ONE element,
+  # silently on 0.6.21 and with a `unknown fit measure: 'srmr_bogus_name'`
+  # warning on 0.7.2. The drop is real on both; only the silence was
+  # version-specific.
+  #
+  # What is under test here is the guard's DIAGNOSIS. It used to test
+  # `identical(names(fm), want)`, which also fails on order and on length,
+  # while its message reported `setdiff(want, names(fm))` -- so any mismatch
+  # that was not a dropped name printed the degenerate "(missing: )" and told
+  # the user nothing.
+  oct <- octants()
+  set.seed(11)
+  dat <- axes_simulate(300L, oct, 2L, xi1 = .15, xi2 = .05, zeta1 = .10)
+  inames <- sprintf("g%02d", seq_len(ncol(dat)))
+  colnames(dat) <- inames
+  items <- split(inames, rep(seq_along(oct), each = 2L))
+  call_it <- function() {
+    suppressMessages(axes_reliability(dat, items = items, angles = oct))
+  }
+  real_fm <- lavaan::fitMeasures
+
+  # (1) An order-only difference is not a missing measure, and must not be
+  # reported as one. lavaan preserves the requested order on both generations
+  # today, so this is forward-looking: the guard must key on membership and
+  # then impose the order itself.
+  local_mocked_bindings(
+    fitMeasures = function(object, fit.measures, ...) {
+      rev(real_fm(object, fit.measures, ...))
+    },
+    .package = "lavaan"
+  )
+  res <- call_it()
+  expect_identical(
+    names(res$fit),
+    c("chisq", "df", "pvalue", "rmsea", "cfi", "srmr")
+  )
+
+  # (2) A genuine drop still refuses, and names the measure that went missing.
+  local_mocked_bindings(
+    fitMeasures = function(object, fit.measures, ...) {
+      fm <- real_fm(object, fit.measures, ...)
+      fm[names(fm) != "cfi"]
+    },
+    .package = "lavaan"
+  )
+  err <- expect_error(call_it(), "did not return the expected fit measures")
+  expect_match(conditionMessage(err), "missing: cfi", fixed = TRUE)
+  expect_false(grepl("missing: )", conditionMessage(err), fixed = TRUE))
+})
+
 test_that("BC11: a boundary fit (xi1 <= 0) returns NA + warning + flag", {
   skip_if_not_installed("lavaan")
   oct <- octants()


### PR DESCRIPTION
Closes the sub-threshold findings M65's third and fourth review passes logged against the FIML path, each of which left a guard, a comment, or a documented claim saying something the code did not do.

- **EM-stall predicate** (`R/axes_fiml.R`) now matches lavaan's wrapped diagnosis sentence rather than a `fixed = TRUE` literal that never fired on either generation. Warning text captured live with `dput(conditionMessage(w))` on lavaan 0.6.21 and 0.7.2; detection no longer rests solely on the version-specific `em.h1` option stem.
- **Fit-measure guard** (`R/axes_reliability.R`) keys on membership and imposes the requested order itself, so the degenerate `"(missing: )"` message is unreachable. The false "silently, no warning" comment is corrected at both sites against a measurement: the drop is silent on 0.6.21 and warns `unknown fit measure` on 0.7.2.
- **Thin-overlap warning** now requires the thinnest pair to be thinner than the sample used, so complete data at N < 30 no longer draws a missing-data warning about its own sample size.
- **OLS-shadow fence**: a suite assertion that the FIML path consumes R-hat rather than an available-case correlation, on the M2 MAR replicate where the two separate by 6.176e-02. Mutation-verified.

Gates: full suite 0 failures / 4393 passing; `devtools::check(args = "--no-manual")` 0 errors / 0 warnings / 0 notes; `document()` no diff; PDF manual builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)