### PR TITLE
Disclose the reference sample at the standardizing call site

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,24 @@ plotting layer has been rebuilt on a real ggplot2 coordinate system.
   values is under query with its authors, and the sample will be corrected or
   withdrawn once that is settled.
 
+* `norm_standardize()` now reports which normative sample it used. Every
+  successful call prints the sample number, its size and its description — for
+  example, "Standardized against IIP-SC normative sample 1: N = 872, American
+  college students." — and, where the instrument carries more than one sample,
+  says how many others are available. Which sample you standardize against is
+  a result-determining choice rather than a technicality: across the shipped
+  instruments, different samples of the same instrument move a respondent's
+  z-scores by roughly half a standard deviation on average, and by nearly
+  twice that at the extreme. Pass the new
+  `quiet = TRUE` to suppress the message in loops and knitted documents.
+
+* Every data frame returned by `norm_standardize()` now carries a
+  `"norm_sample"` attribute recording the instrument, the sample number, its
+  size and its description, so a script that never sees the console can still
+  report what its z-scores are relative to. Retrieve it with
+  `attr(x, "norm_sample")`. It is attached whether or not `quiet` is set, and
+  on both the `append = TRUE` and `append = FALSE` return paths.
+
 * The package now requires ggplot2 (>= 4.0.0), and `ggforce` is no longer a
   dependency. The declared R requirement moves to R (>= 4.1) to match the floor
   ggplot2 already imposes; no installation that worked before is affected.
@@ -767,6 +785,17 @@ plotting layer has been rebuilt on a real ggplot2 coordinate system.
   reported fit can fall below 0.
 
 ## Bug fixes
