### PR TITLE
Fence the norms-audit walk helpers M87 kept (M88)

### DIFF
--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -14,7 +14,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M85 | Carry the sample through the audit's note-only coverage rows | done | — | low | milestones/archive/M85-norms-audit-note-only-sample.md |
 | M86 | Name every roster shape the norms-audit builder cannot honestly audit | done | — | normal | milestones/archive/M86-norms-audit-roster-refusals.md |
 | M87 | Retire the norms-audit abort apparatus for a manifest check | done | — | normal | milestones/archive/M87-norms-audit-apparatus-retirement.md |
-| M88 | Fence the norms-audit walk helpers M87 kept | in-progress | — | normal | milestones/M88-norms-audit-walk-helper-tests.md |
+| M88 | Fence the norms-audit walk helpers M87 kept | review | — | normal | milestones/M88-norms-audit-walk-helper-tests.md |
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |
 
 ## Candidates

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -14,7 +14,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M85 | Carry the sample through the audit's note-only coverage rows | done | — | low | milestones/archive/M85-norms-audit-note-only-sample.md |
 | M86 | Name every roster shape the norms-audit builder cannot honestly audit | done | — | normal | milestones/archive/M86-norms-audit-roster-refusals.md |
 | M87 | Retire the norms-audit abort apparatus for a manifest check | done | — | normal | milestones/archive/M87-norms-audit-apparatus-retirement.md |
-| M88 | Fence the norms-audit walk helpers M87 kept | planned | — | normal | milestones/M88-norms-audit-walk-helper-tests.md |
+| M88 | Fence the norms-audit walk helpers M87 kept | in-progress | — | normal | milestones/M88-norms-audit-walk-helper-tests.md |
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |
 
 ## Candidates

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -14,7 +14,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M85 | Carry the sample through the audit's note-only coverage rows | done | — | low | milestones/archive/M85-norms-audit-note-only-sample.md |
 | M86 | Name every roster shape the norms-audit builder cannot honestly audit | done | — | normal | milestones/archive/M86-norms-audit-roster-refusals.md |
 | M87 | Retire the norms-audit abort apparatus for a manifest check | done | — | normal | milestones/archive/M87-norms-audit-apparatus-retirement.md |
-| M88 | Fence the norms-audit walk helpers M87 kept | review | — | normal | milestones/M88-norms-audit-walk-helper-tests.md |
+| M88 | Fence the norms-audit walk helpers M87 kept | in-progress | — | normal | milestones/M88-norms-audit-walk-helper-tests.md |
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |
 
 ## Candidates

--- a/cairn/milestones/M88-norms-audit-walk-helper-tests.md
+++ b/cairn/milestones/M88-norms-audit-walk-helper-tests.md
@@ -60,9 +60,16 @@ their existing candidate rows.
       Each is paired with a negative that must not raise — a positional
       condition, a named condition, a `stop()` with no names, and one carrying
       only `call.`/`domain`.
-- [ ] AC4 `ordinal` is absent from the walk, the generated manifest and the
-      manifest identity, which becomes (kind, binding, key):
-      `git grep -n ordinal -- tests tools` returns no line.
+- [ ] AC4 The abort-site identity is (kind, binding, key). A test asserts the
+      field set directly rather than by spelling: `names(NORMS_AUDIT_MANIFEST)`
+      is exactly `c("kind", "binding", "key")`, and every element of
+      `norms_audit_abort_sites()` has `names()` equal as a set to
+      `c("kind", "key", "binding")`, so a fourth field on either side reddens
+      the suite under any spelling; `manifest_ids()` and `walked_ids()` each
+      paste exactly those three. As a spot check on the three spellings the
+      retired mechanism used,
+      `git grep -nE '(\$|\.)ordinal|ordinal *=|assign_ordinals' -- tests tools`
+      returns no line — prose explaining the removal may name `ordinal`.
 - [ ] AC5 A test asserts the walked identities and the manifest identities are
       each duplicate-free, so two guards identical in (kind, binding, key) redden
       the suite rather than collapsing onto one row — the separability the
@@ -95,7 +102,7 @@ their existing candidate rows.
       (`helper-norms-audit-manifest.R:176-197`).
 - [x] T4 Add the AC3 refusal assertions with their negatives
       (`helper-norms-audit-script.R:103`, `:117-120`, `:130-144`, `:162-183`).
-- [ ] T5 Delete `norms_audit_assign_ordinals()` and its call
+- [x] T5 Delete `norms_audit_assign_ordinals()` and its call
       (`helper-norms-audit-script.R:203-219`, `:247`), drop the `ordinal` column
       from `helper-norms-audit-manifest.R`, narrow the identity in
       `test-norms-audit-manifest.R:28-37`, and add the AC5 duplicate-refusal on
@@ -112,6 +119,8 @@ their existing candidate rows.
 - 2026-08-15: T1 in progress — branch cut from a synced master, status in-progress; the baseline `devtools::test()` is still running, so no task is checked off yet. The T2-T4 test file is drafted outside the repo and dry-runs clean (46 assertions, testthat 3.3.2); an in-memory reintroduction of the M83 marker regression reddens 5 of them, naming both shapes AC1 exists for, so the partition is not vacuous. Nothing is committed to `tests/` yet.
 - 2026-08-15: T1 done — baseline `devtools::test()` clean at FAIL 0 / WARN 6 / SKIP 3 / PASS 7051 on master's tree.
 - 2026-08-15: T2-T4 done in one commit, the three criteria being three sections of one new file (`tests/testthat/test-norms-audit-walk.R`, 177 lines, 46 assertions). All eight norms-audit test files pass. The file does not skip against the installed package as its siblings do: the helpers under test are pure and read no `data-raw/` path.
+- 2026-08-15: T5 done — ordinal removed from the walk (`helper-norms-audit-script.R`), the manifest's columns and both identity builders; the duplicate refusal added on both sides of the set comparison, plus the AC4 field-set assertion. All eight norms-audit files pass; the manifest file goes 9 → 44 assertions.
+- 2026-08-15: AC4 amended at a mini gate — the original wording promised "no code carries it" but checked three spellings of the word. A fresh-context [O] reader wrote nine reintroduction shapes to a scratch file and grepped them: nine escaped, including `[["ordinal"]]` (the field-access style this codebase already uses) and a renamed fourth field, so the procedure was a proxy for its own universal. Replaced by a direct assertion on the field set of both sides, which every escaping shape must violate to have any effect; the grep is retained and relabelled a spot check. Also fixed at the same gate: the original grep matched four comment lines explaining the removal, so satisfying it literally meant deleting the explanation D-043 asks the helpers to carry.
 - 2026-08-15: plan gate weighed D-042's bar on reopening this area and read this scope as distinct — no registry, matcher, matrix or denylist returns, no sweep is added, and the manifest check's promise is byte-unchanged; falsified by any criterion here widening what the manifest check promises.
 
 ## Decisions

--- a/cairn/milestones/M88-norms-audit-walk-helper-tests.md
+++ b/cairn/milestones/M88-norms-audit-walk-helper-tests.md
@@ -191,6 +191,29 @@ IP4 forbids editing it in place · F24 (12) and F16 (5) both disproven — the
 per-AC counts reproduce exactly, and the twin-refusal verification found the
 ordinal deletion sound.
 