+
+* `norm_standardize()`'s refusal of an off-metric normative sample now names
+  the offending scales for every instrument. On the seven instruments whose
+  normative data labels its scale column `Abbrev` rather than `Scale`, the
+  message previously named no scale at all.
+
+* Asking `norm_standardize()` for a normative sample an instrument does not
+  carry now produces an error naming that argument and listing the sample
+  numbers the instrument does carry. Previously the call fell through to an
+  unrelated check and failed with a message about `scales` not matching the
+  normative data, which named neither the argument at fault nor a valid value.
 
 * Fixed a bug where a bootstrap resample under pairwise deletion
   (`listwise = FALSE`) could crash `ssm_analyze()` with `mean(): object has no

--- a/R/tidying_functions.R
+++ b/R/tidying_functions.R
@@ -121,6 +121,22 @@ score <- function(data, items, instrument, na.rm = TRUE,
   }
 }
 
+# Would norm_standardize() accept this sample of this instrument? Shares the
+# anchor-range predicate with the refusal below rather than restating it, so
+# the disclosure's count of usable alternatives cannot drift from what the
+# refusal actually does.
+norm_sample_usable <- function(instrument, sample) {
+  key <- instrument$Norms[[1]]
+  key <- key[which(key$Sample == sample), ]
+  if (nrow(key) == 0) return(FALSE)
+  anchors <- instrument$Anchors
+  if (is.null(anchors)) return(TRUE)
+  all(
+    key$M >= min(anchors$Value) & key$M <= max(anchors$Value),
+    na.rm = TRUE
+  )
+}
+
 #' Standardize circumplex scales using normative data
 #'
 #' Take in a data frame containing circumplex scales, angle definitions for each
@@ -134,8 +150,8 @@ score <- function(data, items, instrument, na.rm = TRUE,
 #' respondent's z-scores by more than half a standard deviation. So unless
 #' `quiet = TRUE`, every successful call reports which sample it used, how
 #' large that sample was, and how it is described, and every call attaches the
-#' same facts to the result (see `@return`). Use `norms()` to see the samples
-#' an instrument carries before choosing one.
+#' same facts to the result (see the Value section below). Use `norms()` to see
+#' the samples an instrument carries before choosing one.
 #'
 #' @param data Required. A data frame or matrix containing at least circumplex
 #'   scales.
@@ -204,7 +220,12 @@ norm_standardize <- function(data, scales, angles = octants(), instrument,
 
   if (is.matrix(data)) data <- as.data.frame(data)
   key <- instrument$Norms[[1]]
-  key <- key[key$Sample == sample, ]
+  # which() rather than a bare logical index: `key$Sample == NA` is NA rather
+  # than FALSE, and indexing a data frame by NA returns a row of NAs instead of
+  # no rows -- so an NA `sample` (or an NA in the column) would survive the
+  # zero-row guard below and fail later, somewhere that names neither the
+  # argument nor the mistake. which() drops NAs from either side.
+  key <- key[which(key$Sample == sample), ]
 
   # An unmatched `sample` used to fall through to the arity check below, whose
   # message names neither the argument at fault nor what would have been
@@ -305,7 +326,16 @@ norm_standardize <- function(data, scales, angles = octants(), instrument,
     # The stored label names the group the sample was drawn from, so it is
     # printed as a plain description; framing it as a population would make
     # the package assert a representativeness none of these samples claims.
-    n_other <- nrow(instrument$Norms[[2]]) - 1L
+    #
+    # The count offers the reader an alternative they can act on, so it counts
+    # only samples this function would accept -- not rows of Norms[[2]]. A
+    # sample whose means leave the response range is refused, and advertising
+    # it would point at a call that errors.
+    n_other <- sum(vapply(
+      setdiff(instrument$Norms[[2]]$Sample, sample),
+      function(other) norm_sample_usable(instrument, other),
+      logical(1)
+    ))
     msg <- paste0(
       "Standardized against ", disclosure$Instrument, " normative sample ",
       sample, ": N = ", disclosure$Size, ", ", disclosure$Population, "."

--- a/R/tidying_functions.R
+++ b/R/tidying_functions.R
@@ -162,9 +162,10 @@ score <- function(data, items, instrument, na.rm = TRUE,
 #' @examples
 #' data("jz2017")
 #' norm_standardize(jz2017, scales = 2:9, instrument = iipsc, sample = 1)
-norm_standardize <- function(data, scales, angles = octants(), instrument, 
-                       sample = 1, prefix = "", suffix = "_z", append = TRUE) {
-  
+norm_standardize <- function(data, scales, angles = octants(), instrument,
+                       sample = 1, prefix = "", suffix = "_z", append = TRUE,
+                       quiet = FALSE) {
+
   stopifnot(is.data.frame(data) || is.matrix(data))
   stopifnot(is_var(scales))
   stopifnot(is.numeric(angles))
@@ -174,6 +175,7 @@ norm_standardize <- function(data, scales, angles = octants(), instrument,
   stopifnot(is_char(prefix, n = 1))
   stopifnot(is_char(suffix, n = 1))
   stopifnot(is_flag(append))
+  stopifnot(is_flag(quiet))
 
   if (is.matrix(data)) data <- as.data.frame(data)
   key <- instrument$Norms[[1]]
@@ -237,12 +239,48 @@ norm_standardize <- function(data, scales, angles = octants(), instrument,
     scores[, i] <- (scale_data[[i]] - m_i) / s_i
   }
   scores[is.nan(scores)] <- NA_real_
-  
-  if (append) {
+
+  # Which sample the scores are relative to is a result-determining input --
+  # the choice moves scores far more than the sampling error of any one
+  # sample's moments -- so it is disclosed at the call site rather than left
+  # in an argument the caller may have defaulted. The read is keyed on Sample
+  # rather than taken by row position: nothing requires Norms[[2]] to be
+  # stored in Sample order, and a positional read would silently report a
+  # different sample's size and description than the one used.
+  info <- instrument$Norms[[2]]
+  info <- info[info$Sample == sample, ]
+  disclosure <- list(
+    Instrument = instrument$Details$Abbrev,
+    Sample = sample,
+    Size = info$Size[[1]],
+    Population = info$Population[[1]]
+  )
+
+  if (!quiet) {
+    # The stored label names the group the sample was drawn from, so it is
+    # printed as a plain description; framing it as a population would make
+    # the package assert a representativeness none of these samples claims.
+    n_other <- nrow(instrument$Norms[[2]]) - 1L
+    msg <- paste0(
+      "Standardized against ", disclosure$Instrument, " normative sample ",
+      sample, ": N = ", disclosure$Size, ", ", disclosure$Population, "."
+    )
+    if (n_other > 0) {
+      msg <- paste0(
+        msg, " ", n_other, " other sample", if (n_other > 1L) "s are" else " is",
+        " available; see norms()."
+      )
+    }
+    message(msg)
+  }
+
+  out <- if (append) {
     cbind(data, scores)
   } else {
-    as.data.frame(scores) 
+    as.data.frame(scores)
   }
+  attr(out, "norm_sample") <- disclosure
+  out
 }
 
 #' Standardize circumplex scales using sample data

--- a/R/tidying_functions.R
+++ b/R/tidying_functions.R
@@ -124,9 +124,18 @@ score <- function(data, items, instrument, na.rm = TRUE,
 #' Standardize circumplex scales using normative data
 #'
 #' Take in a data frame containing circumplex scales, angle definitions for each
-#' scale, and normative data (from the package or custom) and return that same
-#' data frame with each specified circumplex scale transformed into standard
-#' scores (i.e., z-scores) based on comparison to the normative data.
+#' scale, and an instrument whose normative data will be used, and return that
+#' same data frame with each specified circumplex scale transformed into
+#' standard scores (i.e., z-scores) based on comparison to that instrument's
+#' normative sample.
+#'
+#' The sample the scores are compared against is a result-determining choice,
+#' not a technicality: different samples of the same instrument can move a
+#' respondent's z-scores by more than half a standard deviation. So unless
+#' `quiet = TRUE`, every successful call reports which sample it used, how
+#' large that sample was, and how it is described, and every call attaches the
+#' same facts to the result (see `@return`). Use `norms()` to see the samples
+#' an instrument carries before choosing one.
 #'
 #' @param data Required. A data frame or matrix containing at least circumplex
 #'   scales.
@@ -143,10 +152,12 @@ score <- function(data, items, instrument, na.rm = TRUE,
 #'   available circumplex instruments, see `instruments()`.
 #' @param sample Required. An integer corresponding to the normative sample to
 #'   use in standardizing the scale scores (default = 1). See `?norms` to
-#'   see the normative samples available for an instrument. A sample whose
-#'   mean scores fall outside the instrument's own response range cannot be on
-#'   the same metric as the scores being standardized, and is refused with an
-#'   error rather than used; `norms()` lists the alternatives.
+#'   see the normative samples available for an instrument. Two conditions are
+#'   refused with an error rather than used: a `sample` the instrument does not
+#'   carry (the error lists the sample numbers it does), and a sample whose
+#'   mean scores fall outside the instrument's own response range, which cannot
+#'   be on the same metric as the scores being standardized. `norms()` lists
+#'   the alternatives in both cases.
 #' @param prefix Optional. A string to include at the beginning of the newly
 #'   calculated scale variables' names, before the scale name and `suffix`
 #'   (default = "").
@@ -156,12 +167,26 @@ score <- function(data, items, instrument, na.rm = TRUE,
 #' @param append Optional. A logical that determines whether the calculated
 #'   standardized scores should be added as columns to `data` in the output or
 #'   the standardized scores alone should be output (default = TRUE).
-#' @return A data frame that contains the norm-standardized versions of `scales`.
+#' @param quiet Optional. A logical that suppresses the message naming the
+#'   normative sample used (default = FALSE). Set to `TRUE` in loops, knitted
+#'   documents, and anywhere else the message is noise; the returned attribute
+#'   below records the same facts either way.
+#' @return A data frame that contains the norm-standardized versions of
+#'   `scales`. It carries a `"norm_sample"` attribute -- a list with elements
+#'   `Instrument`, `Sample`, `Size` and `Population` -- recording which
+#'   normative sample produced the scores, so a script that never sees the
+#'   console can still report what its z-scores are relative to. Retrieve it
+#'   with `attr(x, "norm_sample")`.
 #' @export
 #' @family tidying functions
 #' @examples
 #' data("jz2017")
 #' norm_standardize(jz2017, scales = 2:9, instrument = iipsc, sample = 1)
+#'
+#' # The IIP-SC carries more than one normative sample. Omitting `sample` takes
+#' # the first, and the message says which one that was.
+#' z <- norm_standardize(jz2017, scales = 2:9, instrument = iipsc)
+#' attr(z, "norm_sample")
 norm_standardize <- function(data, scales, angles = octants(), instrument,
                        sample = 1, prefix = "", suffix = "_z", append = TRUE,
                        quiet = FALSE) {

--- a/R/tidying_functions.R
+++ b/R/tidying_functions.R
@@ -181,6 +181,22 @@ norm_standardize <- function(data, scales, angles = octants(), instrument,
   key <- instrument$Norms[[1]]
   key <- key[key$Sample == sample, ]
 
+  # An unmatched `sample` used to fall through to the arity check below, whose
+  # message names neither the argument at fault nor what would have been
+  # valid -- so the one mistake the argument invites was reported as a
+  # mismatch between `scales` and the norms.
+  if (nrow(key) == 0) {
+    available <- sort(unique(instrument$Norms[[1]]$Sample))
+    stop(
+      "No normative data for sample ", sample, ". The ",
+      instrument$Details$Abbrev, " carries sample",
+      if (length(available) > 1) "s " else " ",
+      paste(available, collapse = ", "),
+      "; see norms() for what each one is.",
+      call. = FALSE
+    )
+  }
+
   stopifnot(length(scales) == nrow(key))
 
   # A normative sample whose means fall outside the instrument's own response
@@ -193,10 +209,14 @@ norm_standardize <- function(data, scales, angles = octants(), instrument,
     hi <- max(anchors$Value)
     outside <- which(key$M < lo | key$M > hi)
     if (length(outside) > 0) {
+      # The norms label their scale column `Scale` on some instruments and
+      # `Abbrev` on others; reading `Scale` unconditionally printed a bare NA
+      # for the seven that use the other name.
+      labels <- if ("Scale" %in% names(key)) key$Scale else key$Abbrev
       stop(
         "The ", instrument$Details$Abbrev, " normative sample ", sample,
         " cannot be used for standardization. Its mean score for ",
-        paste(key$Scale[outside], collapse = ", "),
+        paste(labels[outside], collapse = ", "),
         " falls outside the instrument's ", lo, " to ", hi,
         " response range, so this sample is not on the same metric as the ",
         "scores being standardized. Use norms() to see the other samples ",

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -15,7 +15,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M73 | Norms provenance audit, batch 2 (single-sample instruments) | done | — | high | milestones/archive/M73-norms-provenance-audit-batch2.md |
 | M74 | Norms provenance audit, batch 3 (multi-sample instruments) | done | M73 | high | milestones/archive/M74-norms-provenance-audit-batch3.md |
 | M75 | Norms provenance audit, batch 4 (IIP family) | done | — | high | milestones/archive/M75-norms-provenance-audit-batch4.md |
-| M76 | Disclose the reference sample at the standardizing call site | planned | — | normal | milestones/M76-norms-call-site-disclosure.md |
+| M76 | Disclose the reference sample at the standardizing call site | in-progress | — | normal | milestones/M76-norms-call-site-disclosure.md |
 | M77 | Say precisely what the shipped reference statistics are | planned | M76 | normal | milestones/M77-norms-fitness-docs.md |
 
 ## Candidates

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -15,7 +15,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M73 | Norms provenance audit, batch 2 (single-sample instruments) | done | — | high | milestones/archive/M73-norms-provenance-audit-batch2.md |
 | M74 | Norms provenance audit, batch 3 (multi-sample instruments) | done | M73 | high | milestones/archive/M74-norms-provenance-audit-batch3.md |
 | M75 | Norms provenance audit, batch 4 (IIP family) | done | — | high | milestones/archive/M75-norms-provenance-audit-batch4.md |
-| M76 | Disclose the reference sample at the standardizing call site | review | — | normal | milestones/M76-norms-call-site-disclosure.md |
+| M76 | Disclose the reference sample at the standardizing call site | in-progress | — | normal | milestones/M76-norms-call-site-disclosure.md |
 | M77 | Say precisely what the shipped reference statistics are | planned | M76 | normal | milestones/M77-norms-fitness-docs.md |
 
 ## Candidates

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -15,7 +15,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M73 | Norms provenance audit, batch 2 (single-sample instruments) | done | — | high | milestones/archive/M73-norms-provenance-audit-batch2.md |
 | M74 | Norms provenance audit, batch 3 (multi-sample instruments) | done | M73 | high | milestones/archive/M74-norms-provenance-audit-batch3.md |
 | M75 | Norms provenance audit, batch 4 (IIP family) | done | — | high | milestones/archive/M75-norms-provenance-audit-batch4.md |
-| M76 | Disclose the reference sample at the standardizing call site | in-progress | — | normal | milestones/M76-norms-call-site-disclosure.md |
+| M76 | Disclose the reference sample at the standardizing call site | review | — | normal | milestones/M76-norms-call-site-disclosure.md |
 | M77 | Say precisely what the shipped reference statistics are | planned | M76 | normal | milestones/M77-norms-fitness-docs.md |
 
 ## Candidates

--- a/cairn/milestones/M76-norms-call-site-disclosure.md
+++ b/cairn/milestones/M76-norms-call-site-disclosure.md
@@ -1,6 +1,6 @@
 # M76: Disclose the reference sample at the standardizing call site
 
-- **Status:** review
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** RR16
@@ -34,7 +34,7 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
 
 ## Acceptance criteria
 
-- [x] AC1 `norm_standardize()` takes `quiet`, default `FALSE`. On a successful
+- [ ] AC1 `norm_standardize()` takes `quiet`, default `FALSE`. On a successful
       non-quiet call it emits a message naming the sample number used and that
       sample's `Size` and `Population`, read from the `Norms[[2]]` row whose
       `Sample` equals the number used rather than by row position; where the
@@ -59,7 +59,7 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
       violator and is `Scale`-labelled — so the shipped roster cannot exhibit
       this. The exact-set pin at `tests/testthat/test-norms-anchor-range.R:46`
       is left standing.
-- [x] AC4 A `sample` matching no `Norms[[1]]` row is refused by its own check,
+- [ ] AC4 A `sample` matching no `Norms[[1]]` row is refused by its own check,
       distinct from the scales-vs-norms arity `stopifnot()`, which is retained
       and separately tested. The error names the `sample` argument and lists the
       sample numbers the instrument carries; the test asserts those numbers
@@ -167,6 +167,8 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
 
 - 2026-08-08: T8 and T9 done. `devtools::check(args = "--no-manual")` clean — 0 errors, 0 warnings, 0 notes, vignettes rebuilt (13m 33s). T9's pin was written with the AC1/AC2 tests in the same file rather than as a separate late task; it asserts both exports and the `Population` column over the shipped enumeration. All tasks complete; status → review.
 
+- 2026-08-08: review returned the milestone to in-progress (defect return 1). F1 (90): the "N other samples are available" clause counts anchor-range-refused samples, so cais sample 1's message advertises a sample D-040 refuses. F4 (85): `sample = NA_real_` bypasses AC4's refusal, which is AC4 failing inside its own domain. AC1 and AC4 unticked; the other seven criteria keep their recorded evidence. F2, F10 and F16 are actioned without forcing the return.
+
 ## Decisions
 
 - 2026-08-08 (RR16 R1, R5, R6): `norm_standardize()`, `norms()`, `$Norms` and the `Population` column keep their names. The plan gate's provisional keep is now decided on the merits — the identifiers are the interpersonal-circumplex field's own usage rather than claims, the behavioral hazard runs through silence plus the definite article and is closed by this milestone's disclosure plus M77's prose, and the rename's benefit is near zero at any cost. Promoted to D-041; the ROADMAP's parked rename item is closed rather than deferred.
@@ -231,3 +233,47 @@ generated files regenerated rather than hand-edited; `pkgdown::check_pkgdown()`
 reports no problems; NEWS entries present; no new top-level files, so no
 `.Rbuildignore` change.
 
+**Independent review (three lenses + scorer), 2026-08-08.** 22 candidate
+findings; 5 scored >= 80 and are actioned, 17 below 80 are logged here.
+
+Actioned (>= 80):
+
+- F1 (90) — `R/tidying_functions.R`: the "N other samples are available" clause
+  counts every `Norms[[2]]` row, including samples D-040 refuses. Live: cais
+  sample 1 prints "1 other sample is available; see norms()." while cais sample
+  2 errors. The disclosure points the user at a sample the package refuses.
+- F2 (88) — `test-norms-disclosure.R`: the multi-sample assertion computes its
+  expected count with the same expression the implementation uses
+  (`nrow(Norms[[2]]) - 1`), so no test in the branch can fail on F1.
+- F4 (85) — `R/tidying_functions.R`: `sample = NA_real_` passes
+  `is_num(sample, n = 1)`, then `key$Sample == NA` yields NAs and `key[NA, ]`
+  returns NA-filled rows, so `nrow(key) == 0` is false and the new refusal is
+  bypassed — the call dies in the arity `stopifnot()` or in the angle loop.
+- F10 (80) — `test-norms-disclosure.R`: "the attribute is present whether or
+  not the message was emitted" asserts only identity between two attributes,
+  which passes if both are NULL; the AC2 sweep uses `quiet = TRUE` on every
+  call, so the non-quiet path's attribute presence is unfenced.
+- F16 (88) — `R/tidying_functions.R:137`: "(see `@return`)" renders in the
+  shipped help page as the literal text `@return`.
+
+Logged, below threshold (17): F9 (78, the partition assertions are true by
+construction and nothing pins the roster at 15) · F3 (68, `Norms[[1]]`/`[[2]]`
+sample sets assumed in sync; bare "subscript out of bounds" if not, unreachable
+on the shipped roster) · F5 (55, chained `append = TRUE` leaves the attribute
+describing only the last call) · F12 (55, bare `expect_error()` on the arity
+check) · F14 (45, the single-sample sweep omits the `disclosure_usable()` skip)
+· F11 (40) · F13 (40) · F18 (35, NEWS "nearly twice that") · F21 (35) · F6 (30)
+· F8 (30) · F17 (30) · F20 (30, the vignette chunk gains a message; file
+untouched by the diff and outside Scope) · F22 (30, the `expect_silent`
+narrowing, judged deliberate and compensated) · F7 (25) · F19 (20).
+
+Lens coverage: the prior-review lens reported no prior-review evidence
+contradicted (GitHub inline-comment probe returned empty; the M72-M75 archives
+do not touch this code surface). The blame-history lens confirmed D-040's
+refusal intact, PR #99's `iei` sample-key pin preserved, and no contradiction
+of D-039/D-040/D-041.
+
+**Return floor met — status back to `in-progress`.** F1 scores 90 on a defect
+in what the package does for its users, and F4 demonstrates AC4 failing inside
+its own domain: a `sample` matching no `Norms[[1]]` row is not refused by its
+own check when that sample is `NA`. Defect-return count for this milestone: 1.

--- a/cairn/milestones/M76-norms-call-site-disclosure.md
+++ b/cairn/milestones/M76-norms-call-site-disclosure.md
@@ -138,7 +138,7 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
       `R/tidying_functions.R:197`.
 - [x] T6 Test-first, then implement, the unmatched-`sample` refusal, leaving the
       arity check in place with its own test.
-- [ ] T7 Roxygen for `quiet`, `@return`, the message and both refusals; add the
+- [x] T7 Roxygen for `quiet`, `@return`, the message and both refusals; add the
       default-sample example; resolve the "or custom" claim at
       `R/tidying_functions.R:127`; run `document()`.
 - [ ] T8 NEWS entries; full `test()` and `check()`.
@@ -159,6 +159,11 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
 - 2026-08-08: this file now carries 9 acceptance criteria, over the ~7 split tripwire. Not split: AC8 constrains AC1's message text and AC9 is a one-file test pin, so both land inside the same reviewable PR rather than forming an independent slice.
 
 - 2026-08-08: T5 and T6 done. The `Abbrev`/`Scale` defect's pre-fix failure was verified rather than assumed: `key$Scale` is NULL on an Abbrev-labelled instrument, so `paste(NULL[outside], collapse = ", ")` yields `""` and the refusal named no scale at all — it did not print "NA", which the test's first draft asserted. The test now pins the empty-list shape it actually produced. Two further loud call sites in `test-tidying_functions.R` (the 0-vs-360 pair) were quieted in the same pass; the suite now emits no disclosure noise.
+
+- 2026-08-08: T7 done — `quiet`, `@return`'s attribute, both refusal conditions, the multi-sample default-`sample` example, and RR16 B1's "or custom" opening, which now names the instrument argument the signature actually requires. `document()` regenerates `man/norm_standardize.Rd` only, with no `resolve link` line and no further diff on a second run.
+- 2026-08-08: AC6 entry-to-test mapping. "reports which normative sample it used" + `quiet` → test-norms-disclosure.R "a single-sample instrument's message names the sample, size and description", "a multi-sample instrument's message says how many other samples exist", "quiet = TRUE emits nothing". "norm_sample attribute" → "both return paths carry the norm_sample attribute" and "the attribute is present whether or not the message was emitted". "names the offending scales for every instrument" → test-norms-anchor-range.R "the refusal names the offending scales on an Abbrev-labelled instrument". "a normative sample an instrument does not carry" → test-norms-disclosure.R "a sample the instrument does not carry is refused by name", with the retained arity check fenced by "the scales-vs-norms arity check is retained and still fires".
+- 2026-08-08: the NEWS entry's first draft said the reference choice moves scores "half a standard deviation on average"; M74 measured 0.44, so the entry now reads "roughly half ... and by nearly twice that at the extreme" (0.78). Corrected before the entry was committed.
+- 2026-08-08: full `devtools::test()` clean — 0 failures, 6537 passing. The 4 warnings are all in `test-ci_accuracy.R`, which this branch does not touch.
 
 ## Decisions
 

--- a/cairn/milestones/M76-norms-call-site-disclosure.md
+++ b/cairn/milestones/M76-norms-call-site-disclosure.md
@@ -134,9 +134,9 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
       "population" nor "representative" (AC8).
 - [x] T4 Test-first, then implement, the returned attribute on both `append`
       branches.
-- [ ] T5 Test-first, then fix, the `Abbrev`/`Scale` column assumption at
+- [x] T5 Test-first, then fix, the `Abbrev`/`Scale` column assumption at
       `R/tidying_functions.R:197`.
-- [ ] T6 Test-first, then implement, the unmatched-`sample` refusal, leaving the
+- [x] T6 Test-first, then implement, the unmatched-`sample` refusal, leaving the
       arity check in place with its own test.
 - [ ] T7 Roxygen for `quiet`, `@return`, the message and both refusals; add the
       default-sample example; resolve the "or custom" claim at
@@ -157,6 +157,8 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
 - 2026-08-08: T2/T3/T1/T4 done in one checkpoint, T1 following T3 rather than leading it — the re-fencing adds `quiet = TRUE` at call sites, which cannot pass until the argument exists. Tests written red first (10 failures, all "unused argument (quiet = TRUE)" or no message emitted), then green. Two sites beyond T1's named three were re-fenced in the same pass: `test-norms-anchor-range.R`'s two `out <- norm_standardize(...)` calls, the same class as the `expect_silent` case T1 named.
 - 2026-08-08: implementation choices settled at the pre-implementation gate — message form "Standardized against IIP-SC normative sample 1: N = 872, American college students." plus, on a multi-sample instrument, "1 other sample is available; see norms()."; and one list attribute `"norm_sample"` over four flat ones. The gate showed `see norms(iipsc)`; the shipped text says `see norms()` because `$Details` carries no lowercase object name to interpolate, and the existing anchor-range refusal already points at bare `norms()`.
 - 2026-08-08: this file now carries 9 acceptance criteria, over the ~7 split tripwire. Not split: AC8 constrains AC1's message text and AC9 is a one-file test pin, so both land inside the same reviewable PR rather than forming an independent slice.
+
+- 2026-08-08: T5 and T6 done. The `Abbrev`/`Scale` defect's pre-fix failure was verified rather than assumed: `key$Scale` is NULL on an Abbrev-labelled instrument, so `paste(NULL[outside], collapse = ", ")` yields `""` and the refusal named no scale at all — it did not print "NA", which the test's first draft asserted. The test now pins the empty-list shape it actually produced. Two further loud call sites in `test-tidying_functions.R` (the 0-vs-360 pair) were quieted in the same pass; the suite now emits no disclosure noise.
 
 ## Decisions
 

--- a/cairn/milestones/M76-norms-call-site-disclosure.md
+++ b/cairn/milestones/M76-norms-call-site-disclosure.md
@@ -284,7 +284,12 @@ refuses with "No normative data for sample NA. The IIP-SC carries samples 1, 2"
 on a multi-sample instrument and the ISC equivalent on a single-sample one;
 `document()` emits zero `resolve link` lines and the rendered `.Rd` carries
 "see the Value section below" with no `\verb{@return}`. `devtools::test()`:
-0 failures, 6550 passing. AC1 and AC4 re-ticked on this evidence.
+0 failures, 6550 passing (4 WARNs, all `test-ci_accuracy.R`'s, untouched).
+`devtools::check(args = "--no-manual")`: 0 errors, 0 warnings, 0 notes (14m 9s).
+`cairn_validate` exit 0. AC1, AC4 and AC7 re-ticked on this evidence; the
+remaining six criteria keep their round-1 evidence, none of it invalidated by
+the fixes (the diff touches the message's count, the `Sample` subset, three
+test assertions, and one roxygen line).
 
 **Return floor met — status back to `in-progress`.** F1 scores 90 on a defect
 in what the package does for its users, and F4 demonstrates AC4 failing inside

--- a/cairn/milestones/M76-norms-call-site-disclosure.md
+++ b/cairn/milestones/M76-norms-call-site-disclosure.md
@@ -1,6 +1,6 @@
 # M76: Disclose the reference sample at the standardizing call site
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** RR16
@@ -34,7 +34,7 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
 
 ## Acceptance criteria
 
-- [ ] AC1 `norm_standardize()` takes `quiet`, default `FALSE`. On a successful
+- [x] AC1 `norm_standardize()` takes `quiet`, default `FALSE`. On a successful
       non-quiet call it emits a message naming the sample number used and that
       sample's `Size` and `Population`, read from the `Norms[[2]]` row whose
       `Sample` equals the number used rather than by row position; where the
@@ -59,7 +59,7 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
       violator and is `Scale`-labelled — so the shipped roster cannot exhibit
       this. The exact-set pin at `tests/testthat/test-norms-anchor-range.R:46`
       is left standing.
-- [ ] AC4 A `sample` matching no `Norms[[1]]` row is refused by its own check,
+- [x] AC4 A `sample` matching no `Norms[[1]]` row is refused by its own check,
       distinct from the scales-vs-norms arity `stopifnot()`, which is retained
       and separately tested. The error names the `sample` argument and lists the
       sample numbers the instrument carries; the test asserts those numbers
@@ -169,6 +169,9 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
 
 - 2026-08-08: review returned the milestone to in-progress (defect return 1). F1 (90): the "N other samples are available" clause counts anchor-range-refused samples, so cais sample 1's message advertises a sample D-040 refuses. F4 (85): `sample = NA_real_` bypasses AC4's refusal, which is AC4 failing inside its own domain. AC1 and AC4 unticked; the other seven criteria keep their recorded evidence. F2, F10 and F16 are actioned without forcing the return.
 
+- 2026-08-08: all five actioned findings fixed on the branch, tests-first (three new/changed assertions red first, each for its own reason). F1: the other-samples count now counts only samples `norm_standardize()` would accept, via a new internal `norm_sample_usable()` that shares the anchor-range predicate with the refusal rather than restating it — live, cais sample 1 no longer advertises its refused sibling while iipsc sample 1 still offers its usable one. F4: the `Sample` subset uses `which()`, which drops NAs from either side; the first attempt (`!is.na(key$Sample) & key$Sample == sample`) was wrong because `TRUE & NA` is NA, and was corrected before it was run. F2: the multi-sample assertion derives its expected count from the usability predicate instead of mirroring the implementation's `nrow() - 1`. F10: presence is asserted on each path before the two are compared. F16: the roxygen now says "the Value section below" rather than a literal tag name. F9 (78, below threshold) was fixed in the same pass since it sat in the test AC1 names — the roster size is now pinned at 15.
+- 2026-08-08: post-fix `devtools::test()`: 0 failures, 6550 passing (up from 6537). The 4 WARNs remain `test-ci_accuracy.R`'s, untouched. AC1 and AC4 re-ticked on the live evidence recorded in the Review section.
+
 ## Decisions
 
 - 2026-08-08 (RR16 R1, R5, R6): `norm_standardize()`, `norms()`, `$Norms` and the `Population` column keep their names. The plan gate's provisional keep is now decided on the merits — the identifiers are the interpersonal-circumplex field's own usage rather than claims, the behavioral hazard runs through silence plus the definite article and is closed by this milestone's disclosure plus M77's prose, and the rename's benefit is near zero at any cost. Promoted to D-041; the ROADMAP's parked rename item is closed rather than deferred.
@@ -272,6 +275,16 @@ contradicted (GitHub inline-comment probe returned empty; the M72-M75 archives
 do not touch this code surface). The blame-history lens confirmed D-040's
 refusal intact, PR #99's `iei` sample-key pin preserved, and no contradiction
 of D-039/D-040/D-041.
+
+**Post-fix verification, 2026-08-08 (round 2).** All five actioned findings
+fixed and verified live: cais sample 1's message now omits the other-samples
+clause entirely (its only sibling is anchor-range refused) while iipsc sample 1
+still reads "1 other sample is available; see norms()."; `sample = NA_real_`
+refuses with "No normative data for sample NA. The IIP-SC carries samples 1, 2"
+on a multi-sample instrument and the ISC equivalent on a single-sample one;
+`document()` emits zero `resolve link` lines and the rendered `.Rd` carries
+"see the Value section below" with no `\verb{@return}`. `devtools::test()`:
+0 failures, 6550 passing. AC1 and AC4 re-ticked on this evidence.
 
 **Return floor met — status back to `in-progress`.** F1 scores 90 on a defect
 in what the package does for its users, and F4 demonstrates AC4 failing inside

--- a/cairn/milestones/M76-norms-call-site-disclosure.md
+++ b/cairn/milestones/M76-norms-call-site-disclosure.md
@@ -1,6 +1,6 @@
 # M76: Disclose the reference sample at the standardizing call site
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** RR16
@@ -141,8 +141,8 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
 - [x] T7 Roxygen for `quiet`, `@return`, the message and both refusals; add the
       default-sample example; resolve the "or custom" claim at
       `R/tidying_functions.R:127`; run `document()`.
-- [ ] T8 NEWS entries; full `test()` and `check()`.
-- [ ] T9 The AC9 regression pin on the two exports and the `Population` column.
+- [x] T8 NEWS entries; full `test()` and `check()`.
+- [x] T9 The AC9 regression pin on the two exports and the `Population` column.
 
 ## Work log
 
@@ -164,6 +164,8 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
 - 2026-08-08: AC6 entry-to-test mapping. "reports which normative sample it used" + `quiet` → test-norms-disclosure.R "a single-sample instrument's message names the sample, size and description", "a multi-sample instrument's message says how many other samples exist", "quiet = TRUE emits nothing". "norm_sample attribute" → "both return paths carry the norm_sample attribute" and "the attribute is present whether or not the message was emitted". "names the offending scales for every instrument" → test-norms-anchor-range.R "the refusal names the offending scales on an Abbrev-labelled instrument". "a normative sample an instrument does not carry" → test-norms-disclosure.R "a sample the instrument does not carry is refused by name", with the retained arity check fenced by "the scales-vs-norms arity check is retained and still fires".
 - 2026-08-08: the NEWS entry's first draft said the reference choice moves scores "half a standard deviation on average"; M74 measured 0.44, so the entry now reads "roughly half ... and by nearly twice that at the extreme" (0.78). Corrected before the entry was committed.
 - 2026-08-08: full `devtools::test()` clean — 0 failures, 6537 passing. The 4 warnings are all in `test-ci_accuracy.R`, which this branch does not touch.
+
+- 2026-08-08: T8 and T9 done. `devtools::check(args = "--no-manual")` clean — 0 errors, 0 warnings, 0 notes, vignettes rebuilt (13m 33s). T9's pin was written with the AC1/AC2 tests in the same file rather than as a separate late task; it asserts both exports and the `Population` column over the shipped enumeration. All tasks complete; status → review.
 
 ## Decisions
 

--- a/cairn/milestones/M76-norms-call-site-disclosure.md
+++ b/cairn/milestones/M76-norms-call-site-disclosure.md
@@ -5,7 +5,7 @@
 - **Depends on:** —
 - **Driving RR:** RR16
 - **Principles touched:** GP2, GP4
-- **Branch/PR:** `m76-norms-call-site-disclosure`
+- **Branch/PR:** `m76-norms-call-site-disclosure` / https://github.com/jmgirard/circumplex/pull/104
 
 ## Goal
 
@@ -34,7 +34,7 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
 
 ## Acceptance criteria
 
-- [ ] AC1 `norm_standardize()` takes `quiet`, default `FALSE`. On a successful
+- [x] AC1 `norm_standardize()` takes `quiet`, default `FALSE`. On a successful
       non-quiet call it emits a message naming the sample number used and that
       sample's `Size` and `Population`, read from the `Norms[[2]]` row whose
       `Sample` equals the number used rather than by row position; where the
@@ -46,25 +46,25 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
       are asserted to partition all 15. The `Sample`-keyed read is fenced by a
       constructed instrument whose `Norms[[2]]` row order differs from its
       `Sample` values, which no shipped instrument does.
-- [ ] AC2 Every successful call returns a frame carrying an attribute recording
+- [x] AC2 Every successful call returns a frame carrying an attribute recording
       the instrument abbreviation, the sample number used, its `Size` and its
       `Population`, on both the `append = TRUE` (`R/tidying_functions.R:242`)
       and `append = FALSE` (`:244`) return paths, and `@return` documents it.
       Tested over the `shipped_instruments()` enumeration at both `append`
       values.
-- [ ] AC3 The out-of-anchor-range refusal names the offending scales for an
+- [x] AC3 The out-of-anchor-range refusal names the offending scales for an
       instrument whose `Norms[[1]]` labels its second column `Abbrev`, as it
       already does for one labelled `Scale`. Fenced by a constructed
       `Abbrev`-labelled violating instrument, because `cais` is the only shipped
       violator and is `Scale`-labelled — so the shipped roster cannot exhibit
       this. The exact-set pin at `tests/testthat/test-norms-anchor-range.R:46`
       is left standing.
-- [ ] AC4 A `sample` matching no `Norms[[1]]` row is refused by its own check,
+- [x] AC4 A `sample` matching no `Norms[[1]]` row is refused by its own check,
       distinct from the scales-vs-norms arity `stopifnot()`, which is retained
       and separately tested. The error names the `sample` argument and lists the
       sample numbers the instrument carries; the test asserts those numbers
       appear, not merely the word "sample".
-- [ ] AC5 `?norm_standardize` documents `quiet`, the message, the attribute and
+- [x] AC5 `?norm_standardize` documents `quiet`, the message, the attribute and
       both refusal conditions, and its `@examples` include one call on a
       multi-sample instrument that omits `sample`, so the disclosure appears in
       shipped documentation. Its opening "normative data (from the package or
@@ -72,14 +72,14 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
       what it means, the signature admitting only a `circumplex_instrument`
       (`:172`). `Rscript -e 'options(cli.width = 500); devtools::document()'`
       produces no diff and zero lines matching `resolve link`.
-- [ ] AC6 `NEWS.md` carries user-facing entries for `quiet`, the message, the
+- [x] AC6 `NEWS.md` carries user-facing entries for `quiet`, the message, the
       attribute and the two refusal-message fixes, naming no test file. Each
       entry's asserted behavior has a test that fails without it; the
       entry-to-test mapping is recorded in this milestone's work log, not in
       NEWS.
-- [ ] AC7 `Rscript -e 'devtools::test()'` clean and `Rscript -e
+- [x] AC7 `Rscript -e 'devtools::test()'` clean and `Rscript -e
       'devtools::check()'` clean (0 errors, 0 warnings; NOTEs justified).
-- [ ] AC8 (BC2) The disclosure message emitted by `norm_standardize()` (M76 AC1)
+- [x] AC8 (BC2) The disclosure message emitted by `norm_standardize()` (M76 AC1)
       contains the selected sample's `Norms[[2]]$Population` value verbatim, and
       its fixed (non-data) message text contains neither the token "population"
       nor the token "representative", case-insensitively; the verbatim-value
@@ -90,7 +90,7 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
       tokens, so the procedure asserts what the tolerance states. Tolerance:
       exact string absence in the fixed text; a shipped `Population` *value*
       containing those tokens does not violate this criterion.
-- [ ] AC9 (BC1) `norm_standardize` and `norms` both appear in `NAMESPACE` as
+- [x] AC9 (BC1) `norm_standardize` and `norms` both appear in `NAMESPACE` as
       exports under exactly those names, and every instrument in the
       `shipped_instruments()` enumeration has a `Norms` list slot whose second
       element contains a column named `Population`. Asserted by a regression pin
@@ -174,3 +174,60 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
 - 2026-08-08 (RR16 R3, BC3, B2): the per-sample reference-kind column, and the extension of this milestone's message and attribute to carry it, go to a new milestone rather than into this scope. RR16 leaves scheduling to the maintainer, who chose that route at the ingest gate; the pre-2.0.0 window is what makes it cheap, so it is planned before the release.
 
 ## Review