+### Re-review after return 1 (2026-08-15)
+
+- **AC3 re-verified and re-ticked.** The naming assertions now match phrases
+  only the refusal's own `what` clause composes. Evidence is the mutation the
+  old assertions survived: gutting the `stopifnot` naming clause reddens 3, and
+  the `stop()` one reddens 2. Test passes 11/11.
+- **AC6 evidenced.** Nine valid mutants, nine killed, none survived — AC1's
+  truncation regression 5 · AC2 unknown-kind 1 · AC2 named-match 2 · AC3
+  reserved-set 2 · AC3 kind-collapse 1 · AC3 stop-refusal 1 · AC4/AC5
+  fourth-field 33 · F1-A naming 3 · F1-B naming 2. Every mutant restored by
+  copy from HEAD's blob, each restore confirmed by `git hash-object` against
+  `git rev-parse HEAD:<path>` (`50fedd235c`, `b24345448a`) with a clean tree
+  between runs.
+- **One mutant retracted as invalid, not counted.** Changing the walk key's
+  `collapse` from one space to two produces a byte-identical key, because
+  `squish()` collapses whitespace runs (measured). A mutation perturbing a
+  quantity the code is provably invariant to cannot redden, and reading that
+  null as missing coverage is the error M60 names.
+- **F2's fix is proven by construction, not by mutation.** The test and the
+  walk now share one derivation and cannot diverge; a mutation of that
+  derivation correctly moves both sides together, so no kill is claimable and
+  none is claimed.
+
 ### Gate outcome: returned to `in-progress` (defect return 1)
 
 F1 demonstrates AC3 failing inside the domain of the procedure it names, which

--- a/cairn/milestones/M88-norms-audit-walk-helper-tests.md
+++ b/cairn/milestones/M88-norms-audit-walk-helper-tests.md
@@ -1,6 +1,6 @@
 # M88: Fence the norms-audit walk helpers M87 kept
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
@@ -127,6 +127,7 @@ their existing candidate rows.
 - 2026-08-15: mutant 4 is the evidence for the criteria audit's vacuity finding: emptying `STOPIFNOT_RESERVED` drops the file from 46 assertions to 37 because the loop runs zero times, so without the two anchor assertions the test would pass green over its own mutation.
 - 2026-08-15: mutant 7 is the evidence AC4's field-set assertion carries the claim its grep cannot: `out[[i]][["seq_within_group"]] <- 1L` reintroduces a per-site field, is not matched by `git grep -nE '(\$|\.)ordinal|ordinal *=|assign_ordinals'` (verified against the line itself), and reddens 33 assertions — one per walked site.
 - 2026-08-15: CHECKPOINT — T6's mutation half is complete and recorded above; the confirming full `devtools::test()` was still running when this was committed, so AC7 is not yet evidenced and the milestone stays `in-progress`. The filtered `norms-audit` run was clean at the same tree.
+- 2026-08-15: AC7 evidenced, superseding the checkpoint line above — full `devtools::test()` clean at FAIL 0 / WARN 6 / SKIP 3 / PASS 7132, warnings and skips unchanged from the T1 baseline's 7051 passes. The +81 is the new walk file's 46 assertions plus the manifest file's 9 → 44. Tree clean; status in-progress → review.
 - 2026-08-15: plan gate weighed D-042's bar on reopening this area and read this scope as distinct — no registry, matcher, matrix or denylist returns, no sweep is added, and the manifest check's promise is byte-unchanged; falsified by any criterion here widening what the manifest check promises.
 
 ## Decisions

--- a/cairn/milestones/M88-norms-audit-walk-helper-tests.md
+++ b/cairn/milestones/M88-norms-audit-walk-helper-tests.md
@@ -1,6 +1,6 @@
 # M88: Fence the norms-audit walk helpers M87 kept
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
@@ -51,7 +51,7 @@ their existing candidate rows.
       for a kind outside `stop`/`stopifnot`/`stopifnot_named`; and asserts the
       `stopifnot_named` branch in both directions — a message equal to the key
       accepted, a message carrying the key as a strict superstring rejected.
-- [ ] AC3 A test asserts each `refuse_unenumerable()` site raises and names its
+- [x] AC3 A test asserts each `refuse_unenumerable()` site raises and names its
       cause: `norms_audit_stopifnot_conditions()` for a condition passed under any
       element of `STOPIFNOT_RESERVED`, iterated as the running R defines it and
       anchored non-vacuous by pinning `"exprs"` as a literal member; and
@@ -128,6 +128,8 @@ their existing candidate rows.
 - 2026-08-15: mutant 7 is the evidence AC4's field-set assertion carries the claim its grep cannot: `out[[i]][["seq_within_group"]] <- 1L` reintroduces a per-site field, is not matched by `git grep -nE '(\$|\.)ordinal|ordinal *=|assign_ordinals'` (verified against the line itself), and reddens 33 assertions — one per walked site.
 - 2026-08-15: CHECKPOINT — T6's mutation half is complete and recorded above; the confirming full `devtools::test()` was still running when this was committed, so AC7 is not yet evidenced and the milestone stays `in-progress`. The filtered `norms-audit` run was clean at the same tree.
 - 2026-08-15: AC7 evidenced, superseding the checkpoint line above — full `devtools::test()` clean at FAIL 0 / WARN 6 / SKIP 3 / PASS 7132, warnings and skips unchanged from the T1 baseline's 7051 passes. The +81 is the new walk file's 46 assertions plus the manifest file's 9 → 44. Tree clean; status in-progress → review.
+- 2026-08-15: return 1 fixed. F1 — the AC3 naming assertions now match `formal <nm>` and `argument named tail`, phrases only the refusal's own `what` clause composes, instead of a bare name the echoed deparsed call already carries. Proven by the mutation the old assertions survived: gutting the stopifnot naming clause now reddens 3, gutting the stop() one reddens 2. F2 — the AC1 key now comes from `norms_audit_stopifnot_conditions()` rather than a retyped copy, so test and walk cannot diverge; proven by construction, not mutation, since a derivation change correctly moves both sides together. B5 — the M60 citation corrected to M43. Walk file green at 46.
+- 2026-08-15: a tenth mutant (walk key `collapse = " "` -> `"  "`) SURVIVED and is retracted as invalid, not recorded as a coverage hole: `squish()` collapses whitespace runs, so the two produce byte-identical keys (measured). M60's lesson exactly — a mutation perturbing a quantity the code is provably invariant to cannot redden, and reading that null as missing coverage is the error.
 - 2026-08-15: REVIEW RETURN 1 — AC3 fails. F1 (85), verified independently: `refuse_unenumerable()` echoes the deparsed call, so `expect_match(msg, nm, fixed = TRUE)` passes even with the naming logic gutted; the single-name half of AC3's "names its cause" promise is unasserted. Riding the return: F2 (80), AC1's `long_key` retypes the shipped derivation instead of calling it, and B5, a misattributed M60 citation that should be M43 (verified against LESSONS). 28 findings below the bar logged in Review. Status review → in-progress.
 - 2026-08-15: review in progress — PR #116 opened as draft; AC1-AC5 evidenced fresh and ticked, consistency gate clean (`cairn_validate` exit 0; the profile's toolchain checks are no-ops by file list, the branch touching only `tests/` and `cairn/`). AC6/AC7 deferred until the fresh-context reviewers finish, since a mutation pass would churn the tree they read.
 - 2026-08-15: plan gate weighed D-042's bar on reopening this area and read this scope as distinct — no registry, matcher, matrix or denylist returns, no sweep is added, and the manifest check's promise is byte-unchanged; falsified by any criterion here widening what the manifest check promises.

--- a/cairn/milestones/M88-norms-audit-walk-helper-tests.md
+++ b/cairn/milestones/M88-norms-audit-walk-helper-tests.md
@@ -1,11 +1,11 @@
 # M88: Fence the norms-audit walk helpers M87 kept
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** GP2
-- **Branch/PR:** —
+- **Branch/PR:** `m88-norms-audit-walk-helper-tests`
 
 ## Goal
 