+
+Verified 2026-08-08 against branch `m76-norms-call-site-disclosure` at `ac1e9e10`,
+PR #104. `devtools::check()` ran at `ee061927`; `git diff ee061927..HEAD -- . ':!cairn'`
+is empty, so the check evidence holds for HEAD.
+
+- AC1 — Live: a default (`sample` omitted) call on iipsc emits "Standardized against
+  IIP-SC normative sample 1: N = 872, American college students. 1 other sample is
+  available; see norms()."; isc (single-sample) emits the form without the
+  others clause. Tests: both message forms over their memberships, the two
+  memberships asserted to partition all 15, `quiet = TRUE` silence over every
+  usable sample, and the row-order-vs-`Sample` fixture (iipsc rows reversed,
+  message still reports N = 872 and not N = 106). All green.
+- AC2 — Live: `attr(z, "norm_sample")` is a 4-element list (Instrument "IIP-SC",
+  Sample 1, Size 872, Population "American college students"); present on the
+  `append = FALSE` path too, and identical whether or not `quiet` suppressed the
+  message. Tested over the enumeration at both `append` values.
+- AC3 — Live: a constructed `Abbrev`-labelled violator (iitc, one octant pushed
+  past its anchor maximum) refuses with "Its mean score for DE falls outside the
+  instrument's 0 to 5 response range". The exact-set pin at
+  `test-norms-anchor-range.R` is untouched and green.
+- AC4 — Live: `sample = 7` on iipsc refuses with "No normative data for sample 7.
+  The IIP-SC carries samples 1, 2; see norms() for what each one is." — names the
+  argument and lists the numbers. The arity `stopifnot()` is retained and has its
+  own test.
+- AC5 — `Rscript -e 'options(cli.width = 500); devtools::document()'` produces no
+  diff and zero `resolve link` lines. The shipped `man/norm_standardize.Rd`
+  carries the multi-sample default-`sample` example ending in
+  `attr(z, "norm_sample")`. The "or custom" opening is gone (RR16 B1).
+- AC6 — 4 new user-facing NEWS entries, naming no test file. The entry-to-test
+  mapping is in this milestone's work log (2026-08-08), not in NEWS.
+- AC7 — `devtools::test()`: 0 failures, 6537 passing; the 4 WARNs are all in
+  `test-ci_accuracy.R`, untouched by this branch. `devtools::check(args =
+  "--no-manual")`: 0 errors, 0 warnings, 0 notes, vignettes rebuilt (13m 33s).
+- AC8 (BC2) — Measured over the shipped roster: 24 (instrument, sample) pairs, 23
+  emitting a message (the CAIS adult sample is refused before any message, D-040),
+  and 23 of 23 carrying that sample's `Population` value verbatim. The
+  fixed-text clause is asserted via a sentinel `Population`
+  ("a representative population of nobody"): stripping the value from the emitted
+  message leaves text containing neither "population" nor "representative",
+  case-insensitively.
+- AC9 (BC1) — `norm_standardize` and `norms` both exported under exactly those
+  names; 15 of 15 shipped instruments carry a `Population` column in `Norms[[2]]`.
+
+**Projection vs outcome (RR16).** The one numeric quantity ingested is AC8's
+domain: measured 24 (instrument, sample) pairs against RR16's stated 24, and
+23 emitting messages — the one gap being the anchor-range refusal RR16 did not
+model. RR16's other counts (BC3's 6/16/2 partition) were not ingested here and
+are carried by the ROADMAP candidate row.
+
+**Consistency gate.** `cairn_validate` exit 0, every check PASS; the one WARN is
+`sizing (split tripwires)` on this file's 9 criteria, logged at the ingest gate
+with its justification. No `DESIGN.md` principle changed, so `cairn_impact` was
+not run. Toolchain slot: `document()` no-diff and no `resolve link` (above);
+generated files regenerated rather than hand-edited; `pkgdown::check_pkgdown()`
+reports no problems; NEWS entries present; no new top-level files, so no
+`.Rbuildignore` change.
+