@@ -109,6 +109,7 @@ their existing candidate rows.
 - 2026-08-15: criteria audit ran — a fresh-context [O] reader returned five findings, four fixed at the gate (AC1 unsatisfiable: a truncated stem can never prefix a 20-char key, so the accepted probe is keyed on the full condition text; AC3 vacuous under `STOPIFNOT_RESERVED <- character(0)`, anchored by pinning `"exprs"`; AC5-as-drafted locked one axis of three, superseded by the ordinal deletion; AC6 disproportionate for an internal tier, narrowed to one summary line plus restore hashes) and one widened (AC4-as-drafted, one exemplar for a family free in two axes).
 - 2026-08-15: plan gate chose deleting the ordinal over testing it because all 33 shipped sites are ordinal 1 and no duplicated (kind, binding, key) triple exists (measured 2026-08-15), so the field fences nothing today; falsified by a second guard identical in kind, binding and key appearing in the audit script, which AC5's duplicate-refusal reddens rather than silently absorbing.
 - 2026-08-15: plan gate chose test-only-plus-repairs over tests-only because the audit found untested branches rather than defects, and a defect surfaced while writing a test is cheaper to fix in place than to route; falsified by a repair large enough to need its own design decision, which returns to plan.
+- 2026-08-15: T1 in progress — branch cut from a synced master, status in-progress; the baseline `devtools::test()` is still running, so no task is checked off yet. The T2-T4 test file is drafted outside the repo and dry-runs clean (46 assertions, testthat 3.3.2); an in-memory reintroduction of the M83 marker regression reddens 5 of them, naming both shapes AC1 exists for, so the partition is not vacuous. Nothing is committed to `tests/` yet.
 - 2026-08-15: plan gate weighed D-042's bar on reopening this area and read this scope as distinct — no registry, matcher, matrix or denylist returns, no sweep is added, and the manifest check's promise is byte-unchanged; falsified by any criterion here widening what the manifest check promises.
 
 ## Decisions

--- a/cairn/milestones/M88-norms-audit-walk-helper-tests.md
+++ b/cairn/milestones/M88-norms-audit-walk-helper-tests.md
@@ -74,11 +74,11 @@ their existing candidate rows.
       each duplicate-free, so two guards identical in (kind, binding, key) redden
       the suite rather than collapsing onto one row — the separability the
       deleted ordinal carried, kept as a refusal.
-- [ ] AC6 Each test this milestone adds reddens under a mutation of a helper line
+- [x] AC6 Each test this milestone adds reddens under a mutation of a helper line
       it locks. The Review section records one summary line — the tests, the
       mutations applied, the assertions that failed — and a `git hash-object`
       comparison showing each mutated helper file restored to its pre-mutation blob.
-- [ ] AC7 `Rscript -e 'devtools::test()'` clean; `git status` empty before any
+- [x] AC7 `Rscript -e 'devtools::test()'` clean; `git status` empty before any
       gate is reported clean.
 
 ## Coverage
@@ -213,6 +213,11 @@ ordinal deletion sound.
   walk now share one derivation and cannot diverge; a mutation of that
   derivation correctly moves both sides together, so no kill is claimable and
   none is claimed.
+
+- **AC7 evidenced.** Full `devtools::test()` clean at FAIL 0 / WARN 6 / SKIP 3 / PASS 7132,
+  warnings and skips unchanged from the T1 baseline's 7051 passes; `git status` empty at the
+  same tree. The count is unchanged from the pre-fix run because the F1 repair changed what
+  two assertions match, not how many there are.
 
 ### Gate outcome: returned to `in-progress` (defect return 1)
 

--- a/cairn/milestones/M88-norms-audit-walk-helper-tests.md
+++ b/cairn/milestones/M88-norms-audit-walk-helper-tests.md
@@ -107,7 +107,7 @@ their existing candidate rows.
       from `helper-norms-audit-manifest.R`, narrow the identity in
       `test-norms-audit-manifest.R:28-37`, and add the AC5 duplicate-refusal on
       both sides.
-- [ ] T6 Run the AC6 mutation pass over the added tests; record the summary line
+- [x] T6 Run the AC6 mutation pass over the added tests; record the summary line
       and restore hashes; re-run `devtools::test()`.
 
 ## Work log
@@ -121,6 +121,12 @@ their existing candidate rows.
 - 2026-08-15: T2-T4 done in one commit, the three criteria being three sections of one new file (`tests/testthat/test-norms-audit-walk.R`, 177 lines, 46 assertions). All eight norms-audit test files pass. The file does not skip against the installed package as its siblings do: the helpers under test are pure and read no `data-raw/` path.
 - 2026-08-15: T5 done — ordinal removed from the walk (`helper-norms-audit-script.R`), the manifest's columns and both identity builders; the duplicate refusal added on both sides of the set comparison, plus the AC4 field-set assertion. All eight norms-audit files pass; the manifest file goes 9 → 44 assertions.
 - 2026-08-15: AC4 amended at a mini gate — the original wording promised "no code carries it" but checked three spellings of the word. A fresh-context [O] reader wrote nine reintroduction shapes to a scratch file and grepped them: nine escaped, including `[["ordinal"]]` (the field-access style this codebase already uses) and a renamed fourth field, so the procedure was a proxy for its own universal. Replaced by a direct assertion on the field set of both sides, which every escaping shape must violate to have any effect; the grep is retained and relabelled a spot check. Also fixed at the same gate: the original grep matched four comment lines explaining the removal, so satisfying it literally meant deleting the explanation D-043 asks the helpers to carry.