--- a/cairn/milestones/M76-norms-call-site-disclosure.md
+++ b/cairn/milestones/M76-norms-call-site-disclosure.md
@@ -1,11 +1,11 @@
 # M76: Disclose the reference sample at the standardizing call site
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** RR16
 - **Principles touched:** GP2, GP4
-- **Branch/PR:** —
+- **Branch/PR:** `m76-norms-call-site-disclosure`
 
 ## Goal
 
@@ -119,20 +119,20 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
 
 ## Tasks
 
-- [ ] T1 Re-fence the existing call sites that will stop being silent:
+- [x] T1 Re-fence the existing call sites that will stop being silent:
       `tests/testthat/test-norms-anchor-range.R`'s `expect_silent` case and the
       explicit-`sample` calls in `tests/testthat/test-tidying_functions.R:43,49,191`.
       Decide per site whether it passes `quiet = TRUE` or asserts the message.
-- [ ] T2 Test-first for AC1 and AC8: both message forms over the partitioned
+- [x] T2 Test-first for AC1 and AC8: both message forms over the partitioned
       roster, the verbatim-`Population` assertion over all 24 (instrument,
       sample) pairs, the fixed-text token absence via a sentinel-`Population`
       fixture, `quiet = TRUE` silence, and the row-order-vs-`Sample` fixture.
-- [ ] T3 Implement `quiet` and the message in `R/tidying_functions.R`, keying
+- [x] T3 Implement `quiet` and the message in `R/tidying_functions.R`, keying
       the `Size`/`Population` read on `Sample`. Use base `message()`, the
       package's established idiom (`R/ssm_analysis.R:350`); cli is not an Import.
       The fixed text frames the stored value as a description and uses neither
       "population" nor "representative" (AC8).
-- [ ] T4 Test-first, then implement, the returned attribute on both `append`
+- [x] T4 Test-first, then implement, the returned attribute on both `append`
       branches.
 - [ ] T5 Test-first, then fix, the `Abbrev`/`Scale` column assumption at
       `R/tidying_functions.R:197`.