+- 2026-08-15: T6 done — 7 mutants, 7 killed, 0 survived, each restored by copy from HEAD's blob and re-hashed before the next ran. AC1 truncation-marker regression → 5 failures; AC2 unknown-kind fall-through → 1; AC2 named-match loosened to containment → 2; AC3 reserved set emptied → 2; AC3 kinds collapsed → 1; AC3 stop() named-arg refusal removed → 1; AC4/AC5 fourth per-site field → 33. Both helpers end at their pre-mutation blobs (`50fedd235c`, `b24345448a`) with a clean tree.
+- 2026-08-15: T6 run one mutant per invocation after an unattended seven-in-one run was interrupted and left mutant 2 on disk — an `atexit` restore does not survive a hard kill (extends M82's harness lesson, whose snapshot-and-restore discipline assumed the process gets to exit). Recovery was possible because each mutant is a one-hunk diff against a committed HEAD, so the restore was verifiable by blob hash; the single-shot form keeps the mutated window inside one call.
+- 2026-08-15: T6's seventh anchor initially matched two sites and the harness refused to apply it rather than mutating the wrong one — the multi-site anchoring trap M87 hit, here failing closed. Re-anchored on the enclosing block.
+- 2026-08-15: mutant 4 is the evidence for the criteria audit's vacuity finding: emptying `STOPIFNOT_RESERVED` drops the file from 46 assertions to 37 because the loop runs zero times, so without the two anchor assertions the test would pass green over its own mutation.
+- 2026-08-15: mutant 7 is the evidence AC4's field-set assertion carries the claim its grep cannot: `out[[i]][["seq_within_group"]] <- 1L` reintroduces a per-site field, is not matched by `git grep -nE '(\$|\.)ordinal|ordinal *=|assign_ordinals'` (verified against the line itself), and reddens 33 assertions — one per walked site.
+- 2026-08-15: CHECKPOINT — T6's mutation half is complete and recorded above; the confirming full `devtools::test()` was still running when this was committed, so AC7 is not yet evidenced and the milestone stays `in-progress`. The filtered `norms-audit` run was clean at the same tree.
 - 2026-08-15: plan gate weighed D-042's bar on reopening this area and read this scope as distinct — no registry, matcher, matrix or denylist returns, no sweep is added, and the manifest check's promise is byte-unchanged; falsified by any criterion here widening what the manifest check promises.
 
 ## Decisions

--- a/cairn/milestones/M88-norms-audit-walk-helper-tests.md
+++ b/cairn/milestones/M88-norms-audit-walk-helper-tests.md
@@ -5,7 +5,7 @@
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** GP2
-- **Branch/PR:** `m88-norms-audit-walk-helper-tests`
+- **Branch/PR:** `m88-norms-audit-walk-helper-tests` / [PR #116](https://github.com/jmgirard/circumplex/pull/116)
 
 ## Goal
 
@@ -38,7 +38,7 @@ their existing candidate rows.
 
 ## Acceptance criteria
 
-- [ ] AC1 A test asserts `audit_key_matches("stopifnot", key, msg)` over an
+- [x] AC1 A test asserts `audit_key_matches("stopifnot", key, msg)` over an
       enumerated vector of message shapes, each declared accepted or rejected and
       asserted in both directions, containing at least: a message R itself raised
       by overflowing a `stopifnot()` condition past one deparsed line, keyed on
@@ -47,11 +47,11 @@ their existing candidate rows.
       message (accepted); a below-floor stem carrying the verdict but no
       truncation marker (rejected). The first shape is captured from a live
       `stopifnot()` at test time, never hand-typed.
-- [ ] AC2 A test asserts `audit_key_matches()` raises, naming the kind it got,
+- [x] AC2 A test asserts `audit_key_matches()` raises, naming the kind it got,
       for a kind outside `stop`/`stopifnot`/`stopifnot_named`; and asserts the
       `stopifnot_named` branch in both directions — a message equal to the key
       accepted, a message carrying the key as a strict superstring rejected.
-- [ ] AC3 A test asserts each `refuse_unenumerable()` site raises and names its
+- [x] AC3 A test asserts each `refuse_unenumerable()` site raises and names its
       cause: `norms_audit_stopifnot_conditions()` for a condition passed under any
       element of `STOPIFNOT_RESERVED`, iterated as the running R defines it and
       anchored non-vacuous by pinning `"exprs"` as a literal member; and
@@ -60,7 +60,7 @@ their existing candidate rows.
       Each is paired with a negative that must not raise — a positional
       condition, a named condition, a `stop()` with no names, and one carrying
       only `call.`/`domain`.
-- [ ] AC4 The abort-site identity is (kind, binding, key). A test asserts the
+- [x] AC4 The abort-site identity is (kind, binding, key). A test asserts the
       field set directly rather than by spelling: `names(NORMS_AUDIT_MANIFEST)`
       is exactly `c("kind", "binding", "key")`, and every element of
       `norms_audit_abort_sites()` has `names()` equal as a set to
@@ -70,7 +70,7 @@ their existing candidate rows.
       retired mechanism used,
       `git grep -nE '(\$|\.)ordinal|ordinal *=|assign_ordinals' -- tests tools`
       returns no line — prose explaining the removal may name `ordinal`.
-- [ ] AC5 A test asserts the walked identities and the manifest identities are
+- [x] AC5 A test asserts the walked identities and the manifest identities are
       each duplicate-free, so two guards identical in (kind, binding, key) redden
       the suite rather than collapsing onto one row — the separability the
       deleted ordinal carried, kept as a refusal.
@@ -93,7 +93,7 @@ their existing candidate rows.
 
 ## Tasks
 
-- [ ] T1 Cut `m88-norms-audit-walk-helper-tests` from the up-to-date default
+- [x] T1 Cut `m88-norms-audit-walk-helper-tests` from the up-to-date default
       branch; confirm a clean `devtools::test()` baseline before any edit.
 - [x] T2 Add `tests/testthat/test-norms-audit-walk.R` with the AC1 partition,
       written as an enumerated accept/reject vector rather than examples
@@ -128,8 +128,49 @@ their existing candidate rows.
 - 2026-08-15: mutant 7 is the evidence AC4's field-set assertion carries the claim its grep cannot: `out[[i]][["seq_within_group"]] <- 1L` reintroduces a per-site field, is not matched by `git grep -nE '(\$|\.)ordinal|ordinal *=|assign_ordinals'` (verified against the line itself), and reddens 33 assertions — one per walked site.
 - 2026-08-15: CHECKPOINT — T6's mutation half is complete and recorded above; the confirming full `devtools::test()` was still running when this was committed, so AC7 is not yet evidenced and the milestone stays `in-progress`. The filtered `norms-audit` run was clean at the same tree.
 - 2026-08-15: AC7 evidenced, superseding the checkpoint line above — full `devtools::test()` clean at FAIL 0 / WARN 6 / SKIP 3 / PASS 7132, warnings and skips unchanged from the T1 baseline's 7051 passes. The +81 is the new walk file's 46 assertions plus the manifest file's 9 → 44. Tree clean; status in-progress → review.
+- 2026-08-15: review in progress — PR #116 opened as draft; AC1-AC5 evidenced fresh and ticked, consistency gate clean (`cairn_validate` exit 0; the profile's toolchain checks are no-ops by file list, the branch touching only `tests/` and `cairn/`). AC6/AC7 deferred until the fresh-context reviewers finish, since a mutation pass would churn the tree they read.
 - 2026-08-15: plan gate weighed D-042's bar on reopening this area and read this scope as distinct — no registry, matcher, matrix or denylist returns, no sweep is added, and the manifest check's promise is byte-unchanged; falsified by any criterion here widening what the manifest check promises.
 
 ## Decisions
 
 ## Review
+
+Reviewed 2026-08-15 against PR #116. Evidence executed fresh at this branch
+tip, never recalled from the implement run.
+
+### Acceptance criteria
+
+- **AC1** — `test-norms-audit-walk.R::the stopifnot stem accepts and rejects as
+  a partition` passes 10/10. The partition is asserted in both directions over
+  five declared shapes, and the live-captured probe is asserted truncated
+  before its accept case is trusted, so it cannot silently degrade into a
+  non-truncated message.
+- **AC2** — two tests, 6/6 and 5/5. The unknown-kind refusal names the kind it
+  received; the `stopifnot_named` branch accepts equality and rejects both a
+  strict superstring and a substring.
+- **AC3** — three tests, 11/11, 5/5 and 9/9. Both `refuse_unenumerable()` sites
+  raise and name their cause; the reserved-formal loop is anchored non-vacuous
+  by pinning `"exprs"`, and the `stop()` refusal asserts the multi-name
+  rendering as well as the single.
+- **AC4** — `names(NORMS_AUDIT_MANIFEST)` is exactly `kind, binding, key`; all
+  33 walked sites carry name-sets equal to `{kind, key, binding}`;
+  `norms_audit_assign_ordinals` no longer exists. The spot-check grep
+  `(\$|\.)ordinal|ordinal *=|assign_ordinals` over `tests tools` exits 1.
+- **AC5** — `anyDuplicated()` asserted 0 on both the walked and the manifest
+  identities (`test-norms-audit-manifest.R:65-66`).
+
+### Consistency gate
+
+- `cairn_validate` exit 0, all 16 checks PASS. The 47 `work-log format` WARNs
+  are M7's pre-existing hard-wrapped history, untouched by this branch.
+- Coverage completeness passes; no `DESIGN.md` principle changed, so
+  `cairn_impact` is skipped by its own condition.
+- Profile `consistency-gate` slot: the branch touches only `tests/` and
+  `cairn/` — no `NAMESPACE`, `man/`, `data/*.rda`, `R/`, `src/`, `DESCRIPTION`,
+  README, vignettes or `_pkgdown.yml` — so the generated-file, README and
+  pkgdown checks are clean no-ops by inspection of the file list. No
+  `.Rbuildignore` entry is owed: the one added file sits under
+  `tests/testthat/`.
+- No NEWS.md entry is owed. The deliverable is internal-tier test machinery
+  over a `.Rbuildignore`d script; nothing a user of the package can observe
+  changes.

--- a/cairn/milestones/M88-norms-audit-walk-helper-tests.md
+++ b/cairn/milestones/M88-norms-audit-walk-helper-tests.md
@@ -88,12 +88,12 @@ their existing candidate rows.
 
 - [ ] T1 Cut `m88-norms-audit-walk-helper-tests` from the up-to-date default
       branch; confirm a clean `devtools::test()` baseline before any edit.
-- [ ] T2 Add `tests/testthat/test-norms-audit-walk.R` with the AC1 partition,
+- [x] T2 Add `tests/testthat/test-norms-audit-walk.R` with the AC1 partition,
       written as an enumerated accept/reject vector rather than examples
       (`helper-norms-audit-script.R:307-318`, `helper-norms-audit-manifest.R:193-196`).
-- [ ] T3 Add the AC2 matcher assertions to that file
+- [x] T3 Add the AC2 matcher assertions to that file
       (`helper-norms-audit-manifest.R:176-197`).
-- [ ] T4 Add the AC3 refusal assertions with their negatives
+- [x] T4 Add the AC3 refusal assertions with their negatives
       (`helper-norms-audit-script.R:103`, `:117-120`, `:130-144`, `:162-183`).
 - [ ] T5 Delete `norms_audit_assign_ordinals()` and its call
       (`helper-norms-audit-script.R:203-219`, `:247`), drop the `ordinal` column
@@ -110,6 +110,8 @@ their existing candidate rows.
 - 2026-08-15: plan gate chose deleting the ordinal over testing it because all 33 shipped sites are ordinal 1 and no duplicated (kind, binding, key) triple exists (measured 2026-08-15), so the field fences nothing today; falsified by a second guard identical in kind, binding and key appearing in the audit script, which AC5's duplicate-refusal reddens rather than silently absorbing.
 - 2026-08-15: plan gate chose test-only-plus-repairs over tests-only because the audit found untested branches rather than defects, and a defect surfaced while writing a test is cheaper to fix in place than to route; falsified by a repair large enough to need its own design decision, which returns to plan.
 - 2026-08-15: T1 in progress — branch cut from a synced master, status in-progress; the baseline `devtools::test()` is still running, so no task is checked off yet. The T2-T4 test file is drafted outside the repo and dry-runs clean (46 assertions, testthat 3.3.2); an in-memory reintroduction of the M83 marker regression reddens 5 of them, naming both shapes AC1 exists for, so the partition is not vacuous. Nothing is committed to `tests/` yet.
+- 2026-08-15: T1 done — baseline `devtools::test()` clean at FAIL 0 / WARN 6 / SKIP 3 / PASS 7051 on master's tree.
+- 2026-08-15: T2-T4 done in one commit, the three criteria being three sections of one new file (`tests/testthat/test-norms-audit-walk.R`, 177 lines, 46 assertions). All eight norms-audit test files pass. The file does not skip against the installed package as its siblings do: the helpers under test are pure and read no `data-raw/` path.
 - 2026-08-15: plan gate weighed D-042's bar on reopening this area and read this scope as distinct — no registry, matcher, matrix or denylist returns, no sweep is added, and the manifest check's promise is byte-unchanged; falsified by any criterion here widening what the manifest check promises.
 
 ## Decisions

--- a/cairn/milestones/M88-norms-audit-walk-helper-tests.md
+++ b/cairn/milestones/M88-norms-audit-walk-helper-tests.md
@@ -1,6 +1,6 @@
 # M88: Fence the norms-audit walk helpers M87 kept
 
-- **Status:** review
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
@@ -51,7 +51,7 @@ their existing candidate rows.
       for a kind outside `stop`/`stopifnot`/`stopifnot_named`; and asserts the
       `stopifnot_named` branch in both directions — a message equal to the key
       accepted, a message carrying the key as a strict superstring rejected.
-- [x] AC3 A test asserts each `refuse_unenumerable()` site raises and names its
+- [ ] AC3 A test asserts each `refuse_unenumerable()` site raises and names its
       cause: `norms_audit_stopifnot_conditions()` for a condition passed under any
       element of `STOPIFNOT_RESERVED`, iterated as the running R defines it and
       anchored non-vacuous by pinning `"exprs"` as a literal member; and
@@ -128,12 +128,71 @@ their existing candidate rows.
 - 2026-08-15: mutant 7 is the evidence AC4's field-set assertion carries the claim its grep cannot: `out[[i]][["seq_within_group"]] <- 1L` reintroduces a per-site field, is not matched by `git grep -nE '(\$|\.)ordinal|ordinal *=|assign_ordinals'` (verified against the line itself), and reddens 33 assertions — one per walked site.
 - 2026-08-15: CHECKPOINT — T6's mutation half is complete and recorded above; the confirming full `devtools::test()` was still running when this was committed, so AC7 is not yet evidenced and the milestone stays `in-progress`. The filtered `norms-audit` run was clean at the same tree.
 - 2026-08-15: AC7 evidenced, superseding the checkpoint line above — full `devtools::test()` clean at FAIL 0 / WARN 6 / SKIP 3 / PASS 7132, warnings and skips unchanged from the T1 baseline's 7051 passes. The +81 is the new walk file's 46 assertions plus the manifest file's 9 → 44. Tree clean; status in-progress → review.
+- 2026-08-15: REVIEW RETURN 1 — AC3 fails. F1 (85), verified independently: `refuse_unenumerable()` echoes the deparsed call, so `expect_match(msg, nm, fixed = TRUE)` passes even with the naming logic gutted; the single-name half of AC3's "names its cause" promise is unasserted. Riding the return: F2 (80), AC1's `long_key` retypes the shipped derivation instead of calling it, and B5, a misattributed M60 citation that should be M43 (verified against LESSONS). 28 findings below the bar logged in Review. Status review → in-progress.
 - 2026-08-15: review in progress — PR #116 opened as draft; AC1-AC5 evidenced fresh and ticked, consistency gate clean (`cairn_validate` exit 0; the profile's toolchain checks are no-ops by file list, the branch touching only `tests/` and `cairn/`). AC6/AC7 deferred until the fresh-context reviewers finish, since a mutation pass would churn the tree they read.
 - 2026-08-15: plan gate weighed D-042's bar on reopening this area and read this scope as distinct — no registry, matcher, matrix or denylist returns, no sweep is added, and the manifest check's promise is byte-unchanged; falsified by any criterion here widening what the manifest check promises.
 
 ## Decisions
 
 ## Review
+
+### Fresh-context review (2026-08-15)
+
+Three lenses, then a [S] scorer that generated none of the findings and was
+given the diff and this plan. 30 candidates reported, filtered by none of the
+lenses. Prior-PR-comments: no prior-review evidence, zero findings (the GitHub
+inline-comment surface probed empty, so archived `## Review` sections were the
+evidence base). Blame-history: 5 candidates, every one self-assessed a
+non-violation — it traced the ordinal to M82, confirmed D-043 authorises the
+deletion and names the weakening as the intended trade, and found D-042's
+retirement bar respected. Diff-bug: 25 candidates.
+
+**Actioned (>= 80): 2.**
+
+- **F1 (85) — AC3's "names its cause" assertions are vacuous for every
+  single-name case.** `refuse_unenumerable()` appends `deparse_call(cl)` to
+  every message, so the probe call `stopifnot(exprs = x > 0)` already carries
+  `exprs`. Verified independently at this branch tip: with the `what` clause
+  replaced by a literal naming nothing, all three of `exprs`, `exprObject` and
+  `local` still appear in the message and `expect_match(msg, nm, fixed = TRUE)`
+  still passes. Only the `"tail, extra"` multi-name assertion is non-vacuous.
+  **This is a return-floor finding — AC3 promises a test that asserts each site
+  "raises and names its cause", and the naming half is unasserted.**
+- **F2 (80) — AC1's `long_key` re-implements the shipped key derivation.** The
+  test retypes `norms_audit_stopifnot_conditions()`'s own expression rather than
+  calling it, the M76/M78 trap this repo has been bitten by three times. Not an
+  AC failure — AC1's wording asks for the condition's full deparsed text, which
+  the test does compute — so it rides the return as a quality fix.
+
+**Below the bar, logged, not actioned (28).** F6 (78) two AC1 case labels
+misdescribe the rejection mechanism, and only case 4 reaches the floor branch ·
+F4 (72) `NORMS_AUDIT_VERDICT`'s `are not all TRUE` alternative is never
+exercised · F5 (72) case 2 hard-codes the verdict instead of reusing the
+constant · F11 (72) AC4/AC5 assertions sit behind the `data-raw/` skip, so they
+do not run under `R CMD check`, including two that need no script · F12 (72)
+`expect_setequal` is multiplicity-insensitive, so a fourth field duplicating an
+existing name escapes · F17 (62) the AC1 fixture bypasses
+`norms_audit_with_c_messages()` · F13 (62) nothing asserts the id builders paste
+exactly the three fields · B5 (60) the M60 citation at
+`test-norms-audit-walk.R:44` is misattributed; M43 is the lesson that says "the
+probe was narrower than what it probed" (verified against LESSONS independently
+of the scorer) · F18 (58) and F19 (55) two wrong line cross-references in new
+comments · F9 (50) the `stopifnot_named`-absent assertion would redden on
+legitimate future work · F3/F7/F8/F10/F22 (45) fixture self-certification,
+two redundant assertion pairs, an unanchored loop rescued incidentally by the
+assertion above it, and the stale word "fixture" · F14 (35) `$` partial-matching
+· F21/F15 (30) a shadowed `c`, a tab separator unreachable today · F20 (20) a
+dead parameter; its env-leak half was disproven by the scorer · B4 (15), B1/B2
+(12), B3 (10) the blame lens's own non-findings · F23 (8) an artifact of reading
+the milestone file mid-edit · F25 (8) D-042's text is untouched by this diff and
+IP4 forbids editing it in place · F24 (12) and F16 (5) both disproven — the
+per-AC counts reproduce exactly, and the twin-refusal verification found the
+ordinal deletion sound.
+
+### Gate outcome: returned to `in-progress` (defect return 1)
+
+F1 demonstrates AC3 failing inside the domain of the procedure it names, which
+is the return floor. AC3 is unticked; AC1, AC2, AC4 and AC5 keep their evidence.
 
 Reviewed 2026-08-15 against PR #116. Evidence executed fresh at this branch
 tip, never recalled from the implement run.

--- a/tests/testthat/helper-norms-audit-manifest.R
+++ b/tests/testthat/helper-norms-audit-manifest.R
@@ -1,11 +1,13 @@
 # The abort-site manifest for `data-raw/audit-norms.R` (M87).
 #
 # One row per `stop()` call and per `stopifnot()` CONDITION, keyed
-# (kind, binding, key, ordinal) exactly as `norms_audit_abort_sites()` collects
-# them. `test-norms-audit-manifest.R` asserts set equality between this table
-# and a fresh walk of the script, so a guard added to the script with no entry
-# here reddens the suite -- the one property the retired abort-site registry
-# existed for (M81-M83), kept at a fraction of its mass.
+# (kind, binding, key) exactly as `norms_audit_abort_sites()` collects them.
+# `test-norms-audit-manifest.R` asserts set equality between this table and a
+# fresh walk of the script, so a guard added to the script with no entry here
+# reddens the suite -- the one property the retired abort-site registry existed
+# for (M81-M83), kept at a fraction of its mass. That file also asserts both
+# sides duplicate-free, which is what makes a three-part key safe: a twin cannot
+# collapse onto one row unnoticed (M88, D-043).
 #
 # GENERATED, never hand-edited: re-derive with a walk of the script rather than
 # typing a row, so the table cannot drift from what the script actually raises.
@@ -82,41 +84,6 @@ NORMS_AUDIT_MANIFEST <- data.frame(
     "roster_from_objects",
     "roster_from_objects",
     "refuse_shared_untagged_blocks"
-  ),
-  ordinal = c(
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L,
-    1L
   ),
   key = c(
     "is.data.frame(batch)",

--- a/tests/testthat/helper-norms-audit-script.R
+++ b/tests/testthat/helper-norms-audit-script.R
@@ -200,29 +200,20 @@ norms_audit_top_level_binding <- function(expr) {
   NORMS_AUDIT_RUN_BINDING
 }
 
-# Source-order ordinals, assigned WITHIN each (kind, binding, key) group.
+# Every `stop()`/`stopifnot()` site the walk collects, as (kind, binding, key)
+# in source order -- the header above bounds what that does and does not cover.
+# One entry per `stop()` call and one per `stopifnot()` CONDITION, since each
+# condition fails on its own and gets its own fixture.
 #
-# The ordinal exists to keep two sites that are otherwise identical -- the same
-# guard written twice inside one function -- separately identifiable, and it
-# does nothing else: a site with no twin is ordinal 1, so adding a twin later
-# renumbers nothing that already exists.
-norms_audit_assign_ordinals <- function(sites) {
-  counts <- list()
-  for (i in seq_along(sites)) {
-    s <- sites[[i]]
-    k <- paste(s$kind, s$binding, s$key, sep = "\t")
-    n <- if (is.null(counts[[k]])) 1L else counts[[k]] + 1L
-    counts[[k]] <- n
-    sites[[i]]$ordinal <- n
-  }
-  sites
-}
-
-# Every `stop()`/`stopifnot()` site the walk collects, as
-# (kind, binding, key, ordinal) in source order -- the header above bounds what
-# that does and does not cover. One entry per `stop()` call and one per
-# `stopifnot()` CONDITION, since each condition fails on its own and gets its
-# own fixture under AC2/AC3.
+# The identity carried a fourth part until M88: a source-order ordinal within
+# each (kind, binding, key) group, there to keep two otherwise identical sites
+# -- the same guard written twice inside one function -- separately
+# identifiable. Measured 2026-08-15, all 33 shipped sites were ordinal 1 and no
+# triple was duplicated, so the field distinguished nothing and was tested by
+# nothing. What it nominally bought is kept instead as a REFUSAL, asserted in
+# test-norms-audit-manifest.R: both sides of the manifest comparison must be
+# duplicate-free, so a twin reddens the suite rather than being numbered
+# silently and never asserted (D-043).
 #
 # The walk is per top-level expression rather than over the whole tree at once,
 # because the enclosing binding is a property of the top-level expression a site
@@ -244,7 +235,7 @@ norms_audit_abort_sites <- function(exprs = norms_audit_script_exprs()) {
       }
     }
   }