@@ -154,6 +154,8 @@ new milestone, ROADMAP candidate row; a `data-raw/` schema change and a
 - 2026-08-08: RB16 opened on the norms vocabulary rename. M76 stays planned and workable — its `quiet`/message/attribute scope is independent of what the vocabulary is called — but an RR16 verdict renaming `norm_standardize()` would amend this file through the /milestone-implement step-6 gate.
 - 2026-08-08: RR16 ingested. Verdict is no rename, so nothing in this file's existing scope changes; the amendment adds AC8 (BC2, the message's wording), AC9 (BC1 as a regression pin), RR16 B1's "or custom" fix to AC5, and T9. BC3 is routed out to a new milestone. Three departures recorded in the Deviations table above.
 - 2026-08-08: ingest audit ([O], fresh context) over the RR16 criteria returned six findings — BC1 vacuous as an AC and naming a procedure that creates no objects to filter, BC2 quantifying over 24 samples while naming a 15-instrument procedure and carving out a tolerance its own procedure would fail, BC3 mandating work both milestones' Scope excludes, the R3-vs-BC3 gap leaving the attribute without the kind, and no milestone owning IP5's `data-raw/` derivation record. All six were determinate; BC3's own falsifier F2 does not fire (2 of 24 hard to place, under its threshold of 4), and every BC3 count verified against the shipped tree. Routing settled at the ingest gate.
+- 2026-08-08: T2/T3/T1/T4 done in one checkpoint, T1 following T3 rather than leading it — the re-fencing adds `quiet = TRUE` at call sites, which cannot pass until the argument exists. Tests written red first (10 failures, all "unused argument (quiet = TRUE)" or no message emitted), then green. Two sites beyond T1's named three were re-fenced in the same pass: `test-norms-anchor-range.R`'s two `out <- norm_standardize(...)` calls, the same class as the `expect_silent` case T1 named.
+- 2026-08-08: implementation choices settled at the pre-implementation gate — message form "Standardized against IIP-SC normative sample 1: N = 872, American college students." plus, on a multi-sample instrument, "1 other sample is available; see norms()."; and one list attribute `"norm_sample"` over four flat ones. The gate showed `see norms(iipsc)`; the shipped text says `see norms()` because `$Details` carries no lowercase object name to interpolate, and the existing anchor-range refusal already points at bare `norms()`.
 - 2026-08-08: this file now carries 9 acceptance criteria, over the ~7 split tripwire. Not split: AC8 constrains AC1's message text and AC9 is a one-file test pin, so both land inside the same reviewable PR rather than forming an independent slice.
 
 ## Decisions

--- a/man/norm_standardize.Rd
+++ b/man/norm_standardize.Rd
@@ -12,7 +12,8 @@ norm_standardize(
   sample = 1,
   prefix = "",
   suffix = "_z",
-  append = TRUE
+  append = TRUE,
+  quiet = FALSE
 )
 }
 \arguments{
@@ -35,10 +36,12 @@ available circumplex instruments, see \code{instruments()}.}
 
 \item{sample}{Required. An integer corresponding to the normative sample to
 use in standardizing the scale scores (default = 1). See \code{?norms} to
-see the normative samples available for an instrument. A sample whose
-mean scores fall outside the instrument's own response range cannot be on
-the same metric as the scores being standardized, and is refused with an
-error rather than used; \code{norms()} lists the alternatives.}
+see the normative samples available for an instrument. Two conditions are
+refused with an error rather than used: a \code{sample} the instrument does not
+carry (the error lists the sample numbers it does), and a sample whose
+mean scores fall outside the instrument's own response range, which cannot
+be on the same metric as the scores being standardized. \code{norms()} lists
+the alternatives in both cases.}
 
 \item{prefix}{Optional. A string to include at the beginning of the newly
 calculated scale variables' names, before the scale name and \code{suffix}
@@ -51,19 +54,44 @@ calculated scale variables' names, after the scale name and \code{prefix}
 \item{append}{Optional. A logical that determines whether the calculated
 standardized scores should be added as columns to \code{data} in the output or
 the standardized scores alone should be output (default = TRUE).}
+
+\item{quiet}{Optional. A logical that suppresses the message naming the
+normative sample used (default = FALSE). Set to \code{TRUE} in loops, knitted
+documents, and anywhere else the message is noise; the returned attribute
+below records the same facts either way.}
 }
 \value{
-A data frame that contains the norm-standardized versions of \code{scales}.
+A data frame that contains the norm-standardized versions of
+\code{scales}. It carries a \code{"norm_sample"} attribute -- a list with elements
+\code{Instrument}, \code{Sample}, \code{Size} and \code{Population} -- recording which
+normative sample produced the scores, so a script that never sees the
+console can still report what its z-scores are relative to. Retrieve it
+with \code{attr(x, "norm_sample")}.
 }
 \description{
 Take in a data frame containing circumplex scales, angle definitions for each
-scale, and normative data (from the package or custom) and return that same
-data frame with each specified circumplex scale transformed into standard
-scores (i.e., z-scores) based on comparison to the normative data.
+scale, and an instrument whose normative data will be used, and return that
+same data frame with each specified circumplex scale transformed into
+standard scores (i.e., z-scores) based on comparison to that instrument's
+normative sample.
+}
+\details{
+The sample the scores are compared against is a result-determining choice,
+not a technicality: different samples of the same instrument can move a
+respondent's z-scores by more than half a standard deviation. So unless
+\code{quiet = TRUE}, every successful call reports which sample it used, how
+large that sample was, and how it is described, and every call attaches the
+same facts to the result (see \verb{@return}). Use \code{norms()} to see the samples
+an instrument carries before choosing one.
 }
 \examples{
 data("jz2017")
 norm_standardize(jz2017, scales = 2:9, instrument = iipsc, sample = 1)
+
+# The IIP-SC carries more than one normative sample. Omitting `sample` takes
+# the first, and the message says which one that was.
+z <- norm_standardize(jz2017, scales = 2:9, instrument = iipsc)
+attr(z, "norm_sample")
 }
 \seealso{
 Other tidying functions:

--- a/man/norm_standardize.Rd
+++ b/man/norm_standardize.Rd
@@ -81,8 +81,8 @@ not a technicality: different samples of the same instrument can move a
 respondent's z-scores by more than half a standard deviation. So unless
 \code{quiet = TRUE}, every successful call reports which sample it used, how
 large that sample was, and how it is described, and every call attaches the
-same facts to the result (see \verb{@return}). Use \code{norms()} to see the samples
-an instrument carries before choosing one.
+same facts to the result (see the Value section below). Use \code{norms()} to see
+the samples an instrument carries before choosing one.
 }
 \examples{
 data("jz2017")

--- a/tests/testthat/test-norms-anchor-range.R
+++ b/tests/testthat/test-norms-anchor-range.R
@@ -81,7 +81,7 @@ test_that("norm_standardize() still standardizes an in-range sample of the same 
   data("jz2017")
   out <- norm_standardize(
     jz2017,
-    scales = 2:9, instrument = cais, sample = 1, append = FALSE
+    scales = 2:9, instrument = cais, sample = 1, append = FALSE, quiet = TRUE
   )
   expect_s3_class(out, "data.frame")
   expect_identical(ncol(out), 8L)
@@ -90,12 +90,18 @@ test_that("norm_standardize() still standardizes an in-range sample of the same 
 
 test_that("the refusal does not disturb instruments with no violation", {
   data("jz2017")
+  # quiet = TRUE because every successful call now discloses its sample; what
+  # this case asserts is that no *refusal* disturbs a non-violating
+  # instrument, and the disclosure message would mask that with noise of its
+  # own. The message itself is fenced in test-norms-disclosure.R.
   expect_silent(
-    norm_standardize(jz2017, scales = 2:9, instrument = iipsc, sample = 2)
+    norm_standardize(
+      jz2017, scales = 2:9, instrument = iipsc, sample = 2, quiet = TRUE
+    )
   )
   out <- norm_standardize(
     jz2017,
-    scales = 2:9, instrument = iipsc, sample = 2, append = FALSE
+    scales = 2:9, instrument = iipsc, sample = 2, append = FALSE, quiet = TRUE
   )
   expect_identical(ncol(out), 8L)
 })

--- a/tests/testthat/test-norms-anchor-range.R
+++ b/tests/testthat/test-norms-anchor-range.R
@@ -105,3 +105,36 @@ test_that("the refusal does not disturb instruments with no violation", {
   )
   expect_identical(ncol(out), 8L)
 })
+
+# The refusal names the offending scales by reading the second column of
+# Norms[[1]], which is labelled `Scale` on 8 shipped instruments and `Abbrev`
+# on 7. cais -- the only shipped violator -- is `Scale`-labelled, so the
+# shipped roster cannot exhibit the `Abbrev` case at all: a constructed
+# violator is the only way to fence it.
+
+test_that("the refusal names the offending scales on an Abbrev-labelled instrument", {
+  data("jz2017")
+  obj <- shipped_instrument("iitc")
+  expect_true("Abbrev" %in% names(obj$Norms[[1]]))
+  values <- obj$Norms[[1]]
+  hi <- max(obj$Anchors$Value)
+  # Push exactly one octant out of range, and remember which.
+  offender <- as.character(values$Abbrev[[3]])
+  values$M[[3]] <- hi + 1
+  obj$Norms[[1]] <- values
+  msg <- tryCatch(
+    norm_standardize(
+      jz2017, scales = 2:9, angles = obj$Scales$Angle, instrument = obj,
+      sample = 1
+    ),
+    error = conditionMessage
+  )
+  expect_match(msg, "response range")
+  expect_match(msg, offender, fixed = TRUE)
+  # Verified against the pre-fix expression: `key$Scale` is NULL on an
+  # Abbrev-labelled instrument, so the offending-scale list came out empty --
+  # the refusal named no scale at all rather than naming a wrong one. This
+  # pins that shape, so the assertion above cannot pass on a message that
+  # merely happens to contain the abbreviation somewhere else.
+  expect_false(grepl("mean score for  falls", msg, fixed = TRUE))
+})

--- a/tests/testthat/test-norms-disclosure.R
+++ b/tests/testthat/test-norms-disclosure.R
@@ -1,0 +1,198 @@
+# What norm_standardize() tells the user about the sample it standardized
+# against.
+#
+# The reference *choice* moves scores 0.44 SD on average and 0.78 at the
+# extreme (M74's measurement), which is far larger than the sampling error of
+# any one sample's moments. So the sample used is a result-determining input,
+# and a call that names it only in an argument the caller may have defaulted
+# leaves no record of which distribution the z-scores are relative to. These
+# tests fence the disclosure: a message at the call site, and an attribute on
+# the returned frame for scripts that never see the console.
+
+# The probe is deliberately shaped from the instrument itself rather than
+# hand-written, so the sweeps below cover every shipped instrument whatever its
+# scale count or naming.
+disclosure_probe <- function(obj) {
+  probe <- as.data.frame(matrix(2, nrow = 2, ncol = nrow(obj$Scales)))
+  names(probe) <- obj$Scales$Abbrev
+  probe
+}
+
+# Samples whose means leave the instrument's response range are refused before
+# any message is emitted (D-040), so the disclosure sweeps skip them rather
+# than hand-listing the one shipped violation.
+disclosure_usable <- function(obj, s) {
+  key <- obj$Norms[[1]]
+  m <- key$M[key$Sample == s]
+  all(
+    m >= min(obj$Anchors$Value) & m <= max(obj$Anchors$Value),
+    na.rm = TRUE
+  )
+}
+
+standardize_probe <- function(obj, s, ...) {
+  probe <- disclosure_probe(obj)
+  norm_standardize(
+    probe,
+    scales = names(probe), angles = obj$Scales$Angle,
+    instrument = obj, sample = s, append = FALSE, ...
+  )
+}
+
+# AC1 -------------------------------------------------------------------
+
+test_that("the two message forms partition the shipped instruments", {
+  # The forms are asserted below over their own memberships; if the two did not
+  # exhaust the roster, an instrument could exhibit neither and go unswept.
+  multi <- single <- character(0)
+  for (nm in shipped_instruments()) {
+    obj <- shipped_instrument(nm)
+    if (nrow(obj$Norms[[2]]) > 1) multi <- c(multi, nm) else single <- c(single, nm)
+  }
+  expect_setequal(c(multi, single), shipped_instruments())
+  expect_identical(intersect(multi, single), character(0))
+  expect_gt(length(multi), 0)
+  expect_gt(length(single), 0)
+})
+
+test_that("a single-sample instrument's message names the sample, size and description", {
+  for (nm in shipped_instruments()) {
+    obj <- shipped_instrument(nm)
+    if (nrow(obj$Norms[[2]]) > 1) next
+    row <- obj$Norms[[2]]
+    msg <- capture_messages(standardize_probe(obj, row$Sample[[1]]))
+    expect_length(msg, 1)
+    expect_match(msg[[1]], paste0("sample ", row$Sample[[1]]), fixed = TRUE)
+    expect_match(msg[[1]], paste0("N = ", row$Size[[1]]), fixed = TRUE)
+    expect_match(msg[[1]], obj$Details$Abbrev, fixed = TRUE)
+    # A one-sample instrument has no alternatives, so it must not offer any.
+    expect_false(grepl("other sample", msg[[1]], fixed = TRUE))
+  }
+})
+
+test_that("a multi-sample instrument's message says how many other samples exist", {
+  for (nm in shipped_instruments()) {
+    obj <- shipped_instrument(nm)
+    n <- nrow(obj$Norms[[2]])
+    if (n < 2) next
+    for (s in obj$Norms[[2]]$Sample) {
+      if (!disclosure_usable(obj, s)) next
+      msg <- capture_messages(standardize_probe(obj, s))
+      expect_length(msg, 1)
+      expect_match(msg[[1]], paste0("sample ", s), fixed = TRUE)
+      expect_match(
+        msg[[1]], paste0(n - 1, " other sample"),
+        fixed = TRUE,
+        info = paste(nm, "sample", s)
+      )
+      expect_match(msg[[1]], "norms()", fixed = TRUE)
+    }
+  }
+})
+
+test_that("quiet = TRUE emits nothing", {
+  for (nm in shipped_instruments()) {
+    obj <- shipped_instrument(nm)
+    for (s in obj$Norms[[2]]$Sample) {
+      if (!disclosure_usable(obj, s)) next
+      expect_silent(standardize_probe(obj, s, quiet = TRUE))
+    }
+  }
+})
+
+test_that("the message reads Size and description by Sample, not by row position", {
+  # No shipped instrument stores its Norms[[2]] rows out of Sample order, so a
+  # positional read passes the whole roster. This fixture is the only thing
+  # that separates the two.
+  obj <- shipped_instrument("iipsc")
+  obj$Norms[[2]] <- obj$Norms[[2]][c(2, 1), ]
+  msg <- capture_messages(standardize_probe(obj, 1))
+  expect_match(msg[[1]], "N = 872", fixed = TRUE)
+  expect_match(msg[[1]], "American college students", fixed = TRUE)
+  expect_false(grepl("N = 106", msg[[1]], fixed = TRUE))
+})
+
+# AC8 (RR16 BC2) --------------------------------------------------------
+
+test_that("every shipped sample's message carries its Population value verbatim", {
+  # Quantified over all 24 (instrument, sample) pairs rather than over the 15
+  # instruments: the value varies per sample, and `sample` defaults to 1, so an
+  # instrument-level sweep would never emit a message for 9 of the 24.
+  seen <- 0L
+  for (nm in shipped_instruments()) {
+    obj <- shipped_instrument(nm)
+    for (s in obj$Norms[[2]]$Sample) {
+      if (!disclosure_usable(obj, s)) next
+      pop <- obj$Norms[[2]]$Population[obj$Norms[[2]]$Sample == s]
+      msg <- capture_messages(standardize_probe(obj, s))
+      expect_match(msg[[1]], pop, fixed = TRUE, info = paste(nm, "sample", s))
+      seen <- seen + 1L
+    }
+  }
+  # 24 shipped samples less the one refused for leaving its anchor range.
+  expect_identical(seen, 23L)
+})
+
+test_that("the message's fixed text frames the sample as a description, not a population", {
+  # The stored value is data and may say anything; what this pins is the
+  # package's own words around it. A sentinel Population carrying both banned
+  # tokens is the only way to tell the fixed text from the data: strip the
+  # value out of the emitted message, and what remains is the fixed text.
+  sentinel <- "a representative population of nobody"
+  obj <- shipped_instrument("iipsc")
+  obj$Norms[[2]]$Population[obj$Norms[[2]]$Sample == 1] <- sentinel
+  msg <- capture_messages(standardize_probe(obj, 1))
+  expect_match(msg[[1]], sentinel, fixed = TRUE)
+  fixed_text <- sub(sentinel, "", msg[[1]], fixed = TRUE)
+  expect_false(grepl("population", fixed_text, ignore.case = TRUE))
+  expect_false(grepl("representative", fixed_text, ignore.case = TRUE))
+})
+
+# AC2 -------------------------------------------------------------------
+
+test_that("both return paths carry the norm_sample attribute", {
+  for (nm in shipped_instruments()) {
+    obj <- shipped_instrument(nm)
+    for (s in obj$Norms[[2]]$Sample) {
+      if (!disclosure_usable(obj, s)) next
+      row <- obj$Norms[[2]][obj$Norms[[2]]$Sample == s, ]
+      for (app in c(TRUE, FALSE)) {
+        probe <- disclosure_probe(obj)
+        out <- norm_standardize(
+          probe,
+          scales = names(probe), angles = obj$Scales$Angle,
+          instrument = obj, sample = s, append = app, quiet = TRUE
+        )
+        got <- attr(out, "norm_sample")
+        expect_type(got, "list")
+        expect_identical(got$Instrument, obj$Details$Abbrev,
+                         info = paste(nm, "sample", s, "append", app))
+        expect_identical(got$Sample, s)
+        expect_identical(got$Size, row$Size[[1]])
+        expect_identical(got$Population, row$Population[[1]])
+      }
+    }
+  }
+})
+
+test_that("the attribute is present whether or not the message was emitted", {
+  obj <- shipped_instrument("iipsc")
+  loud <- suppressMessages(standardize_probe(obj, 1))
+  hushed <- standardize_probe(obj, 1, quiet = TRUE)
+  expect_identical(attr(loud, "norm_sample"), attr(hushed, "norm_sample"))
+})
+
+# AC9 (RR16 BC1) --------------------------------------------------------
+
+test_that("the norm-standardizing surfaces keep the names the review settled on", {
+  # RR16/D-041 decided against renaming these. The decision is only as durable
+  # as something that fails when it is undone, so this pin is that something.
+  exports <- getNamespaceExports("circumplex")
+  expect_true("norm_standardize" %in% exports)
+  expect_true("norms" %in% exports)
+  for (nm in shipped_instruments()) {
+    obj <- shipped_instrument(nm)
+    expect_true("Norms" %in% names(obj), info = nm)
+    expect_true("Population" %in% names(obj$Norms[[2]]), info = nm)
+  }
+})

--- a/tests/testthat/test-norms-disclosure.R
+++ b/tests/testthat/test-norms-disclosure.R
@@ -196,3 +196,39 @@ test_that("the norm-standardizing surfaces keep the names the review settled on"
     expect_true("Population" %in% names(obj$Norms[[2]]), info = nm)
   }
 })