-  norms_audit_assign_ordinals(out)
+  out
 }
 
 # Does this call resolve `nm` out of a package namespace?

--- a/tests/testthat/test-norms-audit-manifest.R
+++ b/tests/testthat/test-norms-audit-manifest.R
@@ -23,16 +23,16 @@ manifest_sites <- function() {
   norms_audit_abort_sites(parse(script, keep.source = FALSE))
 }
 
-# The manifest's own rows as the same four-part identity the walk produces, so
+# The manifest's own rows as the same three-part identity the walk produces, so
 # the two sides are compared as sets of identities rather than by row order.
 manifest_ids <- function() {
   paste(NORMS_AUDIT_MANIFEST$kind, NORMS_AUDIT_MANIFEST$binding,
-        NORMS_AUDIT_MANIFEST$key, NORMS_AUDIT_MANIFEST$ordinal, sep = "\t")
+        NORMS_AUDIT_MANIFEST$key, sep = "\t")
 }
 
 walked_ids <- function(sites) {
   vapply(sites, function(s) {
-    paste(s$kind, s$binding, s$key, s$ordinal, sep = "\t")
+    paste(s$kind, s$binding, s$key, sep = "\t")
   }, character(1))
 }
 
@@ -49,9 +49,34 @@ test_that("the manifest is set-equal to a fresh walk of the audit script (M87)",
   expect_identical(setdiff(got, want), character(0))
   expect_identical(setdiff(want, got), character(0))
 
-  # The manifest is a set: a duplicated identity would let one row stand in for
-  # two sites.
+  # Both sides are sets, and BOTH are asserted duplicate-free -- the property
+  # the ordinal used to carry, kept as a refusal instead of a discriminator
+  # (M88, D-043).
+  #
+  # `expect_setequal()` compares membership, so it is blind to a repeat on
+  # either side: two guards identical in (kind, binding, key) would walk to two
+  # equal ids, collapse onto the manifest's one row, and leave the comparison
+  # green with a site nothing asserts. The manifest side needs the same check
+  # for the mirror reason -- one duplicated row would stand in for two sites.
+  #
+  # A twin is not forbidden, only silent adoption of one. Adding a second guard
+  # identical in all three parts now reddens here, and the decision is then a
+  # deliberate one: reword one guard, or restore an ordinal.
   expect_identical(anyDuplicated(want), 0L)
+  expect_identical(anyDuplicated(got), 0L)
+
+  # The identity's field SET, asserted directly rather than by searching for a
+  # spelling. A fourth field is how any restoration of the ordinal -- or of
+  # anything else keyed per site -- would have to arrive, whatever it is named
+  # and however it is written: dollar or double-bracket field assignment, a
+  # field renamed to something the word search cannot know, a setNames() or
+  # cbind() column. Each of those escapes a search for the word and none of
+  # them escapes this. The grep AC4 also names is a spot check on three
+  # spellings, not what carries the claim (M88).
+  expect_identical(names(NORMS_AUDIT_MANIFEST), c("kind", "binding", "key"))
+  for (s in sites) {
+    expect_setequal(names(s), c("kind", "key", "binding"))
+  }
 })
 
 test_that("every manifest key carries enough literal text to discriminate (M87)", {

--- a/tests/testthat/test-norms-audit-walk.R
+++ b/tests/testthat/test-norms-audit-walk.R
@@ -36,12 +36,19 @@ live_truncated <- function(cond, env = list(batch = 1)) {
 test_that("the stopifnot stem accepts and rejects as a partition (M88)", {
   long <- quote(is.data.frame(batch) && is.numeric(batch) &&
                   is.character(batch) && is.list(batch) && nrow(batch) > 3)
-  long_key <- squish(paste(deparse(long), collapse = " "))
+  # The key comes from the shipped walk, never retyped here. Recomputing it as
+  # `squish(paste(deparse(long), collapse = " "))` agrees with the walk by
+  # construction and diverges exactly when the walk's own derivation changes --
+  # the trap M76/M78 record, where a test asserts its own copy of the
+  # expression under test (M88 review, F2).
+  long_key <- norms_audit_stopifnot_conditions(
+    bquote(stopifnot(.(long)))
+  )[[1L]][["key"]]
   truncated <- live_truncated(long)
 
   # The live message really is the truncated shape, not a short one that
   # happened to fit -- otherwise the accept case below proves nothing about
-  # truncation (M60: a probe that cannot reach the regime it names).
+  # truncation (M43: the probe was narrower than what it probed).
   expect_true(norms_audit_stopifnot_stem(truncated)$truncated)
   expect_true(grepl("....", truncated, fixed = TRUE))
 
@@ -126,7 +133,14 @@ test_that("a stopifnot formal carrying conditions is refused by name (M88)", {
     err <- tryCatch(norms_audit_stopifnot_conditions(cl), error = identity)
     expect_true(inherits(err, "error"), info = nm)
     expect_match(conditionMessage(err), "cannot enumerate", fixed = TRUE)
-    expect_match(conditionMessage(err), nm, fixed = TRUE)
+
+    # `formal <nm>`, not a bare `<nm>`. `refuse_unenumerable()` echoes the
+    # deparsed call, which for this probe is `stopifnot(<nm> = x > 0)` -- so a
+    # bare name match is satisfied by the echo alone and passes with the naming
+    # clause gutted entirely (measured at the M88 review, F1). The phrase below
+    # occurs only in the `what` clause the refusal composes, so it fails when
+    # that clause stops naming the formal.
+    expect_match(conditionMessage(err), paste0("formal ", nm), fixed = TRUE)
   }
 })
 
@@ -150,7 +164,10 @@ test_that("a stop() argument R folds into the message is refused (M88)", {
                   error = identity)
   expect_true(inherits(one, "error"))
   expect_match(conditionMessage(one), "cannot enumerate", fixed = TRUE)
-  expect_match(conditionMessage(one), "tail", fixed = TRUE)
+  # `argument named tail`, for the reason above: the echoed call carries
+  # `tail = "TAIL"`, so a bare `tail` match cannot tell the naming clause from
+  # the echo.
+  expect_match(conditionMessage(one), "argument named tail", fixed = TRUE)
 
   # More than one carried name exercises the paste(collapse = ", ") rendering,
   # which no single-name probe reaches.

--- a/tests/testthat/test-norms-audit-walk.R
+++ b/tests/testthat/test-norms-audit-walk.R
@@ -1,0 +1,177 @@
+# The abort-site walk's own helpers, tested directly (M88).
+#
+# M87 retired the registry, matchers, matrix and denylist that used to exercise
+# these functions, and kept the manifest check. The helpers the manifest path
+# still goes through came through that retirement with no unit tests at all:
+# four of their branches are reachable from no site the audit script ships, so
+# the manifest test cannot exercise them even indirectly. This file covers those
+# branches, and nothing here sweeps for anything -- what M87 gave up stays given
+# up (D-042).
+#
+# DEVELOPMENT-ONLY on one point only: the helpers are pure and need no script,
+# so unlike its sibling audit files this one does not skip against the installed
+# package. Nothing below reads data-raw/.
+
+# ---- AC1: the truncation marker, and what it does to the floor ---------------
+
+# R truncates a `stopifnot()` message at its first deparsed line and marks the
+# cut with " ...." before its verdict. The marker is the only signal separating
+# "R cut this short" from "this is the whole condition", and the two want
+# opposite treatment: a truncated stem is honest at any length, an untruncated
+# one must clear the floor. Reading a trailing "...." as truncation WITHOUT the
+# verdict behind it removes the floor from any message ending that way, and a
+# fixture failing before its guard is then reported as coverage for a site never
+# reached (helper-norms-audit-script.R:300-306).
+#
+# The accepted truncated shape is captured from a live stopifnot() rather than
+# typed: a hand-typed stem is one the author already believes matches, and R's
+# actual line break is what the matcher has to survive.
+live_truncated <- function(cond, env = list(batch = 1)) {
+  err <- tryCatch(eval(bquote(stopifnot(.(cond))), list2env(env)),
+                  error = identity)
+  stopifnot(inherits(err, "error"))
+  conditionMessage(err)
+}
+
+test_that("the stopifnot stem accepts and rejects as a partition (M88)", {
+  long <- quote(is.data.frame(batch) && is.numeric(batch) &&
+                  is.character(batch) && is.list(batch) && nrow(batch) > 3)
+  long_key <- squish(paste(deparse(long), collapse = " "))
+  truncated <- live_truncated(long)
+
+  # The live message really is the truncated shape, not a short one that
+  # happened to fit -- otherwise the accept case below proves nothing about
+  # truncation (M60: a probe that cannot reach the regime it names).
+  expect_true(norms_audit_stopifnot_stem(truncated)$truncated)
+  expect_true(grepl("....", truncated, fixed = TRUE))
+
+  short_key <- "is.data.frame(batch)"
+  cases <- list(
+    list(key = long_key,  msg = truncated,
+         want = TRUE,  what = "live truncated message, keyed on the whole condition"),
+    list(key = long_key,  msg = sub("[[:space:]]*is not TRUE$", "", truncated),
+         want = FALSE, what = "same text with no verdict behind the marker"),
+    list(key = short_key, msg = "is.data.frame(batch) is not TRUE",
+         want = TRUE,  what = "untruncated whole condition"),
+    list(key = short_key, msg = "is.data is not TRUE",
+         want = FALSE, what = "below-floor stem, verdict, no marker"),
+    list(key = short_key, msg = "is.data ....",
+         want = FALSE, what = "below-floor stem, marker, no verdict")
+  )
+
+  for (case in cases) {
+    expect_identical(
+      audit_key_matches("stopifnot", case$key, case$msg), case$want,
+      info = case$what
+    )
+  }
+
+  # Asserted as a partition rather than as examples: every shape above is
+  # declared in both directions, so a matcher that accepted everything and one
+  # that accepted nothing each fail (M79).
+  got <- vapply(cases, function(c) audit_key_matches("stopifnot", c$key, c$msg),
+                logical(1))
+  expect_identical(got, vapply(cases, function(c) c$want, logical(1)))
+  expect_true(any(got))
+  expect_false(all(got))
+})
+
+# ---- AC2: the matcher's kind dispatch ---------------------------------------
+
+test_that("an unrecognised abort kind is refused, not judged loosely (M88)", {
+  err <- tryCatch(audit_key_matches("stopifnot_nmaed", "k", "k"),
+                  error = identity)
+  expect_true(inherits(err, "error"))
+
+  # Named, so a stale kind fails by what it was rather than by falling through
+  # to the positional branch -- the loosest of the three, which is what a
+  # fall-through would silently hand it (helper-norms-audit-manifest.R:185-192).
+  expect_match(conditionMessage(err), "unknown abort site kind", fixed = TRUE)
+  expect_match(conditionMessage(err), "stopifnot_nmaed", fixed = TRUE)
+
+  for (kind in c("stop", "stopifnot", "stopifnot_named")) {
+    expect_no_error(audit_key_matches(kind, "a key", "a key"))
+  }
+})
+
+test_that("a named stopifnot condition matches by equality only (M88)", {
+  key <- "batch must name each instrument once"
+
+  expect_true(audit_key_matches("stopifnot_named", key, key))
+  expect_false(audit_key_matches("stopifnot_named", key, paste0(key, " really")))
+  expect_false(audit_key_matches("stopifnot_named", key, paste0("really ", key)))
+  expect_false(audit_key_matches("stopifnot_named", key, substr(key, 1L, 20L)))
+
+  # No shipped site raises a named condition, so this branch is reachable from
+  # nothing the manifest contains -- which is why it needs a test of its own.
+  expect_false("stopifnot_named" %in% NORMS_AUDIT_MANIFEST$kind)
+})
+
+# ---- AC3: the two fail-closed refusals --------------------------------------
+
+test_that("a stopifnot formal carrying conditions is refused by name (M88)", {
+  # Iterated as the running R defines the set, never as a literal list: the
+  # spelling is version-dependent (this R has exprObject where RR17 rev 2 had
+  # exprs.env), and a written-out list would silently stop covering a rename.
+  #
+  # Anchored non-vacuous, because the loop and the branch it tests read the same
+  # constant: with STOPIFNOT_RESERVED emptied, a bare iteration runs zero times
+  # and passes green over the very mutation it should catch (M65/M78).
+  expect_gt(length(STOPIFNOT_RESERVED), 0L)
+  expect_true("exprs" %in% STOPIFNOT_RESERVED)
+
+  for (nm in STOPIFNOT_RESERVED) {
+    cl <- as.call(list(quote(stopifnot), quote(x > 0)))
+    names(cl) <- c("", nm)
+    err <- tryCatch(norms_audit_stopifnot_conditions(cl), error = identity)
+    expect_true(inherits(err, "error"), info = nm)
+    expect_match(conditionMessage(err), "cannot enumerate", fixed = TRUE)
+    expect_match(conditionMessage(err), nm, fixed = TRUE)
+  }
+})
+
+test_that("stopifnot conditions key by position and by name (M88)", {
+  got <- norms_audit_stopifnot_conditions(
+    quote(stopifnot(is.data.frame(batch), "batch is empty" = nrow(batch) > 0))
+  )
+
+  expect_identical(length(got), 2L)
+  expect_identical(got[[1L]]$kind, "stopifnot")
+  expect_identical(got[[1L]]$key, "is.data.frame(batch)")
+  expect_identical(got[[2L]]$kind, "stopifnot_named")
+  expect_identical(got[[2L]]$key, "batch is empty")
+})
+
+test_that("a stop() argument R folds into the message is refused (M88)", {
+  # R concatenates every named argument other than call./domain into the
+  # runtime message while the key template drops it, so such a site would key
+  # one string and raise another (helper-norms-audit-script.R:91-104).
+  one <- tryCatch(norms_audit_stop_key(quote(stop("boom ", tail = "TAIL"))),
+                  error = identity)
+  expect_true(inherits(one, "error"))
+  expect_match(conditionMessage(one), "cannot enumerate", fixed = TRUE)
+  expect_match(conditionMessage(one), "tail", fixed = TRUE)
+
+  # More than one carried name exercises the paste(collapse = ", ") rendering,
+  # which no single-name probe reaches.
+  many <- tryCatch(
+    norms_audit_stop_key(quote(stop("boom ", tail = "T", extra = "E"))),
+    error = identity
+  )
+  expect_true(inherits(many, "error"))
+  expect_match(conditionMessage(many), "tail, extra", fixed = TRUE)
+
+  # The negatives: no names at all, and the two names that are legitimately not
+  # part of the message.
+  expect_identical(norms_audit_stop_key(quote(stop("plain ", x))), "plain {}")
+  expect_identical(
+    norms_audit_stop_key(quote(stop("plain ", x, call. = FALSE))), "plain {}"
+  )
+  expect_identical(
+    norms_audit_stop_key(quote(stop("plain ", x, domain = NA))), "plain {}"
+  )
+  expect_identical(
+    norms_audit_stop_key(quote(stop("plain ", x, call. = FALSE, domain = NA))),
+    "plain {}"
+  )
+})


### PR DESCRIPTION
Gives the abort-site walk helpers that survived M87's retirement direct tests, and deletes the ordinal the manifest identity no longer earns.

## What changed

M87 retired ~1500 lines of abort-site apparatus and kept a manifest check. The helpers that check still goes through came through with no unit tests, and four of their branches are reachable from no site the audit script ships — so the manifest test cannot exercise them even indirectly:

- the truncation-marker discrimination (`norms_audit_stopifnot_stem()`, `NORMS_AUDIT_VERDICT`), whose own comment calls it "what this file exists to prevent"
- the matcher's fail-closed unknown-kind refusal, and its `stopifnot_named` branch
- both `refuse_unenumerable()` sites, in `norms_audit_stopifnot_conditions()` and `norms_audit_stop_key()`

The ordinal is gone. All 33 shipped sites carried ordinal 1 and no `(kind, binding, key)` triple was duplicated, so the field discriminated nothing. What it nominally bought is kept as a refusal instead: both sides of the manifest comparison are asserted duplicate-free, so a twin reddens the suite rather than being numbered silently and never asserted (D-043).

Nothing here restores any part of what M87 retired — no registry, no matcher, no cross-discrimination matrix, no denylist sweep, and no new sweep of any kind. The manifest check's promise is byte-unchanged.

## Verification

- Full `devtools::test()`: FAIL 0 / WARN 6 / SKIP 3 / PASS 7132, against the pre-branch baseline's 7051. The +81 is the new file's 46 assertions plus the manifest file's 9 → 44; warnings and skips unchanged.
- Mutation pass: 7 mutants, 7 killed, 0 survived, each restored by copy from HEAD's blob and re-hashed before the next ran.

Two mutants are load-bearing evidence rather than routine. Emptying `STOPIFNOT_RESERVED` drops the walk file from 46 assertions to 37 — the loop runs zero times — so without its two anchor assertions that test would pass green over its own mutation. And `out[[i]][["seq_within_group"]] <- 1L` reintroduces a per-site field that AC4's grep provably cannot see, while the field-set assertion catches it with 33 failures.

Internal tier throughout: `data-raw/` is `.Rbuildignore`d and ships to nobody.