+
+# AC4 -------------------------------------------------------------------
+
+test_that("a sample the instrument does not carry is refused by name", {
+  obj <- shipped_instrument("iipsc")
+  probe <- disclosure_probe(obj)
+  msg <- tryCatch(
+    norm_standardize(
+      probe, scales = names(probe), angles = obj$Scales$Angle,
+      instrument = obj, sample = 7
+    ),
+    error = conditionMessage
+  )
+  expect_match(msg, "sample", ignore.case = TRUE)
+  expect_match(msg, "7", fixed = TRUE)
+  # The numbers the instrument does carry, so the user can act on the message
+  # rather than go looking. Asserted as the numbers, not as the word "sample":
+  # before this check existed the call died in the scales-vs-norms arity
+  # stopifnot(), whose message names neither.
+  for (s in obj$Norms[[2]]$Sample) {
+    expect_match(msg, as.character(s), fixed = TRUE)
+  }
+})
+
+test_that("the scales-vs-norms arity check is retained and still fires", {
+  # Distinct from the unmatched-sample refusal above: here the sample exists
+  # and it is `scales` that disagrees with it.
+  obj <- shipped_instrument("iipsc")
+  probe <- disclosure_probe(obj)
+  expect_error(
+    norm_standardize(
+      probe, scales = names(probe)[1:5], angles = obj$Scales$Angle[1:5],
+      instrument = obj, sample = 1
+    )
+  )
+})

--- a/tests/testthat/test-norms-disclosure.R
+++ b/tests/testthat/test-norms-disclosure.R
@@ -53,6 +53,10 @@ test_that("the two message forms partition the shipped instruments", {
   expect_identical(intersect(multi, single), character(0))
   expect_gt(length(multi), 0)
   expect_gt(length(single), 0)
+  # AC1 asks the two memberships partition all 15. The two assertions above
+  # are true by construction of the loop, so the roster size is what actually
+  # carries the claim -- without it the "partition" holds over any roster.
+  expect_identical(length(multi) + length(single), 15L)
 })
 
 test_that("a single-sample instrument's message names the sample, size and description", {
@@ -80,12 +84,27 @@ test_that("a multi-sample instrument's message says how many other samples exist
       msg <- capture_messages(standardize_probe(obj, s))
       expect_length(msg, 1)
       expect_match(msg[[1]], paste0("sample ", s), fixed = TRUE)
-      expect_match(
-        msg[[1]], paste0(n - 1, " other sample"),
-        fixed = TRUE,
-        info = paste(nm, "sample", s)
-      )
-      expect_match(msg[[1]], "norms()", fixed = TRUE)
+      # Derived independently of the implementation, which counts rows of
+      # Norms[[2]]. What the sentence offers the reader is an alternative they
+      # can actually use, so the expected count is the number of OTHER samples
+      # that would not be refused -- computed here from the anchor-range
+      # predicate, not from nrow().
+      usable_others <- sum(vapply(
+        setdiff(obj$Norms[[2]]$Sample, s),
+        function(o) disclosure_usable(obj, o),
+        logical(1)
+      ))
+      if (usable_others > 0) {
+        expect_match(
+          msg[[1]], paste0(usable_others, " other sample"),
+          fixed = TRUE,
+          info = paste(nm, "sample", s)
+        )
+        expect_match(msg[[1]], "norms()", fixed = TRUE)
+      } else {
+        expect_false(grepl("other sample", msg[[1]], fixed = TRUE),
+                     info = paste(nm, "sample", s))
+      }
     }
   }
 })
@@ -179,6 +198,10 @@ test_that("the attribute is present whether or not the message was emitted", {
   obj <- shipped_instrument("iipsc")
   loud <- suppressMessages(standardize_probe(obj, 1))
   hushed <- standardize_probe(obj, 1, quiet = TRUE)
+  # Assert presence on each path before comparing them: an identity check
+  # alone passes when BOTH attributes are absent, so it fenced nothing.
+  expect_type(attr(loud, "norm_sample"), "list")
+  expect_type(attr(hushed, "norm_sample"), "list")
   expect_identical(attr(loud, "norm_sample"), attr(hushed, "norm_sample"))
 })
 
@@ -231,4 +254,45 @@ test_that("the scales-vs-norms arity check is retained and still fires", {
       instrument = obj, sample = 1
     )
   )
+})
+
+test_that("an NA sample is refused by the same check, not by a later one", {
+  # NA matches no Norms[[1]] row, so AC4's refusal owns this case. It did not:
+  # `key$Sample == NA` is NA rather than FALSE, and `key[NA, ]` returns
+  # NA-filled rows instead of zero rows, so the nrow() == 0 guard was false and
+  # the call fell through -- into the arity stopifnot() on a multi-sample
+  # instrument, and into the angle loop on a single-sample one.
+  for (nm in c("iipsc", "isc")) {
+    obj <- shipped_instrument(nm)
+    probe <- disclosure_probe(obj)
+    msg <- tryCatch(
+      norm_standardize(
+        probe, scales = names(probe), angles = obj$Scales$Angle,
+        instrument = obj, sample = NA_real_
+      ),
+      error = conditionMessage
+    )
+    # Asserts WHICH failure, not that some failure occurred: the two failures
+    # it used to produce name "length(scales)" and "degrees" respectively.
+    expect_match(msg, "No normative data for sample", fixed = TRUE, info = nm)
+    expect_false(grepl("length(scales)", msg, fixed = TRUE), info = nm)
+    expect_false(grepl("degrees", msg, fixed = TRUE), info = nm)
+  }
+})
+
+test_that("the other-samples clause counts only samples that can be used", {
+  # cais carries two samples but sample 2 is refused for leaving its anchor
+  # range (D-040), so there is no other sample a reader of sample 1's message
+  # could act on. Advertising it points at a call that errors.
+  obj <- shipped_instrument("cais")
+  expect_identical(nrow(obj$Norms[[2]]), 2L)
+  expect_false(disclosure_usable(obj, 2))
+  msg <- capture_messages(standardize_probe(obj, 1))
+  expect_false(grepl("other sample", msg[[1]], fixed = TRUE))
+
+  # And the converse: iipsc's second sample IS usable, so it is still offered.
+  ok <- shipped_instrument("iipsc")
+  expect_true(disclosure_usable(ok, 2))
+  msg2 <- capture_messages(standardize_probe(ok, 1))
+  expect_match(msg2[[1]], "1 other sample is available", fixed = TRUE)
 })

--- a/tests/testthat/test-tidying_functions.R
+++ b/tests/testthat/test-tidying_functions.R
@@ -37,17 +37,19 @@ test_that("norm_standardize works", {
     matrix(runif(8 * 5, min = 0, max = 4), nrow = 5, ncol = 8)
   )
   new <- norm_standardize(
-    old, 
-    scales = 1:8, 
-    instrument = iipsc, 
-    sample = 1
-  )
-  new2 <- norm_standardize(
-    old, 
+    old,
     scales = 1:8,
     instrument = iipsc,
     sample = 1,
-    append = FALSE
+    quiet = TRUE
+  )
+  new2 <- norm_standardize(
+    old,
+    scales = 1:8,
+    instrument = iipsc,
+    sample = 1,
+    append = FALSE,
+    quiet = TRUE
   )
   expect_equal(round(new$X1_z, 4), c(3.2176, 4.1562, 3.4605, 4.2189, 1.6150))
   expect_equal(round(new$X2_z, 4), c(-0.1841, 0.7361, 1.8035, 3.07, 4.5891))
@@ -190,7 +192,7 @@ test_that("norm_standardize runs on every shipped instrument and sample", {
       standardize_it <- function() {
         norm_standardize(probe, scales = names(probe),
                          angles = obj$Scales$Angle, instrument = obj,
-                         sample = s, append = FALSE)
+                         sample = s, append = FALSE, quiet = TRUE)
       }
       if (in_range) {
         expect_no_error(standardize_it())
@@ -208,7 +210,7 @@ test_that("norm_standardize runs on every shipped instrument and sample", {
   names(probe) <- iei$Scales$Abbrev
   z1 <- norm_standardize(probe, scales = names(probe),
                          angles = iei$Scales$Angle, instrument = iei,
-                         sample = 1, append = FALSE)
+                         sample = 1, append = FALSE, quiet = TRUE)
   expect_equal(z1$PA_z[[1]], 0)
   expect_equal(z1$BC_z[[1]], (2 - 1.21) / 0.61)
 })

--- a/tests/testthat/test-tidying_functions.R
+++ b/tests/testthat/test-tidying_functions.R
@@ -73,11 +73,11 @@ test_that("norm_standardize matches 0 and 360 degrees as the same angle", {
   # LM stored as 360 in the norms; passing 0 must give identical results
   with360 <- norm_standardize(
     old, scales = 1:8, angles = octants(), instrument = iipsc, sample = 1,
-    append = FALSE
+    append = FALSE, quiet = TRUE
   )
   with0 <- norm_standardize(
     old, scales = 1:8, angles = c(90, 135, 180, 225, 270, 315, 0, 45),
-    instrument = iipsc, sample = 1, append = FALSE
+    instrument = iipsc, sample = 1, append = FALSE, quiet = TRUE
   )
   expect_equal(with0, with360)
 })


### PR DESCRIPTION
`norm_standardize()` now says which normative sample it standardized against.

- A `quiet` argument (default `FALSE`); every non-quiet successful call names the sample, its size and its description, and says how many other samples the instrument carries.
- Every returned frame carries a `"norm_sample"` attribute with the same facts, on both `append` paths, whether or not the message was emitted.
- The out-of-anchor-range refusal now names the offending scales on instruments whose norms label that column `Abbrev` (previously it named none).
- A `sample` the instrument does not carry gets its own error naming the argument and listing the valid sample numbers, instead of falling through to the scales-vs-norms arity check.
- Per RR16/D-041, the message frames the stored label as a plain description: its fixed text carries neither "population" nor "representative".

`devtools::test()`: 0 failures, 6537 passing. `devtools::check()`: 0 errors, 0 warnings, 0 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)