### PR TITLE
M90: Say which degeneracy happened, and stop saying it when it didn't

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -106,12 +106,13 @@ plotting layer has been rebuilt on a real ggplot2 coordinate system.
   standard-error surface's two internal arms would label one matrix
   differently, the reported literal is the correlation-metric arm's — the
   same arm the fit-scaling surface prices — so the two surfaces never name
-  the same matrix differently. Two of these literals are reachable today
-  only at the internal helpers' documented contract boundary, not through
-  any `axes_reliability()` call: `"saturated"` needs a three-item map, which
-  `axes_reliability()` refuses, and the backstop's relabel has never been
-  observed to fire (a 30,000-draw search found no reaching input); they are
-  recorded for code that branches on the documented `details` reason fields.
+  the same matrix differently. Two of these changes are visible today only
+  at the internal helpers' documented contract boundary, not through any
+  `axes_reliability()` call: `"saturated"` needs a three-item map, which
+  `axes_reliability()` refuses, and the backstop's relabel has not been
+  observed to fire (a 30,000-draw search found no reaching input — recorded
+  as not-reached, not as unreachable); they are documented for code that
+  branches on the `details` reason fields.
 
 * `axes_reliability()` objects now report `details$n_moments`, the number of
   distinct analyzed moments p\* = p(p+1)/2, and `details$baseline`, the

--- a/NEWS.md
+++ b/NEWS.md
@@ -88,8 +88,25 @@ plotting layer has been rebuilt on a real ggplot2 coordinate system.
   `details$se_correction_failed` and `details$fit_scaling_failed` alike: an
   exactly singular fitted matrix reports `"ill_conditioned"` where both
   previously reported `"singular"`, and an indefinite one reports
-  `"ill_conditioned"` where both previously reported `"indefinite"`. Code
+  `"indefinite"` deliberately or `"ill_conditioned"` at the numerical
+  margin, per the refusal-vocabulary split in the next entry. Code
   that branches on any of these reason strings needs updating.
+
+* `axes_reliability()`'s refusal reasons now say which degeneracy happened.
+  Within the degeneracy criterion's refusal region, a fitted correlation
+  structure whose smallest eigenvalue is decisively negative — beyond the
+  fit's own numerical noise band — reports `"indefinite"`, a statement about
+  the model; roundoff-level negativity, exact singularity, and mere
+  ill-conditioning report `"ill_conditioned"`, a numerical caution. A
+  saturated model (zero degrees of freedom) is refused as `"saturated"`
+  before any scaling arithmetic runs, where it previously surfaced as
+  `"indefinite"` through an internal division by zero; and the final
+  nonpositive-scaling-factor backstop likewise reports `"ill_conditioned"`
+  rather than `"indefinite"`, an indefiniteness it cannot diagnose. When the
+  standard-error surface's two internal arms would label one matrix
+  differently, the reported literal is the correlation-metric arm's — the
+  same arm the fit-scaling surface prices — so the two surfaces never name
+  the same matrix differently.
 
 * `axes_reliability()` objects now report `details$n_moments`, the number of
   distinct analyzed moments p\* = p(p+1)/2, and `details$baseline`, the

--- a/NEWS.md
+++ b/NEWS.md
@@ -80,8 +80,8 @@ plotting layer has been rebuilt on a real ggplot2 coordinate system.
   internal `solve()` failed first refused with an incidental label — so a
   sufficiently degenerate fitted matrix could yield `NA` corrected standard
   errors beside silently scaled fit statistics derived from the same matrix.
-  The failure-reason vocabulary is now shared across both surfaces, and four
-  reported literals change. On `details$se_correction_failed` alone: a
+  The failure-reason vocabulary is now shared across both surfaces, and the
+  reported literals change as follows. On `details$se_correction_failed` alone: a
   nonpositive fitted variance reports `"singular"` where it previously
   reported `"nonpositive_diagonal"`, and a positive-infinite one reports
   `"infinite_diagonal"` rather than `"unidentified"`. On
@@ -106,7 +106,12 @@ plotting layer has been rebuilt on a real ggplot2 coordinate system.
   standard-error surface's two internal arms would label one matrix
   differently, the reported literal is the correlation-metric arm's — the
   same arm the fit-scaling surface prices — so the two surfaces never name
-  the same matrix differently.
+  the same matrix differently. Two of these literals are reachable today
+  only at the internal helpers' documented contract boundary, not through
+  any `axes_reliability()` call: `"saturated"` needs a three-item map, which
+  `axes_reliability()` refuses, and the backstop's relabel has never been
+  observed to fire (a 30,000-draw search found no reaching input); they are
+  recorded for code that branches on the documented `details` reason fields.
 
 * `axes_reliability()` objects now report `details$n_moments`, the number of
   distinct analyzed moments p\* = p(p+1)/2, and `details$baseline`, the

--- a/R/axes_corrected_se.R
+++ b/R/axes_corrected_se.R
@@ -256,14 +256,29 @@ axes_corrected_se <- function(sigma, item_names, item_angle_deg, item_scale,
   # end of this file for the criterion and its rationale. Checked before any
   # pricing so that what refuses a degenerate matrix is a stated contract, not
   # whichever solve() call happens to give up first on this platform's LAPACK.
-  # Evaluated on BOTH matrices this helper prices: the raw realigned Sigma-hat
-  # (the `naive` arm below inverts it) and cov2cor(Sigma-hat) (the corrected
-  # arm, and the only matrix anything user-reported depends on). Either arm
+  # Evaluated on BOTH matrices this helper prices: cov2cor(Sigma-hat) (the
+  # corrected arm, and the only matrix anything user-reported depends on) and
+  # the raw realigned Sigma-hat (the `naive` arm below inverts it). Either arm
   # tripping refuses all three vectors as a unit -- the retained cost recorded
-  # in M89's Deviations table; RR18 rec 7's decoupling of `naive` is M90's.
-  degenerate <- axes_sigma_degenerate(sigma)
+  # in M89's Deviations table; RR18 rec 7's decoupling of `naive` is M91's.
+  #
+  # ORDER (M90 AC7): the cov2cor arm is consulted FIRST, so whenever both
+  # arms refuse, the literal reported is the cov2cor arm's -- the arm
+  # axes_scaling_factor() also prices. M90's indefinite/ill_conditioned
+  # partition is not congruence-invariant (the eigenvalue RATIO moves under
+  # cov2cor even though the signs do not), so the two arms can label one
+  # matrix differently; without this precedence the raw arm's label would
+  # leak out and break the same-literal half of M89's nestedness contract.
+  # The finiteness hoist above this comment exists for that order: the raw
+  # matrix is checked finite before cov2cor() runs on it, because cov2cor()
+  # of an NA/NaN diagonal emits its own warning and the M71 contract is
+  # exactly one warning per refusal (the same trap the sibling documents at
+  # R/axes_scaled_fit.R; finiteness is metric-blind, so hoisting it moves no
+  # refusal across the arms' boundary).
+  if (!all(is.finite(sigma))) return(na_out("singular"))
+  degenerate <- axes_sigma_degenerate(stats::cov2cor(sigma))
   if (is.null(degenerate)) {
-    degenerate <- axes_sigma_degenerate(stats::cov2cor(sigma))
+    degenerate <- axes_sigma_degenerate(sigma)
   }
   if (!is.null(degenerate)) return(na_out(degenerate))
 

--- a/R/axes_corrected_se.R
+++ b/R/axes_corrected_se.R
@@ -269,7 +269,7 @@ axes_corrected_se <- function(sigma, item_names, item_angle_deg, item_scale,
   # cov2cor even though the signs do not), so the two arms can label one
   # matrix differently; without this precedence the raw arm's label would
   # leak out and break the same-literal half of M89's nestedness contract.
-  # The finiteness hoist above this comment exists for that order: the raw
+  # The finiteness hoist just below exists for that order: the raw
   # matrix is checked finite before cov2cor() runs on it, because cov2cor()
   # of an NA/NaN diagonal emits its own warning and the M71 contract is
   # exactly one warning per refusal (the same trap the sibling documents at
@@ -305,10 +305,12 @@ axes_corrected_se <- function(sigma, item_names, item_angle_deg, item_scale,
 #
 # THE CRITERION: the smallest eigenvalue of the priced matrix, relative to its
 # largest, must exceed sqrt(p * eps / tau) (tau below); at or below that the
-# matrix is refused as "ill_conditioned". One inequality carries three cases:
-# indefinite (lambda_min <= 0 < lambda_max), exactly singular (lambda_min = 0),
-# and ill-conditioned (lambda_max/lambda_min >= sqrt(tau/(p*eps)), about 1.4e4
-# at p = 24).
+# matrix is refused. One inequality carries three cases -- indefinite
+# (lambda_min <= 0 < lambda_max), exactly singular (lambda_min = 0), and
+# ill-conditioned (lambda_max/lambda_min >= sqrt(tau/(p*eps)), about 1.4e4 at
+# p = 24) -- and since M90 the refusal's literal says which happened:
+# "indefinite" where the negativity is decisive, "ill_conditioned" otherwise;
+# the partition and its rationale live at axes_sigma_degenerate() below.
 #
 # WHICH MATRIX (M89 re-cut, RR18): each consumer prices the matrix it actually
 # computes with. Every quantity the scaling surface computes -- and every

--- a/R/axes_corrected_se.R
+++ b/R/axes_corrected_se.R
@@ -305,12 +305,14 @@ axes_corrected_se <- function(sigma, item_names, item_angle_deg, item_scale,
 #
 # THE CRITERION: the smallest eigenvalue of the priced matrix, relative to its
 # largest, must exceed sqrt(p * eps / tau) (tau below); at or below that the
-# matrix is refused. One inequality carries three cases -- indefinite
-# (lambda_min <= 0 < lambda_max), exactly singular (lambda_min = 0), and
-# ill-conditioned (lambda_max/lambda_min >= sqrt(tau/(p*eps)), about 1.4e4 at
-# p = 24) -- and since M90 the refusal's literal says which happened:
-# "indefinite" where the negativity is decisive, "ill_conditioned" otherwise;
-# the partition and its rationale live at axes_sigma_degenerate() below.
+# matrix is refused. One inequality carries three spectral cases -- a
+# negative smallest eigenvalue (lambda_min <= 0 < lambda_max), exact
+# singularity (lambda_min = 0), and mere ill-conditioning
+# (lambda_max/lambda_min >= sqrt(tau/(p*eps)), about 1.4e4 at p = 24) --
+# and since M90 the refusal's LITERAL is decided by depth, not by case:
+# "indefinite" only where the negativity is decisive, "ill_conditioned" for
+# everything else including roundoff-level negativity; the partition and
+# its rationale live at axes_sigma_degenerate() below.
 #
 # WHICH MATRIX (M89 re-cut, RR18): each consumer prices the matrix it actually
 # computes with. Every quantity the scaling surface computes -- and every

--- a/R/axes_corrected_se.R
+++ b/R/axes_corrected_se.R
@@ -338,15 +338,39 @@ axes_degeneracy_tau <- 1e-6
 
 # Returns NULL (priceable), "singular" (non-finite entries: the literal the
 # NA/NaN-diagonal route has carried since before M69, now reached here rather
-# than in solve()), or "ill_conditioned". Callers refuse nonpositive and +Inf
-# diagonals at their own doors first, so lambda_max > 0 whenever the
-# eigendecomposition runs.
+# than in solve()), "indefinite", or "ill_conditioned". Callers refuse
+# nonpositive and +Inf diagonals at their own doors first, so lambda_max > 0
+# whenever the eigendecomposition runs.
+#
+# WITHIN the refusal region, which word (M90): "indefinite" is a statement
+# about the user's MODEL -- the model-implied matrix has a genuinely negative
+# direction -- so it is claimed only where the negativity exceeds what the
+# fit's own noise can produce: lambda_min < -lambda_max * sqrt(p * eps).
+# RATIONALE for that band (RR18 BC5's constant; M90 AC2 demands the rationale
+# stated here): the priced matrix's entries are not exact -- they are
+# optimizer output rounded through cov2cor(), carrying entrywise relative
+# error no smaller than order sqrt(eps) (an iterative fit stopped on a
+# relative objective tolerance `tol` leaves the implied moments with errors
+# of order sqrt(tol) near a quadratic optimum, and sqrt(tol) >= sqrt(eps) for
+# any achievable tolerance). A symmetric entrywise perturbation of relative
+# size sqrt(eps) has spectral norm ~ sqrt(p)*sqrt(eps)*lambda_max under
+# incoherent signs, and Weyl's inequality moves every eigenvalue by at most
+# that norm -- so a computed eigenvalue within lambda_max*sqrt(p*eps) of zero
+# is indistinguishable from a nonnegative one perturbed by the fit's own
+# error, and is refused as "ill_conditioned" (a numerical caution), never
+# reported as a defect of the user's model. The claim is one-directional:
+# within the band, indefiniteness cannot be asserted; beyond it, "indefinite"
+# is the best available reading of a decisively negative eigenvalue. Changing
+# this constant is an escalation (RB, no-oracle), never a silent edit.
 axes_sigma_degenerate <- function(sigma) {
   if (!all(is.finite(sigma))) return("singular")
   ev <- eigen(sigma, symmetric = TRUE, only.values = TRUE)$values
   p <- nrow(sigma)
   floor_ <- sqrt(p * .Machine$double.eps / axes_degeneracy_tau)
-  if (ev[p] <= ev[1] * floor_) return("ill_conditioned")
+  if (ev[p] <= ev[1] * floor_) {
+    if (ev[p] < -ev[1] * sqrt(p * .Machine$double.eps)) return("indefinite")
+    return("ill_conditioned")
+  }
   NULL
 }
 

--- a/R/axes_reliability.R
+++ b/R/axes_reliability.R
@@ -742,7 +742,10 @@ axes_resolve_blocks <- function(blocks, src, all_cols) {
 #' coincide. Separately, a saturated model (`df = 0`) is refused as
 #' `"saturated"` before any scaling arithmetic runs -- a refusal that
 #' touches only the four scaled statistics; the corrected standard errors
-#' still compute. `df` and `srmr` still report.
+#' still compute. (A `df = 0` fit is reachable today only at the internal
+#' helpers' documented contract boundary: `axes_reliability()` itself
+#' refuses the three-item maps that could saturate.) `df` and `srmr` still
+#' report.
 #'
 #' If you cross-check against lavaan, match the variant. The scaled `chisq`,
 #' `pvalue`, `rmsea` and `cfi` here are built with the definitions lavaan calls

--- a/R/axes_reliability.R
+++ b/R/axes_reliability.R
@@ -719,19 +719,26 @@ axes_resolve_blocks <- function(blocks, src, all_cols) {
 #' eigenvalue, relative to its largest, falls at or below
 #' `sqrt(p * .Machine$double.eps / 1e-6)`, where the `1e-6` is a stated
 #' accuracy target: past that floor the corrected standard errors could carry
-#' relative error above it -- is refused by both surfaces with the reason
-#' `"ill_conditioned"`, so the corrected standard errors and the four scaled
-#' statistics go `NA` together (each with its own warning naming that reason)
-#' rather than one surface refusing while the other silently scales. The
-#' standard-error surface additionally applies the same criterion to the raw
-#' fitted matrix, which one of its internal arms inverts, so its refusals
+#' relative error above it -- is refused by both surfaces, and the refusal
+#' says which degeneracy happened: `"indefinite"` when the smallest
+#' eigenvalue is decisively negative (beyond the fit's own numerical noise
+#' band, so it is a statement about the model), `"ill_conditioned"` for
+#' roundoff-level negativity, exact singularity, or mere ill-conditioning (a
+#' numerical caution). Either way the corrected standard errors and the four
+#' scaled statistics go `NA` together (each with its own warning naming that
+#' reason) rather than one surface refusing while the other silently scales.
+#' The standard-error surface additionally applies the same criterion to the
+#' raw fitted matrix, which one of its internal arms inverts, so its refusals
 #' nest the scaling surface's: whatever refuses the scaled statistics also
-#' refuses the standard errors with the same reason, while a matrix
-#' degenerate only in the raw metric (wildly unequal fitted variances over a
-#' well-conditioned correlation structure) returns `NA` standard errors
-#' beside validly scaled fit statistics -- never the reverse. On a
-#' unit-diagonal fitted matrix the two metrics coincide and the surfaces
-#' agree exactly. `df` and `srmr` still report.
+#' refuses the standard errors with the same reason -- when its two arms
+#' would label one matrix differently, the correlation-metric arm's literal
+#' is the one reported, which is what keeps the two surfaces in exact
+#' agreement -- while a matrix degenerate only in the raw metric (wildly
+#' unequal fitted variances over a well-conditioned correlation structure)
+#' returns `NA` standard errors beside validly scaled fit statistics --
+#' never the reverse. On a unit-diagonal fitted matrix the two metrics
+#' coincide. A saturated model (`df = 0`) is refused as `"saturated"`
+#' before any scaling arithmetic runs. `df` and `srmr` still report.
 #'
 #' If you cross-check against lavaan, match the variant. The scaled `chisq`,
 #' `pvalue`, `rmsea` and `cfi` here are built with the definitions lavaan calls
@@ -1003,11 +1010,14 @@ axes_resolve_blocks <- function(blocks, src, all_cols) {
 #'   errors as normal-theory maximum likelihood reports them before the
 #'   correlation-structure correction, `se_correction_failed`, `NULL` when
 #'   that correction succeeded or a string naming why the reported SEs are
-#'   `NA` -- notably `"ill_conditioned"`, the shared degeneracy criterion
+#'   `NA` -- notably the shared degeneracy criterion's two literals
 #'   (smallest eigenvalue relative to largest at or below
 #'   `sqrt(p * .Machine$double.eps / 1e-6)`, evaluated on `cov2cor()` of the
 #'   fitted covariance matrix and, for this surface only, on the raw matrix
-#'   as well), which also sets `fit_scaling_failed` when the correlation form
+#'   as well): `"indefinite"` for a decisively negative eigenvalue, a
+#'   statement about the model, and `"ill_conditioned"` for roundoff-level
+#'   negativity, singularity, or ill-conditioning, a numerical caution --
+#'   which also sets `fit_scaling_failed` when the correlation form
 #'   is what tripped it -- `fit_uncorrected`, the six fit statistics as
 #'   lavaan reports them
 #'   before the correlation-metric scaling, `scaling_factor`, the two
@@ -1895,13 +1905,17 @@ axes_reliability <- function(data = NULL, items, angles = NULL,
       se_uncorrected = se_uncorrected,
       # NULL when the correction succeeded; otherwise why every corrected SE
       # is NA ("singular" from the nonpositive-diagonal door or non-finite
-      # entries, "infinite_diagonal", "ill_conditioned" from the stated
-      # degeneracy criterion -- M89, axes_sigma_degenerate() -- and
-      # "unidentified", "indefinite" forwarded from axes_se_pricing() as
-      # backstops behind it). M71 audited the list against the source;
-      # "indefinite" in particular has never been observed to fire
+      # entries, "infinite_diagonal", "ill_conditioned"/"indefinite" from the
+      # stated degeneracy criterion's M90 partition -- M89/M90,
+      # axes_sigma_degenerate(); when the helper's two arms would label one
+      # matrix differently, the correlation-metric arm's literal is reported
+      # -- and "unidentified", "indefinite" forwarded from axes_se_pricing()
+      # as backstops behind it). M71 audited the list against the source;
+      # the PRICING "indefinite" backstop has never been observed to fire
       # (R/axes_corrected_se.R:185-198), so this enumerates what the helper
-      # CONTAINS, not what a user has been shown.
+      # CONTAINS, not what a user has been shown -- the criterion's
+      # "indefinite", by contrast, fires on any decisively indefinite
+      # fitted matrix (tested).
       se_correction_failed = corrected$reason,
       # What lavaan reported before the correlation-metric scaling (M68), on the
       # same footing as `se_uncorrected` above: visible for comparison and for
@@ -1922,17 +1936,18 @@ axes_reliability <- function(data = NULL, items, angles = NULL,
       # Both are NA together when the scaling failed.
       scaling_factor = c(model = scaling$scale, baseline = scaling$baseline),
       # NULL when the scaling succeeded; otherwise why the four chi-square-
-      # derived statistics are NA ("singular", "ill_conditioned" from the
-      # shared degeneracy criterion (M89), "unidentified", "df_mismatch",
-      # "baseline_df_mismatch", "indefinite", "infinite_diagonal"), enumerated
-      # from the source the same way as the SE list above, and carrying the
-      # same caveat: it enumerates what the helper CONTAINS, not what a user
-      # has been shown. All seven are reachable at the helper's contract
-      # boundary; what a call through axes_reliability() can actually reach is
-      # a strictly smaller set, because this assembly refuses upstream several
-      # of the shapes that reach them.
+      # derived statistics are NA ("singular", "ill_conditioned"/"indefinite"
+      # from the shared degeneracy criterion's M90 partition (M89/M90),
+      # "saturated", "unidentified", "df_mismatch", "baseline_df_mismatch",
+      # "infinite_diagonal"), enumerated from the source the same way as the
+      # SE list above, and carrying the same caveat: it enumerates what the
+      # helper CONTAINS, not what a user has been shown. All eight are
+      # reachable at the helper's contract boundary; what a call through
+      # axes_reliability() can actually reach is a strictly smaller set,
+      # because this assembly refuses upstream several of the shapes that
+      # reach them.
       #
-      # Two of them are worth naming, for what the M89 re-cut left reachable:
+      # Three of them are worth naming, for what the M89/M90 re-cuts left:
       #
       #   "unidentified"  fires when Delta'V Delta is singular. One measured
       #                   route remains: a degenerate Delta (a one-scale map
@@ -1942,23 +1957,31 @@ axes_reliability <- function(data = NULL, items, angles = NULL,
       #                   correlation-degenerate Sigma-hat): the criterion now
       #                   prices cov2cor(Sigma-hat) -- the metric everything
       #                   below computes in -- so that shape is refused at the
-      #                   door as "ill_conditioned" (RR18).
-      #   "indefinite"    fires on a nonpositive or non-finite scaling factor.
-      #                   The measured negative-c route (a cancellation
-      #                   sign-flip at kappa = 6.65e6, p = 3, whose exact value
-      #                   is positive -- RR18) is refused at the door by the
-      #                   tau = 1e-6 floor, whose p = 3 cutoff is kappa ~
-      #                   3.9e4. A saturated df = 0 probe does NOT reach it:
-      #                   measured at p = 3 (the only p where q can reach
-      #                   p(p+1)/2, and only with zeta1 fitted), the
-      #                   degenerate zeta1 column answers "unidentified"
-      #                   before the cval division. Guarding df = 0
-      #                   explicitly is M90's task (RR18 BC4).
+      #                   door (RR18).
+      #   "saturated"     fires on df = 0 (M90, RR18 BC4), ahead of every
+      #                   matrix computation. Before the guard, the measured
+      #                   p = 3 saturated construction (the only p where q can
+      #                   reach p(p+1)/2, and only with zeta1 fitted) reached
+      #                   the cval division and answered "indefinite" via
+      #                   cval = Inf -- a comment here previously claimed it
+      #                   answered "unidentified"; that claim was measured
+      #                   false at the M90 replan audit.
+      #   "indefinite"    is, since M90, the criterion's own word for a
+      #                   decisively negative smallest eigenvalue -- past the
+      #                   convergence-noise band, a statement about the
+      #                   model. The final nonpositive/non-finite-factor
+      #                   backstop no longer says "indefinite": it says
+      #                   "ill_conditioned", because a negative computed cval
+      #                   there is cancellation, not evidence (its one
+      #                   measured instance, kappa = 6.65e6 at p = 3, has a
+      #                   positive exact value and is refused at the door by
+      #                   the tau floor -- RR18; a 30,000-draw search reached
+      #                   the backstop zero times, M90 AC5).
       #
-      # Neither surviving route outlives the assembly: axes_reliability()
+      # None of these routes outlives the assembly: axes_reliability()
       # refuses fewer than four scales, and axes_design() drops a component
       # collinear with another, so no call through it has been seen to reach
-      # either at the exported surface.
+      # them at the exported surface.
       fit_scaling_failed = scaling$reason,
       ols_shadow = ols
     ),

--- a/R/axes_reliability.R
+++ b/R/axes_reliability.R
@@ -721,8 +721,10 @@ axes_resolve_blocks <- function(blocks, src, all_cols) {
 #' accuracy target: past that floor the corrected standard errors could carry
 #' relative error above it -- is refused by both surfaces, and the refusal
 #' says which degeneracy happened: `"indefinite"` when the smallest
-#' eigenvalue is decisively negative (beyond the fit's own numerical noise
-#' band, so it is a statement about the model), `"ill_conditioned"` for
+#' eigenvalue is decisively negative (below
+#' `-lambda_max * sqrt(p * .Machine$double.eps)` -- beyond the fit's own
+#' numerical noise band, so it is a statement about the model),
+#' `"ill_conditioned"` for
 #' roundoff-level negativity, exact singularity, or mere ill-conditioning (a
 #' numerical caution). Either way the corrected standard errors and the four
 #' scaled statistics go `NA` together (each with its own warning naming that
@@ -737,8 +739,10 @@ axes_resolve_blocks <- function(blocks, src, all_cols) {
 #' unequal fitted variances over a well-conditioned correlation structure)
 #' returns `NA` standard errors beside validly scaled fit statistics --
 #' never the reverse. On a unit-diagonal fitted matrix the two metrics
-#' coincide. A saturated model (`df = 0`) is refused as `"saturated"`
-#' before any scaling arithmetic runs. `df` and `srmr` still report.
+#' coincide. Separately, a saturated model (`df = 0`) is refused as
+#' `"saturated"` before any scaling arithmetic runs -- a refusal that
+#' touches only the four scaled statistics; the corrected standard errors
+#' still compute. `df` and `srmr` still report.
 #'
 #' If you cross-check against lavaan, match the variant. The scaled `chisq`,
 #' `pvalue`, `rmsea` and `cfi` here are built with the definitions lavaan calls
@@ -1014,7 +1018,8 @@ axes_resolve_blocks <- function(blocks, src, all_cols) {
 #'   (smallest eigenvalue relative to largest at or below
 #'   `sqrt(p * .Machine$double.eps / 1e-6)`, evaluated on `cov2cor()` of the
 #'   fitted covariance matrix and, for this surface only, on the raw matrix
-#'   as well): `"indefinite"` for a decisively negative eigenvalue, a
+#'   as well): `"indefinite"` for a decisively negative smallest eigenvalue
+#'   (below `-lambda_max * sqrt(p * .Machine$double.eps)`), a
 #'   statement about the model, and `"ill_conditioned"` for roundoff-level
 #'   negativity, singularity, or ill-conditioning, a numerical caution --
 #'   which also sets `fit_scaling_failed` when the correlation form

--- a/R/axes_scaled_fit.R
+++ b/R/axes_scaled_fit.R
@@ -246,9 +246,11 @@ axes_scaling_factor <- function(sigma, item_names, item_angle_deg, item_scale,
   #     sum((1 - rho^2)^2) / baseline_df over finite rho (sigma passed the
   #     finiteness gate above), so cb is finite and >= 0, with equality only
   #     if every |rho| = 1, a matrix the degeneracy criterion refuses first.
+  #     baseline_df > 0 whenever this line runs: p(p - 1)/2 = 0 only at
+  #     p = 1, where q >= 1 forces df <= 0, refused above.
   #   cval <= 0 and !is.finite(cval): tr(U Gamma) >= 0 in exact arithmetic
-  #     (U is the psd projection residual of V, Gamma_R is psd) and df > 0
-  #     past the saturation guard, so a nonpositive or non-finite cval here
+  #     (U is the psd projection residual of V, Gamma_R is psd) and df is
+  #     nonzero past the saturation guard, so a nonpositive or non-finite cval here
   #     is double-precision cancellation, never evidence about the user's
   #     model -- which is why this door stopped saying "indefinite" at M90.
   #     The criterion's tau floor caps the cancellation error a computed

--- a/R/axes_scaled_fit.R
+++ b/R/axes_scaled_fit.R
@@ -241,8 +241,28 @@ axes_scaling_factor <- function(sigma, item_names, item_angle_deg, item_scale,
   # matrix is a grossly inconsistent estimate of it.
   cb <- sum((1 - rho^2)^2) / baseline_df
 
+  # Defensive backstop, not a diagnosis (M90 AC3/AC5). Four arms:
+  #   cb <= 0 and !is.finite(cb): analytically unreachable -- cb =
+  #     sum((1 - rho^2)^2) / baseline_df over finite rho (sigma passed the
+  #     finiteness gate above), so cb is finite and >= 0, with equality only
+  #     if every |rho| = 1, a matrix the degeneracy criterion refuses first.
+  #   cval <= 0 and !is.finite(cval): tr(U Gamma) >= 0 in exact arithmetic
+  #     (U is the psd projection residual of V, Gamma_R is psd) and df > 0
+  #     past the saturation guard, so a nonpositive or non-finite cval here
+  #     is double-precision cancellation, never evidence about the user's
+  #     model -- which is why this door stopped saying "indefinite" at M90.
+  #     The criterion's tau floor caps the cancellation error a computed
+  #     cval can carry (RR18), and the one matrix measured to produce
+  #     cval < 0 in doubles (exemplar B, true cval +0.0556) is refused
+  #     upstream. Recorded search (M90 AC5, work log): 30,000
+  #     criterion-accepted draws spanning p in {3, 8, 24} plus adversarial
+  #     hill-climbs reached this branch 0 times; the nearest miss, an
+  #     adversarial p = 3 / df = 1 draw at cval = +1.2e-5, still computes.
+  #     Retained because "not reached by the search" is not "unreachable":
+  #     the p = 3 / df = 1 family approaches 0+ continuously, so a deeper
+  #     adversary could land inside the cancellation noise.
   if (!is.finite(cval) || !is.finite(cb) || cval <= 0 || cb <= 0) {
-    return(na_out("indefinite"))
+    return(na_out("ill_conditioned"))
   }
   list(scale = cval, baseline = cb, reason = NULL)
 }

--- a/R/axes_scaled_fit.R
+++ b/R/axes_scaled_fit.R
@@ -100,6 +100,14 @@ axes_scaling_factor <- function(sigma, item_names, item_angle_deg, item_scale,
   if (!isTRUE(p * (p - 1) / 2 == baseline_df)) {
     return(na_out("baseline_df_mismatch"))
   }
+  # A saturated model has no chi-square to scale: T = 0 on 0 degrees of
+  # freedom, and the cval line below divides by df. Before M90 this reached
+  # cval = Inf and fell out of the final refusal as "indefinite" -- a claim
+  # about the user's model that df = 0 never licenses. Checked AFTER the two
+  # df-consistency guards (a df = 0 that does not match the derivative set is
+  # a df_mismatch, not a saturation) and before any matrix computation; this
+  # guard is also what keeps df nonzero at the cval division (M90 AC1).
+  if (df == 0) return(na_out("saturated"))
   # `na.rm = TRUE` is load-bearing, not defensive. Without it a single NA or
   # NaN on the fitted diagonal makes the predicate NA and `if (NA)` ERRORS with
   # "missing value where TRUE/FALSE needed" -- in place of the named-reason NA

--- a/R/axes_scaled_fit.R
+++ b/R/axes_scaled_fit.R
@@ -246,8 +246,11 @@ axes_scaling_factor <- function(sigma, item_names, item_angle_deg, item_scale,
   #     sum((1 - rho^2)^2) / baseline_df over finite rho (sigma passed the
   #     finiteness gate above), so cb is finite and >= 0, with equality only
   #     if every |rho| = 1, a matrix the degeneracy criterion refuses first.
-  #     baseline_df > 0 whenever this line runs: p(p - 1)/2 = 0 only at
-  #     p = 1, where q >= 1 forces df <= 0, refused above.
+  #     baseline_df > 0 whenever this line runs: the baseline_df guard pins
+  #     baseline_df = p(p - 1)/2, which is 0 only at p = 1 -- where the
+  #     information matrix (q x q from a single moment, rank <= 1 < q) is
+  #     singular, so acov's solve refuses "unidentified" before this line
+  #     (measured at the M90 round-2 review).
   #   cval <= 0 and !is.finite(cval): tr(U Gamma) >= 0 in exact arithmetic
   #     (U is the psd projection residual of V, Gamma_R is psd) and df is
   #     nonzero past the saturation guard, so a nonpositive or non-finite cval here

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -13,7 +13,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M87 | Retire the norms-audit abort apparatus for a manifest check | done | — | normal | milestones/archive/M87-norms-audit-apparatus-retirement.md |
 | M88 | Fence the norms-audit walk helpers M87 kept | done | — | normal | milestones/archive/M88-norms-audit-walk-helper-tests.md |
 | M89 | Price the degeneracy criterion in the metric the reported numbers live in | done | — | normal | milestones/archive/M89-fitted-matrix-degeneracy-criterion.md |
-| M90 | Say which degeneracy happened, and stop saying it when it did not | planned | M89 | normal | milestones/M90-degeneracy-reason-vocabulary.md |
+| M90 | Say which degeneracy happened, and stop saying it when it did not | in-progress | M89 | normal | milestones/M90-degeneracy-reason-vocabulary.md |
 | M91 | Stop NA-ing computable numbers when only the raw arm refuses | planned | M90 | normal | milestones/M91-naive-arm-decoupling.md |
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |
 

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -13,7 +13,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M87 | Retire the norms-audit abort apparatus for a manifest check | done | — | normal | milestones/archive/M87-norms-audit-apparatus-retirement.md |
 | M88 | Fence the norms-audit walk helpers M87 kept | done | — | normal | milestones/archive/M88-norms-audit-walk-helper-tests.md |
 | M89 | Price the degeneracy criterion in the metric the reported numbers live in | done | — | normal | milestones/archive/M89-fitted-matrix-degeneracy-criterion.md |
-| M90 | Say which degeneracy happened, and stop saying it when it did not | in-progress | M89 | normal | milestones/M90-degeneracy-reason-vocabulary.md |
+| M90 | Say which degeneracy happened, and stop saying it when it did not | review | M89 | normal | milestones/M90-degeneracy-reason-vocabulary.md |
 | M91 | Stop NA-ing computable numbers when only the raw arm refuses | planned | M90 | normal | milestones/M91-naive-arm-decoupling.md |
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |
 

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -13,7 +13,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M87 | Retire the norms-audit abort apparatus for a manifest check | done | — | normal | milestones/archive/M87-norms-audit-apparatus-retirement.md |
 | M88 | Fence the norms-audit walk helpers M87 kept | done | — | normal | milestones/archive/M88-norms-audit-walk-helper-tests.md |
 | M89 | Price the degeneracy criterion in the metric the reported numbers live in | done | — | normal | milestones/archive/M89-fitted-matrix-degeneracy-criterion.md |
-| M90 | Say which degeneracy happened, and stop saying it when it did not | review | M89 | normal | milestones/M90-degeneracy-reason-vocabulary.md |
+| M90 | Say which degeneracy happened, and stop saying it when it did not | in-progress | M89 | normal | milestones/M90-degeneracy-reason-vocabulary.md |
 | M91 | Stop NA-ing computable numbers when only the raw arm refuses | planned | M90 | normal | milestones/M91-naive-arm-decoupling.md |
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |
 

--- a/cairn/milestones/M90-degeneracy-reason-vocabulary.md
+++ b/cairn/milestones/M90-degeneracy-reason-vocabulary.md
@@ -127,9 +127,9 @@ RR18 asks for its constant to be calibrated against the oracle first.
       against M89's merged code (measured at the replan audit: it returns
       `"indefinite"` today).
 - [x] **T2** — The `df == 0` guard and its `"saturated"` literal.
-- [ ] **T3** — Test-first: the indefinite/near-singular partition at the
+- [x] **T3** — Test-first: the indefinite/near-singular partition at the
       nestedness-grid probes, red where the two currently share one literal.
-- [ ] **T4** — The partition in `axes_sigma_degenerate()`, plus the AC6
+- [x] **T4** — The partition in `axes_sigma_degenerate()`, plus the AC6
       battery: two p values, two λmax scales, two construction forms, three
       partition mutants verified to redden.
 - [ ] **T5** — The cov2cor-arm-first inversion and finiteness hoist in
@@ -151,6 +151,8 @@ RR18 asks for its constant to be calibrated against the oracle first.
 - 2026-08-16: alternative rejected at the gate — tightening the AC2 partition to the eigensolver-noise band (~p·ε); the reviewed BC5 constant kept with a demanded convergence-noise rationale; falsified by implementation finding no defensible rationale, in which case escalate via RB (no-oracle) rather than silently change the constant.
 
 - 2026-08-16: T1+T2 — red premise re-measured on the branch (construction returns "indefinite" via cval = Inf pre-guard; q = 6, df = 0 verified); guard added after the df-consistency guards with a df_mismatch-ordering control; suite 7423 pass / 0 fail.
+
+- 2026-08-16: T3+T4 — anchors+battery written first, red on exactly the 10 "indefinite" expectations; partition landed with the convergence-noise rationale comment (one-directional claim, so no escalation needed); grid dd-probe, check_nested set, and d44 cells re-expected ("indefinite" measured λmin −0.56 raw / −48 cor); suite 7444/0. Mutant verification follows this commit.
 
 ## Decisions
 

--- a/cairn/milestones/M90-degeneracy-reason-vocabulary.md
+++ b/cairn/milestones/M90-degeneracy-reason-vocabulary.md
@@ -138,7 +138,7 @@ RR18 asks for its constant to be calibrated against the oracle first.
 - [x] **T6** — The `cval ≤ 0` relabel, the four-arm comment, and AC5's
       arm-by-arm record (`cb` by argument; `cval` by reaching test or
       recorded search).
-- [ ] **T7** — AC4's grep sweep: roxygen enumerations, the
+- [x] **T7** — AC4's grep sweep: roxygen enumerations, the
       `R/axes_reliability.R:1897-1950` comment block (falsified df = 0
       claim), `devtools::document()`, NEWS.
 - [ ] **T8** — Full `devtools::check()`.
@@ -158,6 +158,8 @@ RR18 asks for its constant to be calibrated against the oracle first.
 - 2026-08-16: T5 — arm-disagreement probe measured red first (cov2cor arm "indefinite", raw arm "ill_conditioned", reported = raw's); finiteness hoisted, cov2cor arm now consulted first, AC7 pin test asserts both surfaces say "indefinite" on the split probe; suite 7448/0.
 
 - 2026-08-16: T6 (AC5 search record) — families: Wishart correlations at 3 concentrations + spectrum-surgery draws pinned 1.05–3× above the refusal floor + 1000-step adversarial hill-climbs from the minimum-cval draw; 10,000 accepted draws per p ∈ {3, 8, 24} (30,000 total; script `scratchpad/ac5-search.R`, seed 20260816). Branch reached 0 times; min cval by map: +1.2e-5 (p=3, df=1), +0.813 (p=8), +0.956 (p=24). Disposition: defensive backstop, relabeled "ill_conditioned"; cb arms settled analytically; seeded smoke tier + exemplar-B upstream-guard identity in test. Suite 8250/0.
+
+- 2026-08-16: T7 (AC4 grep disposition) — repo-wide grep over R/, man/, NEWS.md, vignettes/: vignettes 0 hits; updated the two roxygen passages (refusal criterion, se_correction_failed), both inline reason-list comments (falsified df=0 "unidentified" claim corrected to the measured "indefinite"-via-cval=Inf history; enumeration now 8 literals incl. "saturated"), NEWS M89 bullet's now-false indefinite→ill_conditioned sentence fixed in place, M90 bullet added; document() warning-free, no DESCRIPTION drift; suite 8250/0.
 
 ## Decisions
 

--- a/cairn/milestones/M90-degeneracy-reason-vocabulary.md
+++ b/cairn/milestones/M90-degeneracy-reason-vocabulary.md
@@ -135,7 +135,7 @@ RR18 asks for its constant to be calibrated against the oracle first.
 - [x] **T5** — The cov2cor-arm-first inversion and finiteness hoist in
       `axes_corrected_se()`; M89's nestedness grid re-expected under the new
       vocabulary and re-run (AC7).
-- [ ] **T6** — The `cval ≤ 0` relabel, the four-arm comment, and AC5's
+- [x] **T6** — The `cval ≤ 0` relabel, the four-arm comment, and AC5's
       arm-by-arm record (`cb` by argument; `cval` by reaching test or
       recorded search).
 - [ ] **T7** — AC4's grep sweep: roxygen enumerations, the
@@ -156,6 +156,8 @@ RR18 asks for its constant to be calibrated against the oracle first.
 
 - 2026-08-16: T4 mutants — drop-p 8 fails, squared-p 8 fails, drop-λmax 5 fails (the λmax-scale cells), each applied/restored with blob-hash verification; first perl attempt silently no-opped (interpolated `$double` in \Q…\E), caught by the hash check before any green was trusted.
 - 2026-08-16: T5 — arm-disagreement probe measured red first (cov2cor arm "indefinite", raw arm "ill_conditioned", reported = raw's); finiteness hoisted, cov2cor arm now consulted first, AC7 pin test asserts both surfaces say "indefinite" on the split probe; suite 7448/0.
+
+- 2026-08-16: T6 (AC5 search record) — families: Wishart correlations at 3 concentrations + spectrum-surgery draws pinned 1.05–3× above the refusal floor + 1000-step adversarial hill-climbs from the minimum-cval draw; 10,000 accepted draws per p ∈ {3, 8, 24} (30,000 total; script `scratchpad/ac5-search.R`, seed 20260816). Branch reached 0 times; min cval by map: +1.2e-5 (p=3, df=1), +0.813 (p=8), +0.956 (p=24). Disposition: defensive backstop, relabeled "ill_conditioned"; cb arms settled analytically; seeded smoke tier + exemplar-B upstream-guard identity in test. Suite 8250/0.
 
 ## Decisions
 

--- a/cairn/milestones/M90-degeneracy-reason-vocabulary.md
+++ b/cairn/milestones/M90-degeneracy-reason-vocabulary.md
@@ -42,13 +42,13 @@ RR18 asks for its constant to be calibrated against the oracle first.
 
 ## Acceptance criteria
 
-- [ ] **AC1 (BC4, narrowed)** — `axes_scaling_factor()` refuses `df == 0` with the literal
+- [x] **AC1 (BC4, narrowed)** — `axes_scaling_factor()` refuses `df == 0` with the literal
       `"saturated"`, after the two df-consistency guards and before any matrix computation; the
       deterministic p = 3 construction (S = {1,.5,.3;.5,1,.4;.3,.4,1}, scales A/A/B, `fit_zeta1 =
       TRUE`, df = 0) returns `"saturated"`; the guard's position upstream of the `cval` division —
       asserted by code order and the construction's literal, not a claim over all paths — makes
       `df` nonzero wherever `cval` is computed.
-- [ ] **AC2 (BC5, anchors restated)** — Within the refusal region the criterion returns
+- [x] **AC2 (BC5, anchors restated)** — Within the refusal region the criterion returns
       `"indefinite"` iff λmin < −λmax·sqrt(p·ε), else `"ill_conditioned"`; the comment beside the
       partition states its rationale as a convergence-noise band (fitted-matrix entries carry
       optimizer error ~sqrt(ε), so eigenvalues within ~λmax·sqrt(p·ε) of zero are not confident
@@ -57,10 +57,10 @@ RR18 asks for its constant to be calibrated against the oracle first.
       the M89 nestedness-grid indefinite probe (`dd %*% sigma %*% dd`, cov2cor, p = 24, λmin =
       −0.5) returns `"indefinite"` on both surfaces; the near-singular probe (cov2cor, p = 24, λmin
       = −9.32e-16) returns `"ill_conditioned"` on both.
-- [ ] **AC3 (BC6)** — The `cval ≤ 0` (or non-finite) refusal at the end of `axes_scaling_factor()`
+- [x] **AC3 (BC6)** — The `cval ≤ 0` (or non-finite) refusal at the end of `axes_scaling_factor()`
       no longer returns `"indefinite"`; it returns `"ill_conditioned"`, with the tr(UΓ) ≥ 0
       rationale recorded in a comment beside it.
-- [ ] **AC4 (procedure-based)** — A repo-wide grep for each pre-M90 refusal literal
+- [x] **AC4 (procedure-based)** — A repo-wide grep for each pre-M90 refusal literal
       (`"indefinite"`, `"ill_conditioned"`, `"saturated"`) over `R/`, `man/`, `NEWS.md`,
       `vignettes/` enumerates the doc surfaces; every hit either already describes the post-M90
       vocabulary or is updated here — including the inline comments at
@@ -68,7 +68,7 @@ RR18 asks for its constant to be calibrated against the oracle first.
       falsified (measured: `"indefinite"`), the roxygen enumerations, `man/axes_reliability.Rd`,
       and NEWS. Documented: the three printed-output changes — AC1's `"saturated"`, AC2's
       partition, AC3's relabel (GP4).
-- [ ] **AC5 (amended at review round 1)** — The `cval ≤ 0` branch's four-arm predicate is
+- [x] **AC5 (amended at review round 1)** — The `cval ≤ 0` branch's four-arm predicate is
       dispositioned arm by arm on recorded evidence (recorded in this file's work log). The two
       `cb` arms are settled by argument in the comment (cb = Σ(1−ρ²)²/baseline_df ≥ 0, equality
       only at |ρ| = 1, refused upstream; baseline_df > 0 wherever the line runs). For the two
@@ -85,14 +85,14 @@ RR18 asks for its constant to be calibrated against the oracle first.
       `"ill_conditioned"` (the mock is the upstream criterion, never the branch's condition; the
       test claims only the emitted literal, never that any unmocked input reaches the branch —
       M62). AC3's comment covers all four arms.
-- [ ] **AC6 (probe family widened)** — At p = 24 and at least one of p ∈ {8, 12}, tests construct
+- [x] **AC6 (probe family widened)** — At p = 24 and at least one of p ∈ {8, 12}, tests construct
       matrices with λmin just inside and just outside −λmax·sqrt(p·ε) (factors ≈ 0.5 and ≈ 2,
       computed per p), at two λmax scales (≈ 1, ≈ 1e3) and two construction forms (rank-one
       negative perturbation; eigen-recomposition Q diag(λ) Qᵀ), asserting the literal flips across
       the boundary in every cell; the drop-p, squared-p, and drop-λmax partition mutants each
       verifiably redden. p = 3 excluded deliberately: there the ×2 factor no longer separates the
       squared-p mutant.
-- [ ] **AC7 (reworded at the replan)** — Whenever both of `axes_corrected_se()`'s arms refuse, the
+- [x] **AC7 (reworded at the replan)** — Whenever both of `axes_corrected_se()`'s arms refuse, the
       reported literal is the one its cov2cor arm produces — requiring the arm order at
       `R/axes_corrected_se.R:264-268` inverted (cov2cor first) and the raw-matrix finiteness check
       `!all(is.finite(sigma))` hoisted ahead of both arms (mirroring
@@ -169,6 +169,8 @@ RR18 asks for its constant to be calibrated against the oracle first.
 - 2026-08-16: correction — the T3+T4 work-log line's measured numbers were false: the d44 probe measures λmin −0.3819 raw / −38.25 cov2cor and the dd grid probe −0.1407 raw / −0.5000 cov2cor (the −0.56/−48 came from an ad-hoc reproduction with wrong population parameters; found by the diff lens, re-measured with the test file's own probe).
 
 - 2026-08-16: amendment return: AC5 — "either a test reaches the branch on an unmocked input — AC1's guard and the degeneracy criterion both live — and asserts \"ill_conditioned\", or the recorded search … finds no reaching input, the branch is marked a defensive backstop (not \"unreachable\"), and three tests pin the disposition: a seeded smoke tier re-runs the family with the smallest cval that search recorded (p = 3 / df = 1, min +1.2e-5), asserting every accepted draw computes with cval > 0; the upstream criterion — not the backstop — is asserted to refuse the one matrix on record (RR18 exemplar B) measured to compute cval < 0 in doubles, pinned at the criterion itself; and a mocked-criterion test asserts the backstop's own literal is \"ill_conditioned\" (the mock is the upstream criterion, never the branch's condition — M62)". Amended text audited by a fresh [O] reader (PASS with 4 wording repairs, all applied: disjunct made disjoint, both superlatives replaced by citations, mock kind corrected); user approved the amendment at the round-1 gate.
+
+- 2026-08-16: review round 2 — delta reviewer's 7 findings all fixed same-round (search-script detector, false p=1 argument, NEWS/roxygen qualifiers, comment homonymy, test-block split, fresh check); all 7 AC boxes ticked against recorded evidence; suite 8257/0 on the final tree.
 
 ## Decisions
 
@@ -247,3 +249,43 @@ ranked by the reviewers). Dispositions:
 - DISSOLVED on measurement: F15 (AC2's near-singular anchor "mislabeled
   cov2cor" — the probe is unit-diagonal, `cov2cor()` of it is identical,
   label accurate; clarifying assertion added to the test).
+
+### Round 2 (2026-08-16)
+
+The round-1 fixes plus the audited AC5 amendment landed (commit f832c982
+and the round-2 delta). A fresh [O] reviewer over the fix delta returned 7
+findings, all fixed in the delta's follow-up: (R1) the committed search
+script's reach detector still read the pre-relabel literal, so a re-run
+could never fire — detector corrected to the post-relabel identity
+("ill_conditioned" on an accepted draw = the backstop, since the criterion
+already returned NULL); (R2) the cb-arm p = 1 argument was false (q = 3,
+df = −2 passes the df guards; what actually refuses p = 1 is the singular
+information matrix, "unidentified", measured) — comment corrected; (R3)
+NEWS qualifier said "two literals" where the claim is about two CHANGES,
+and implied unreachability — reworded; (R4) the roxygen `"saturated"`
+guarantee lacked the boundary caveat NEWS carries — added; (R5) THE
+CRITERION comment's case names collided with the literals — reworded to
+"decided by depth, not by case"; (R6) AC5 says three tests, delta had two
+blocks — smoke tier and exemplar-B pin split into their own `test_that`
+blocks; (R7) check evidence predated the delta — full `devtools::check()`
+re-run on the final tree (below). The reviewer verified clean: the wiring
+test genuinely lands on the cval arm (cval = −0.2160593 measured under the
+mock), is site-exclusive and mutation-sensitive; the one-warning test
+reddens on hoist-revert; the corrected numbers (−0.3819 raw / −38.25
+cov2cor) reproduce; roxygen/Rd threshold text matches the code verbatim.
+
+Evidence closing the held criteria:
+- **AC3** ✓ — relabel + four-arm comment in source; the wiring test pins
+  the branch's literal, and the relabel-revert mutant reddens exactly that
+  test (hash-verified apply/restore).
+- **AC4** ✓ — the missed THE CRITERION block updated; grep procedure
+  re-run over `R/`, `NEWS.md`, `vignettes/`: zero surfaces describing the
+  pre-M90 semantics remain (`man/` regenerates from the roxygen).
+- **AC5 (amended)** ✓ — all three named tests exist as their own blocks
+  and pass; the search record, corrected script (devel/m90-ac5-search/),
+  backstop marking, and cb-arm argument (corrected per R2) are in place.
+
+Final tree: suite 8257 pass / 0 fail; `document()` 0 link warnings, Rd in
+sync, no DESCRIPTION drift; `pkgdown::check_pkgdown()` no problems;
+`cairn_validate` all checks pass; full `devtools::check()` on this tree —
+see the gate presentation.

--- a/cairn/milestones/M90-degeneracy-reason-vocabulary.md
+++ b/cairn/milestones/M90-degeneracy-reason-vocabulary.md
@@ -132,7 +132,7 @@ RR18 asks for its constant to be calibrated against the oracle first.
 - [x] **T4** — The partition in `axes_sigma_degenerate()`, plus the AC6
       battery: two p values, two λmax scales, two construction forms, three
       partition mutants verified to redden.
-- [ ] **T5** — The cov2cor-arm-first inversion and finiteness hoist in
+- [x] **T5** — The cov2cor-arm-first inversion and finiteness hoist in
       `axes_corrected_se()`; M89's nestedness grid re-expected under the new
       vocabulary and re-run (AC7).
 - [ ] **T6** — The `cval ≤ 0` relabel, the four-arm comment, and AC5's
@@ -153,6 +153,9 @@ RR18 asks for its constant to be calibrated against the oracle first.
 - 2026-08-16: T1+T2 — red premise re-measured on the branch (construction returns "indefinite" via cval = Inf pre-guard; q = 6, df = 0 verified); guard added after the df-consistency guards with a df_mismatch-ordering control; suite 7423 pass / 0 fail.
 
 - 2026-08-16: T3+T4 — anchors+battery written first, red on exactly the 10 "indefinite" expectations; partition landed with the convergence-noise rationale comment (one-directional claim, so no escalation needed); grid dd-probe, check_nested set, and d44 cells re-expected ("indefinite" measured λmin −0.56 raw / −48 cor); suite 7444/0. Mutant verification follows this commit.
+
+- 2026-08-16: T4 mutants — drop-p 8 fails, squared-p 8 fails, drop-λmax 5 fails (the λmax-scale cells), each applied/restored with blob-hash verification; first perl attempt silently no-opped (interpolated `$double` in \Q…\E), caught by the hash check before any green was trusted.
+- 2026-08-16: T5 — arm-disagreement probe measured red first (cov2cor arm "indefinite", raw arm "ill_conditioned", reported = raw's); finiteness hoisted, cov2cor arm now consulted first, AC7 pin test asserts both surfaces say "indefinite" on the split probe; suite 7448/0.
 
 ## Decisions
 

--- a/cairn/milestones/M90-degeneracy-reason-vocabulary.md
+++ b/cairn/milestones/M90-degeneracy-reason-vocabulary.md
@@ -1,11 +1,11 @@
 # M90: Say which degeneracy happened, and stop saying it when it didn't
 
-- **Status:** review
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** M89
 - **Driving RR:** RR18
 - **Principles touched:** GP2, GP4
-- **Branch/PR:** m90-degeneracy-reason-vocabulary
+- **Branch/PR:** m90-degeneracy-reason-vocabulary · https://github.com/jmgirard/circumplex/pull/118
 
 ## Goal
 
@@ -42,72 +42,74 @@ RR18 asks for its constant to be calibrated against the oracle first.
 
 ## Acceptance criteria
 
-- [ ] **AC1 (BC4, narrowed)** — `axes_scaling_factor()` refuses `df == 0` with the
-      literal `"saturated"`, after the two df-consistency guards and before any matrix
-      computation; the deterministic p = 3 construction (S = {1,.5,.3;.5,1,.4;.3,.4,1},
-      scales A/A/B, `fit_zeta1 = TRUE`, df = 0) returns `"saturated"`; the guard's
-      position upstream of the `cval` division — asserted by code order and the
-      construction's literal, not a claim over all paths — makes `df` nonzero wherever
-      `cval` is computed.
+- [ ] **AC1 (BC4, narrowed)** — `axes_scaling_factor()` refuses `df == 0` with the literal
+      `"saturated"`, after the two df-consistency guards and before any matrix computation; the
+      deterministic p = 3 construction (S = {1,.5,.3;.5,1,.4;.3,.4,1}, scales A/A/B, `fit_zeta1 =
+      TRUE`, df = 0) returns `"saturated"`; the guard's position upstream of the `cval` division —
+      asserted by code order and the construction's literal, not a claim over all paths — makes
+      `df` nonzero wherever `cval` is computed.
 - [ ] **AC2 (BC5, anchors restated)** — Within the refusal region the criterion returns
-      `"indefinite"` iff λmin < −λmax·sqrt(p·ε), else `"ill_conditioned"`; the comment
-      beside the partition states its rationale as a convergence-noise band
-      (fitted-matrix entries carry optimizer error ~sqrt(ε), so eigenvalues within
-      ~λmax·sqrt(p·ε) of zero are not confident statements about the user's model) — if
-      implementation cannot defend it, escalate rather than silently change the constant
-      (RB tripwire: no-oracle). Anchors by construction and metric: the M89
-      nestedness-grid indefinite probe (`dd %*% sigma %*% dd`, cov2cor, p = 24,
-      λmin = −0.5) returns `"indefinite"` on both surfaces; the near-singular probe
-      (cov2cor, p = 24, λmin = −9.32e-16) returns `"ill_conditioned"` on both.
-- [ ] **AC3 (BC6)** — The `cval ≤ 0` (or non-finite) refusal at the end of
-      `axes_scaling_factor()` no longer returns `"indefinite"`; it returns
-      `"ill_conditioned"`, with the tr(UΓ) ≥ 0 rationale recorded in a comment beside it.
+      `"indefinite"` iff λmin < −λmax·sqrt(p·ε), else `"ill_conditioned"`; the comment beside the
+      partition states its rationale as a convergence-noise band (fitted-matrix entries carry
+      optimizer error ~sqrt(ε), so eigenvalues within ~λmax·sqrt(p·ε) of zero are not confident
+      statements about the user's model) — if implementation cannot defend it, escalate rather than
+      silently change the constant (RB tripwire: no-oracle). Anchors by construction and metric:
+      the M89 nestedness-grid indefinite probe (`dd %*% sigma %*% dd`, cov2cor, p = 24, λmin =
+      −0.5) returns `"indefinite"` on both surfaces; the near-singular probe (cov2cor, p = 24, λmin
+      = −9.32e-16) returns `"ill_conditioned"` on both.
+- [ ] **AC3 (BC6)** — The `cval ≤ 0` (or non-finite) refusal at the end of `axes_scaling_factor()`
+      no longer returns `"indefinite"`; it returns `"ill_conditioned"`, with the tr(UΓ) ≥ 0
+      rationale recorded in a comment beside it.
 - [ ] **AC4 (procedure-based)** — A repo-wide grep for each pre-M90 refusal literal
       (`"indefinite"`, `"ill_conditioned"`, `"saturated"`) over `R/`, `man/`, `NEWS.md`,
-      `vignettes/` enumerates the doc surfaces; every hit either already describes the
-      post-M90 vocabulary or is updated here — including the inline comments at
-      `R/axes_reliability.R:1897-1950`, whose df = 0 claim (`"unidentified"`) the replan
-      audit falsified (measured: `"indefinite"`), the roxygen enumerations,
-      `man/axes_reliability.Rd`, and NEWS. Documented: the three printed-output changes —
-      AC1's `"saturated"`, AC2's partition, AC3's relabel (GP4).
-- [ ] **AC5** — The `cval ≤ 0` branch's four-arm predicate is dispositioned arm by arm
-      on recorded evidence. The two `cb` arms are settled by argument in the comment
-      (cb = Σ(1−ρ²)²/baseline_df ≥ 0, equality only at |ρ| = 1, refused upstream). For
-      the two `cval` arms: either a test reaches the branch with AC1's guard live and
-      asserts `"ill_conditioned"`, or the recorded search — near-floor draws plus
-      adversarial near-cancellation constructions targeting tr_vg − sum(acov·bmat) ≈ 0,
-      ≥1e4 draws spanning p ∈ {3, 8, 24} — finds no reaching input, the branch is marked
-      a defensive backstop (not "unreachable"), and a test asserts the upstream guard
-      fires on the search's nearest miss. AC3's comment covers all four arms.
-- [ ] **AC6 (probe family widened)** — At p = 24 and at least one of p ∈ {8, 12}, tests
-      construct matrices with λmin just inside and just outside −λmax·sqrt(p·ε) (factors
-      ≈ 0.5 and ≈ 2, computed per p), at two λmax scales (≈ 1, ≈ 1e3) and two
-      construction forms (rank-one negative perturbation; eigen-recomposition
-      Q diag(λ) Qᵀ), asserting the literal flips across the boundary in every cell; the
-      drop-p, squared-p, and drop-λmax partition mutants each verifiably redden. p = 3
-      excluded deliberately: there the ×2 factor no longer separates the squared-p mutant.
-- [ ] **AC7 (reworded at the replan)** — Whenever both of `axes_corrected_se()`'s arms
-      refuse, the reported literal is the one its cov2cor arm produces — requiring the
-      arm order at `R/axes_corrected_se.R:264-268` inverted (cov2cor first) and the
-      raw-matrix finiteness check `!all(is.finite(sigma))` hoisted ahead of both arms
-      (mirroring `R/axes_scaled_fit.R:149-154`), so `cov2cor()` never runs on an NA/NaN
-      diagonal and M71's one-warning-per-refusal contract holds — and M89's nestedness
-      grid is re-run with expected literals updated to the new vocabulary, asserting the
-      nesting relation pointwise: every cell where the scaling surface refuses, the SE
-      helper refuses with the same literal.
+      `vignettes/` enumerates the doc surfaces; every hit either already describes the post-M90
+      vocabulary or is updated here — including the inline comments at
+      `R/axes_reliability.R:1897-1950`, whose df = 0 claim (`"unidentified"`) the replan audit
+      falsified (measured: `"indefinite"`), the roxygen enumerations, `man/axes_reliability.Rd`,
+      and NEWS. Documented: the three printed-output changes — AC1's `"saturated"`, AC2's
+      partition, AC3's relabel (GP4).
+- [ ] **AC5 (amended at review round 1)** — The `cval ≤ 0` branch's four-arm predicate is
+      dispositioned arm by arm on recorded evidence (recorded in this file's work log). The two
+      `cb` arms are settled by argument in the comment (cb = Σ(1−ρ²)²/baseline_df ≥ 0, equality
+      only at |ρ| = 1, refused upstream; baseline_df > 0 wherever the line runs). For the two
+      `cval` arms: either a test reaches the branch on an unmocked input — AC1's guard and the
+      degeneracy criterion both live — and asserts `"ill_conditioned"`, or the recorded search —
+      near-floor draws plus adversarial near-cancellation constructions targeting tr_vg −
+      sum(acov·bmat) ≈ 0, ≥1e4 draws per p ∈ {3, 8, 24} — finds no reaching input, the branch is
+      marked a defensive backstop (not "unreachable"), and three tests pin the disposition: a
+      seeded smoke tier re-runs the family with the smallest cval that search recorded (p = 3 / df
+      = 1, min +1.2e-5), asserting every accepted draw computes with cval > 0; the upstream
+      criterion — not the backstop — is asserted to refuse the one matrix on record (RR18 exemplar
+      B, `cairn/reviews/rb18-counterexample-b.rds`) measured to compute cval < 0 in doubles, pinned
+      at the criterion itself; and a mocked-criterion test asserts the backstop's own literal is
+      `"ill_conditioned"` (the mock is the upstream criterion, never the branch's condition; the
+      test claims only the emitted literal, never that any unmocked input reaches the branch —
+      M62). AC3's comment covers all four arms.
+- [ ] **AC6 (probe family widened)** — At p = 24 and at least one of p ∈ {8, 12}, tests construct
+      matrices with λmin just inside and just outside −λmax·sqrt(p·ε) (factors ≈ 0.5 and ≈ 2,
+      computed per p), at two λmax scales (≈ 1, ≈ 1e3) and two construction forms (rank-one
+      negative perturbation; eigen-recomposition Q diag(λ) Qᵀ), asserting the literal flips across
+      the boundary in every cell; the drop-p, squared-p, and drop-λmax partition mutants each
+      verifiably redden. p = 3 excluded deliberately: there the ×2 factor no longer separates the
+      squared-p mutant.
+- [ ] **AC7 (reworded at the replan)** — Whenever both of `axes_corrected_se()`'s arms refuse, the
+      reported literal is the one its cov2cor arm produces — requiring the arm order at
+      `R/axes_corrected_se.R:264-268` inverted (cov2cor first) and the raw-matrix finiteness check
+      `!all(is.finite(sigma))` hoisted ahead of both arms (mirroring
+      `R/axes_scaled_fit.R:149-154`), so `cov2cor()` never runs on an NA/NaN diagonal and M71's
+      one-warning-per-refusal contract holds — and M89's nestedness grid is re-run with expected
+      literals updated to the new vocabulary, asserting the nesting relation pointwise: every cell
+      where the scaling surface refuses, the SE helper refuses with the same literal.
 
 ### Deviations from RR18
 
 | BC/rec | Departure | Why |
 |---|---|---|
-| BC1 | Met in M89 | The metric move is M89's Goal; this milestone depends on it. |
+| BC1, BC3, BC7, BC8 | Met in M89 | The metric move, τ floor, oracle, and metric-contract docs are all M89's; this milestone depends on it. |
 | BC2 | Met in M89 | AC2 here changes the literal BC2 asserts agreement on, which is why it sequences after. Its retained cost (unit refusal) is M91's. |
-| BC3 | Met in M89 | The τ floor is M89's. |
 | BC4 | "no path reaches `cval = Inf`" narrowed to a guard-order claim | Bounded-promise rule: no named procedure enumerates all paths; the guard's position plus the construction's literal is what a procedure settles. |
-| BC5 | Anchor restated by construction and metric (λmin = −0.5, cov2cor, p = 24 — not the brief's −0.382, which matches no committed probe); partition constant kept, rationale demanded in-code | Replan audit: the bare number is irreproducible; the constant's original rationale (the refusal floor) was superseded by M89's τ floor. |
+| BC5 | Anchor restated by construction and metric (λmin = −0.5, cov2cor, p = 24); partition constant kept, rationale demanded in-code | The brief's bare −0.382 named neither construction nor metric; it is the d44 probe's raw-metric λmin (measured at review round 1 — the replan audit's "matches no committed probe" was false, corrected here). The constant's original rationale (the refusal floor) was superseded by M89's τ floor. |
 | BC6 | Met as AC3 | — |
-| BC7 | Met in M89 | The oracle is M89's evidence base for τ. |
-| BC8 | Met in M89 | M89 documents the metric contract; AC4 here documents this milestone's own literals. |
 | rec 6 | Deferred to the τ-calibration candidate row | "Consider"-level; M89's floor closes every measured case; RR18 asks for oracle calibration first. |
 | rec 7 | Split to M91 (planned 2026-08-16, depends on M90) | Size tripwire at the replan gate; D-044 routes it onward. |
 
@@ -163,6 +165,85 @@ RR18 asks for its constant to be calibrated against the oracle first.
 
 - 2026-08-16: T8 — devtools::check() 0 errors / 0 warnings / 0 notes (9m24s). PDF manual unbuildable on this machine (no TeX; environment fact, M82-family); the class it screens for is ruled out directly — 0 non-ASCII bytes in every line the branch adds to R/ and man/. All tasks done; status → review.
 
+- 2026-08-16: review round 1, defect return #1 — AC4 failed inside its grep domain (R/axes_corrected_se.R:293-296 still describes the single-literal criterion; blame lens). 18 findings triaged: 13 fix-now on this return, 1 routed to M91, 2 rejected with reason, 1 dissolved on measurement, plus the AC5 amendment on its own track. Status → in-progress.
+- 2026-08-16: correction — the T3+T4 work-log line's measured numbers were false: the d44 probe measures λmin −0.3819 raw / −38.25 cov2cor and the dd grid probe −0.1407 raw / −0.5000 cov2cor (the −0.56/−48 came from an ad-hoc reproduction with wrong population parameters; found by the diff lens, re-measured with the test file's own probe).
+
+- 2026-08-16: amendment return: AC5 — "either a test reaches the branch on an unmocked input — AC1's guard and the degeneracy criterion both live — and asserts \"ill_conditioned\", or the recorded search … finds no reaching input, the branch is marked a defensive backstop (not \"unreachable\"), and three tests pin the disposition: a seeded smoke tier re-runs the family with the smallest cval that search recorded (p = 3 / df = 1, min +1.2e-5), asserting every accepted draw computes with cval > 0; the upstream criterion — not the backstop — is asserted to refuse the one matrix on record (RR18 exemplar B) measured to compute cval < 0 in doubles, pinned at the criterion itself; and a mocked-criterion test asserts the backstop's own literal is \"ill_conditioned\" (the mock is the upstream criterion, never the branch's condition — M62)". Amended text audited by a fresh [O] reader (PASS with 4 wording repairs, all applied: disjunct made disjoint, both superlatives replaced by citations, mock kind corrected); user approved the amendment at the round-1 gate.
+
 ## Decisions
 
 ## Review
+
+### Round 1 (2026-08-16, PR #118)
+
+Evidence per criterion, fresh this session on the branch head:
+
+- **AC1** ✓ — suite green (fresh run, 0 fail) incl. the M90 AC1 test (6
+  assertions): the deterministic construction returns `"saturated"`; the
+  df_mismatch-ordering control passes; guard position verified in the diff
+  (after both df-consistency guards, before any matrix computation).
+- **AC2** ✓ — anchors test green; re-measured with the test file's own
+  probe: dd grid probe cov2cor λmin −0.5000 → `"indefinite"` on both
+  surfaces (grid cells); exactly-singular probe λmin −9.322e-16, and the
+  probe is unit-diagonal so `cov2cor()` of it is identical — the criterion
+  literally evaluates the cov2cor metric, `"ill_conditioned"` on both
+  surfaces (grid + AC1-refusal tests). Rationale comment present beside the
+  partition; one-directional, no escalation.
+- **AC3** — relabel and four-arm comment verified in source; tick HELD for
+  round 2: no test pinned the branch's literal (finding F1), so the NEWS
+  claim rests on source-reading alone until the wiring test lands.
+- **AC4** ✗ FAILED in-domain — re-running the grep enumerates
+  `R/axes_corrected_se.R:293-296` ("THE CRITERION" block) still describing
+  the pre-M90 single-literal semantics (blame-lens finding). Defect return #1.
+- **AC5** ✗ criterion wrong as written — its "a test asserts the upstream
+  guard fires on the search's nearest miss" clause is unsatisfiable against
+  the recorded search's outcome: the nearest miss (cval +1.2e-5) COMPUTES,
+  so no guard fires on it. Amendment return (see work log).
+- **AC6** ✓ — battery green (16 cells); three mutants verified red this
+  session with blob-hash-verified apply/restore (work log).
+- **AC7** ✓ — split-probe test green (arms measured disagreeing; reported
+  literal = cov2cor arm's = scaling surface's); nestedness grid re-run green.
+
+Driving RR (projection vs outcome): RR18 BC5's indefinite-probe anchor
+projected λmin = −0.382; measured −0.3819 on the committed d44 probe's raw
+metric (the replan's "matches no committed probe" was false — see triage
+F3) and −0.5000 on the grid dd probe the criterion text now names.
+Near-singular: projected −9.32e-16, measured −9.322e-16. BC4/BC6 carry no
+further numerics; the deterministic construction behaves as projected.
+
+Consistency gate: `cairn_validate` PASS (all checks); no principle change
+(impact skipped); `document()` warning-free, no diff, no DESCRIPTION drift;
+NEWS entry present; no new top-level files; full `devtools::check()`
+0e/0w/0n (T8, this session, identical code tree); PDF manual unbuildable
+locally (no TeX — environment fact), branch R/man additions verified pure
+ASCII. pkgdown check deferred to round 2 with the doc fixes.
+
+Findings (3 lenses: [O] diff-bug 17, [S] blame-history 1, [S] prior-review 0;
+ranked by the reviewers). Dispositions:
+
+- FIX on this return: F1 (cval-relabel literal untested — add
+  mocked-criterion wiring test), F2 (test comment + work-log measured
+  numbers false — corrected, see work-log correction line), F3 (Deviations
+  BC5 "Why" cell false — −0.382 IS the d44 probe's raw λmin; cell
+  corrected, minor amendment), F4 (roxygen places `"saturated"` inside the
+  NA-together paragraph, implying SEs also NA — reworded), F5 (comment
+  overclaims "df > 0"; guard establishes df ≠ 0 — reworded), F7 (no
+  one-warning-count test on the SE surface's NA-diagonal route — added),
+  F8 (AC5 search script cited from untracked scratchpad — committed to
+  devel/m90-ac5-search/), F9 (NEWS presents helper-boundary literals as
+  user-reachable — reachability qualifier added), F10 (partition threshold
+  never stated numerically user-facing — formula added to both roxygen
+  passages), F12 (cb comment silently assumes baseline_df > 0 — p = 1
+  clause added), F13 ("hoist above this comment" — it is below; fixed),
+  F14 (NEWS "four reported literals change" now miscounts — count dropped),
+  BH1 = the AC4 failure above.
+- ROUTED: F11 (noise-band rationale derived in the correlation metric but
+  applied to the raw arm too; not empirically reachable) → M91 work-log
+  note, whose decoupling reopens that surface.
+- REJECTED: F16 (equality-case probe at the partition boundary —
+  fp-unstable to construct portably; measure-zero point with no statistical
+  content), F17 (double `cov2cor()` on the success path — perf nitpick,
+  negligible beside the eigendecomposition).
+- DISSOLVED on measurement: F15 (AC2's near-singular anchor "mislabeled
+  cov2cor" — the probe is unit-diagonal, `cov2cor()` of it is identical,
+  label accurate; clarifying assertion added to the test).

--- a/cairn/milestones/M90-degeneracy-reason-vocabulary.md
+++ b/cairn/milestones/M90-degeneracy-reason-vocabulary.md
@@ -1,11 +1,11 @@
 # M90: Say which degeneracy happened, and stop saying it when it didn't
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** M89
 - **Driving RR:** RR18
 - **Principles touched:** GP2, GP4
-- **Branch/PR:** —
+- **Branch/PR:** m90-degeneracy-reason-vocabulary
 
 ## Goal
 
@@ -123,10 +123,10 @@ RR18 asks for its constant to be calibrated against the oracle first.
 
 ## Tasks
 
-- [ ] **T1** — Test-first: the deterministic saturated construction, red
+- [x] **T1** — Test-first: the deterministic saturated construction, red
       against M89's merged code (measured at the replan audit: it returns
       `"indefinite"` today).
-- [ ] **T2** — The `df == 0` guard and its `"saturated"` literal.
+- [x] **T2** — The `df == 0` guard and its `"saturated"` literal.
 - [ ] **T3** — Test-first: the indefinite/near-singular partition at the
       nestedness-grid probes, red where the two currently share one literal.
 - [ ] **T4** — The partition in `axes_sigma_degenerate()`, plus the AC6
@@ -149,6 +149,8 @@ RR18 asks for its constant to be calibrated against the oracle first.
 - 2026-08-16: replanned under the current rulebook (/milestone-plan). Full-mode criteria audit ([O] fresh-context reader, two passes): round 1 returned 1 blocker (AC7's "grid still passes" unsatisfiable — the grid pins the literals AC2/AC8 change) plus 10 findings; round 2 on the final wordings returned clean except the AC7 finiteness hoist, added. AC1/AC4/AC5 narrowed to named procedures, AC2 anchors restated by construction+metric, AC6 gains the λmax/form axes and the drop-λmax mutant, the arm-order task added; AC8 split to M91 at the gate.
 - 2026-08-16: alternative rejected at the gate — keeping AC8 (naive decoupling) in M90; lost to the size tripwire (8 criteria, ~12 tasks after repairs); falsified if the split forces `axes_corrected_se()`'s return shape to be reopened twice across the M90/M91 seam.
 - 2026-08-16: alternative rejected at the gate — tightening the AC2 partition to the eigensolver-noise band (~p·ε); the reviewed BC5 constant kept with a demanded convergence-noise rationale; falsified by implementation finding no defensible rationale, in which case escalate via RB (no-oracle) rather than silently change the constant.
+
+- 2026-08-16: T1+T2 — red premise re-measured on the branch (construction returns "indefinite" via cval = Inf pre-guard; q = 6, df = 0 verified); guard added after the df-consistency guards with a df_mismatch-ordering control; suite 7423 pass / 0 fail.
 
 ## Decisions
 

--- a/cairn/milestones/M90-degeneracy-reason-vocabulary.md
+++ b/cairn/milestones/M90-degeneracy-reason-vocabulary.md
@@ -287,5 +287,7 @@ Evidence closing the held criteria:
 
 Final tree: suite 8257 pass / 0 fail; `document()` 0 link warnings, Rd in
 sync, no DESCRIPTION drift; `pkgdown::check_pkgdown()` no problems;
-`cairn_validate` all checks pass; full `devtools::check()` on this tree —
-see the gate presentation.
+`cairn_validate` all checks pass; full `devtools::check(args =
+"--no-manual")` on this tree, committed and clean when it ran: 0 errors /
+0 warnings / 0 notes (7m15s). PDF manual: no TeX on this machine
+(environment fact); the branch's R/man additions are verified pure ASCII.

--- a/cairn/milestones/M90-degeneracy-reason-vocabulary.md
+++ b/cairn/milestones/M90-degeneracy-reason-vocabulary.md
@@ -1,6 +1,6 @@
 # M90: Say which degeneracy happened, and stop saying it when it didn't
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** M89
 - **Driving RR:** RR18
@@ -141,7 +141,7 @@ RR18 asks for its constant to be calibrated against the oracle first.
 - [x] **T7** — AC4's grep sweep: roxygen enumerations, the
       `R/axes_reliability.R:1897-1950` comment block (falsified df = 0
       claim), `devtools::document()`, NEWS.
-- [ ] **T8** — Full `devtools::check()`.
+- [x] **T8** — Full `devtools::check()`.
 
 ## Work log
 
@@ -160,6 +160,8 @@ RR18 asks for its constant to be calibrated against the oracle first.
 - 2026-08-16: T6 (AC5 search record) — families: Wishart correlations at 3 concentrations + spectrum-surgery draws pinned 1.05–3× above the refusal floor + 1000-step adversarial hill-climbs from the minimum-cval draw; 10,000 accepted draws per p ∈ {3, 8, 24} (30,000 total; script `scratchpad/ac5-search.R`, seed 20260816). Branch reached 0 times; min cval by map: +1.2e-5 (p=3, df=1), +0.813 (p=8), +0.956 (p=24). Disposition: defensive backstop, relabeled "ill_conditioned"; cb arms settled analytically; seeded smoke tier + exemplar-B upstream-guard identity in test. Suite 8250/0.
 
 - 2026-08-16: T7 (AC4 grep disposition) — repo-wide grep over R/, man/, NEWS.md, vignettes/: vignettes 0 hits; updated the two roxygen passages (refusal criterion, se_correction_failed), both inline reason-list comments (falsified df=0 "unidentified" claim corrected to the measured "indefinite"-via-cval=Inf history; enumeration now 8 literals incl. "saturated"), NEWS M89 bullet's now-false indefinite→ill_conditioned sentence fixed in place, M90 bullet added; document() warning-free, no DESCRIPTION drift; suite 8250/0.
+
+- 2026-08-16: T8 — devtools::check() 0 errors / 0 warnings / 0 notes (9m24s). PDF manual unbuildable on this machine (no TeX; environment fact, M82-family); the class it screens for is ruled out directly — 0 non-ASCII bytes in every line the branch adds to R/ and man/. All tasks done; status → review.
 
 ## Decisions
 

--- a/cairn/milestones/M91-naive-arm-decoupling.md
+++ b/cairn/milestones/M91-naive-arm-decoupling.md
@@ -103,6 +103,8 @@ candidate row.
 
 - 2026-08-16: created by /milestone-plan at the M90 replan gate — RR18 rec 7 split out of M90 on the size tripwire. Criteria audited in the same full-mode pass ([O] fresh-context reader, round 2): its blocker on AC2's "grid unchanged" wording and its one-exemplar note on AC1 are repaired in this file's wording; AC3/AC4/AC5 passed as written.
 
+- 2026-08-16: routed from the M90 review (diff-lens F11): the partition's convergence-noise rationale is derived in the correlation metric but the criterion also runs on the SE helper's raw arm; a raw-arm-only "indefinite" was not empirically reachable at M90, and this milestone's decoupling reopens that surface — address the rationale's scope (or the raw arm's own band) when restructuring the arms.
+
 ## Decisions
 
 ## Review

--- a/devel/m90-ac5-search/ac5-search.R
+++ b/devel/m90-ac5-search/ac5-search.R
@@ -5,13 +5,20 @@
 # 0 times; min cval +1.2e-5 (p = 3, df = 1), +0.813 (p = 8), +0.956 (p = 24).
 # Runtime ~6 minutes. Re-run from the repo root with:
 #   Rscript devel/m90-ac5-search/ac5-search.R
+#
+# Reach detection, post-relabel (M90 review round 2): the recorded run
+# happened before the backstop's relabel, when the branch's literal was
+# "indefinite" and unambiguous. Since the relabel the branch says
+# "ill_conditioned" -- but on a draw accept() has already cleared, the
+# criterion cannot be the source of that literal, so on ACCEPTED draws
+# "ill_conditioned" identifies the backstop exactly; "unidentified" is a
+# distinct upstream door and is counted separately.
 # Families per p: Wishart correlation draws at three concentration levels
 # (conditioning spread), spectrum-surgery near-floor draws (lambda-ratio
 # pinned just above the refusal floor), and an adversarial hill-climb that
 # perturbs the minimum-cval draw toward smaller cval. A draw "reaches" the
-# branch iff the criterion accepts it and axes_scaling_factor() returns
-# reason "indefinite" (pre-relabel HEAD: with the criterion already passed,
-# that literal is emitted ONLY by the cval/cb branch).
+# branch iff the criterion accepts it and axes_scaling_factor() still
+# refuses with the backstop's literal (see the reach-detection note above).
 suppressMessages(devtools::load_all(quiet = TRUE))
 set.seed(20260816)
 
@@ -65,8 +72,8 @@ for (m in maps) {
     r <- sf(S)
     if (is.null(r$reason)) {
       if (r$scale < min_cval) { min_cval <- r$scale; min_S <- S }
-    } else if (r$reason == "indefinite") {
-      n_reach <- n_reach + 1L
+    } else if (r$reason == "ill_conditioned") {
+      n_reach <- n_reach + 1L   # backstop: accept() already cleared the criterion
     }
   }
 
@@ -80,8 +87,8 @@ for (m in maps) {
     r <- sf(S2)
     if (is.null(r$reason) && r$scale < min_cval) {
       min_cval <- r$scale; S <- S2; hc <- hc + 1L
-    } else if (!is.null(r$reason) && r$reason == "indefinite") {
-      n_reach <- n_reach + 1L
+    } else if (!is.null(r$reason) && r$reason == "ill_conditioned") {
+      n_reach <- n_reach + 1L   # backstop (see above)
     }
   }
   cat(sprintf(

--- a/devel/m90-ac5-search/ac5-search.R
+++ b/devel/m90-ac5-search/ac5-search.R
@@ -1,0 +1,90 @@
+# M90 AC5 search: can a criterion-accepted matrix reach the cval <= 0 branch?
+# Provenance: authored and run 2026-08-16 on the m90-degeneracy-reason-
+# vocabulary branch (R 4.6.1, macOS); seed 20260816 below. Recorded result
+# (M90 work log): 10,000 accepted draws per p in {3, 8, 24}, branch reached
+# 0 times; min cval +1.2e-5 (p = 3, df = 1), +0.813 (p = 8), +0.956 (p = 24).
+# Runtime ~6 minutes. Re-run from the repo root with:
+#   Rscript devel/m90-ac5-search/ac5-search.R
+# Families per p: Wishart correlation draws at three concentration levels
+# (conditioning spread), spectrum-surgery near-floor draws (lambda-ratio
+# pinned just above the refusal floor), and an adversarial hill-climb that
+# perturbs the minimum-cval draw toward smaller cval. A draw "reaches" the
+# branch iff the criterion accepts it and axes_scaling_factor() returns
+# reason "indefinite" (pre-relabel HEAD: with the criterion already passed,
+# that literal is emitted ONLY by the cval/cb branch).
+suppressMessages(devtools::load_all(quiet = TRUE))
+set.seed(20260816)
+
+maps <- list(
+  list(p = 3L,  ang = c(0, 0, 90), scl = c("A", "A", "B"), z1 = FALSE),
+  list(p = 8L,  ang = as.numeric(octants()), scl = LETTERS[1:8], z1 = FALSE),
+  list(p = 24L, ang = rep(as.numeric(octants()), each = 3L),
+       scl = rep(LETTERS[1:8], each = 3L), z1 = TRUE)
+)
+
+for (m in maps) {
+  p <- m$p
+  d <- axes_se_derivs(m$ang, m$scl, NULL, m$z1, FALSE)
+  q <- length(d$mats)
+  df <- p * (p + 1) / 2 - q
+  bdf <- p * (p - 1) / 2
+  stopifnot(df > 0)
+  nm <- sprintf("i%02d", seq_len(p))
+  floor_ <- sqrt(p * .Machine$double.eps / axes_degeneracy_tau)
+
+  sf <- function(S) {
+    dimnames(S) <- list(nm, nm)
+    suppressWarnings(axes_scaling_factor(S, nm, m$ang, m$scl,
+                                         fit_zeta1 = m$z1, fit_zeta2 = FALSE,
+                                         df = df, baseline_df = bdf))
+  }
+  accept <- function(S) is.null(axes_sigma_degenerate(stats::cov2cor(S)))
+
+  draw <- function(kind) {
+    if (kind <= 3L) {                       # Wishart at 3 concentrations
+      dfw <- c(p + 1L, 2L * p, 10L * p)[kind]
+      S <- stats::cov2cor(drop(stats::rWishart(1L, dfw, diag(p))))
+    } else {                                 # spectrum surgery near the floor
+      S0 <- stats::cov2cor(drop(stats::rWishart(1L, 2L * p, diag(p))))
+      e <- eigen(S0, symmetric = TRUE)
+      tgt <- runif(1L, 1.05, 3) * floor_     # ratio just above the floor
+      v <- e$values - min(e$values)
+      v <- v / max(v) * (1 - tgt) + tgt      # lambda in [tgt, 1]
+      S <- e$vectors %*% diag(v) %*% t(e$vectors)
+      S <- stats::cov2cor((S + t(S)) / 2)
+    }
+    S
+  }
+
+  n_acc <- 0L; n_reach <- 0L; min_cval <- Inf; min_S <- NULL; n_try <- 0L
+  while (n_acc < 10000L && n_try < 60000L) {
+    n_try <- n_try + 1L
+    S <- draw(1L + (n_try %% 4L))
+    if (!accept(S)) next
+    n_acc <- n_acc + 1L
+    r <- sf(S)
+    if (is.null(r$reason)) {
+      if (r$scale < min_cval) { min_cval <- r$scale; min_S <- S }
+    } else if (r$reason == "indefinite") {
+      n_reach <- n_reach + 1L
+    }
+  }
+
+  # Adversarial hill-climb from the minimum-cval accepted draw.
+  hc <- 0L
+  S <- min_S
+  for (i in seq_len(1000L)) {
+    E <- matrix(rnorm(p * p, sd = 0.02), p, p); E <- (E + t(E)) / 2
+    S2 <- stats::cov2cor(S + E)
+    if (!isTRUE(accept(S2))) next
+    r <- sf(S2)
+    if (is.null(r$reason) && r$scale < min_cval) {
+      min_cval <- r$scale; S <- S2; hc <- hc + 1L
+    } else if (!is.null(r$reason) && r$reason == "indefinite") {
+      n_reach <- n_reach + 1L
+    }
+  }
+  cat(sprintf(
+    "p=%2d df=%3d: tried %d, accepted %d, cval-branch reached %d, min cval %.6f (hill-climb accepted %d)\n",
+    p, df, n_try, n_acc, n_reach, min_cval, hc))
+}

--- a/man/axes_reliability.Rd
+++ b/man/axes_reliability.Rd
@@ -232,7 +232,10 @@ never the reverse. On a unit-diagonal fitted matrix the two metrics
 coincide. Separately, a saturated model (\code{df = 0}) is refused as
 \code{"saturated"} before any scaling arithmetic runs -- a refusal that
 touches only the four scaled statistics; the corrected standard errors
-still compute. \code{df} and \code{srmr} still report.
+still compute. (A \code{df = 0} fit is reachable today only at the internal
+helpers' documented contract boundary: \code{axes_reliability()} itself
+refuses the three-item maps that could saturate.) \code{df} and \code{srmr} still
+report.
 
 If you cross-check against lavaan, match the variant. The scaled \code{chisq},
 \code{pvalue}, \code{rmsea} and \code{cfi} here are built with the definitions lavaan calls

--- a/man/axes_reliability.Rd
+++ b/man/axes_reliability.Rd
@@ -83,7 +83,8 @@ that correction succeeded or a string naming why the reported SEs are
 (smallest eigenvalue relative to largest at or below
 \code{sqrt(p * .Machine$double.eps / 1e-6)}, evaluated on \code{cov2cor()} of the
 fitted covariance matrix and, for this surface only, on the raw matrix
-as well): \code{"indefinite"} for a decisively negative eigenvalue, a
+as well): \code{"indefinite"} for a decisively negative smallest eigenvalue
+(below \code{-lambda_max * sqrt(p * .Machine$double.eps)}), a
 statement about the model, and \code{"ill_conditioned"} for roundoff-level
 negativity, singularity, or ill-conditioning, a numerical caution --
 which also sets \code{fit_scaling_failed} when the correlation form
@@ -210,8 +211,10 @@ eigenvalue, relative to its largest, falls at or below
 accuracy target: past that floor the corrected standard errors could carry
 relative error above it -- is refused by both surfaces, and the refusal
 says which degeneracy happened: \code{"indefinite"} when the smallest
-eigenvalue is decisively negative (beyond the fit's own numerical noise
-band, so it is a statement about the model), \code{"ill_conditioned"} for
+eigenvalue is decisively negative (below
+\code{-lambda_max * sqrt(p * .Machine$double.eps)} -- beyond the fit's own
+numerical noise band, so it is a statement about the model),
+\code{"ill_conditioned"} for
 roundoff-level negativity, exact singularity, or mere ill-conditioning (a
 numerical caution). Either way the corrected standard errors and the four
 scaled statistics go \code{NA} together (each with its own warning naming that
@@ -226,8 +229,10 @@ agreement -- while a matrix degenerate only in the raw metric (wildly
 unequal fitted variances over a well-conditioned correlation structure)
 returns \code{NA} standard errors beside validly scaled fit statistics --
 never the reverse. On a unit-diagonal fitted matrix the two metrics
-coincide. A saturated model (\code{df = 0}) is refused as \code{"saturated"}
-before any scaling arithmetic runs. \code{df} and \code{srmr} still report.
+coincide. Separately, a saturated model (\code{df = 0}) is refused as
+\code{"saturated"} before any scaling arithmetic runs -- a refusal that
+touches only the four scaled statistics; the corrected standard errors
+still compute. \code{df} and \code{srmr} still report.
 
 If you cross-check against lavaan, match the variant. The scaled \code{chisq},
 \code{pvalue}, \code{rmsea} and \code{cfi} here are built with the definitions lavaan calls

--- a/man/axes_reliability.Rd
+++ b/man/axes_reliability.Rd
@@ -79,11 +79,14 @@ respondents behind any item pair, \code{se_uncorrected}, the component standard
 errors as normal-theory maximum likelihood reports them before the
 correlation-structure correction, \code{se_correction_failed}, \code{NULL} when
 that correction succeeded or a string naming why the reported SEs are
-\code{NA} -- notably \code{"ill_conditioned"}, the shared degeneracy criterion
+\code{NA} -- notably the shared degeneracy criterion's two literals
 (smallest eigenvalue relative to largest at or below
 \code{sqrt(p * .Machine$double.eps / 1e-6)}, evaluated on \code{cov2cor()} of the
 fitted covariance matrix and, for this surface only, on the raw matrix
-as well), which also sets \code{fit_scaling_failed} when the correlation form
+as well): \code{"indefinite"} for a decisively negative eigenvalue, a
+statement about the model, and \code{"ill_conditioned"} for roundoff-level
+negativity, singularity, or ill-conditioning, a numerical caution --
+which also sets \code{fit_scaling_failed} when the correlation form
 is what tripped it -- \code{fit_uncorrected}, the six fit statistics as
 lavaan reports them
 before the correlation-metric scaling, \code{scaling_factor}, the two
@@ -205,19 +208,26 @@ fitted covariance matrix whose correlation form \code{cov2cor()} is degenerate
 eigenvalue, relative to its largest, falls at or below
 \code{sqrt(p * .Machine$double.eps / 1e-6)}, where the \code{1e-6} is a stated
 accuracy target: past that floor the corrected standard errors could carry
-relative error above it -- is refused by both surfaces with the reason
-\code{"ill_conditioned"}, so the corrected standard errors and the four scaled
-statistics go \code{NA} together (each with its own warning naming that reason)
-rather than one surface refusing while the other silently scales. The
-standard-error surface additionally applies the same criterion to the raw
-fitted matrix, which one of its internal arms inverts, so its refusals
+relative error above it -- is refused by both surfaces, and the refusal
+says which degeneracy happened: \code{"indefinite"} when the smallest
+eigenvalue is decisively negative (beyond the fit's own numerical noise
+band, so it is a statement about the model), \code{"ill_conditioned"} for
+roundoff-level negativity, exact singularity, or mere ill-conditioning (a
+numerical caution). Either way the corrected standard errors and the four
+scaled statistics go \code{NA} together (each with its own warning naming that
+reason) rather than one surface refusing while the other silently scales.
+The standard-error surface additionally applies the same criterion to the
+raw fitted matrix, which one of its internal arms inverts, so its refusals
 nest the scaling surface's: whatever refuses the scaled statistics also
-refuses the standard errors with the same reason, while a matrix
-degenerate only in the raw metric (wildly unequal fitted variances over a
-well-conditioned correlation structure) returns \code{NA} standard errors
-beside validly scaled fit statistics -- never the reverse. On a
-unit-diagonal fitted matrix the two metrics coincide and the surfaces
-agree exactly. \code{df} and \code{srmr} still report.
+refuses the standard errors with the same reason -- when its two arms
+would label one matrix differently, the correlation-metric arm's literal
+is the one reported, which is what keeps the two surfaces in exact
+agreement -- while a matrix degenerate only in the raw metric (wildly
+unequal fitted variances over a well-conditioned correlation structure)
+returns \code{NA} standard errors beside validly scaled fit statistics --
+never the reverse. On a unit-diagonal fitted matrix the two metrics
+coincide. A saturated model (\code{df = 0}) is refused as \code{"saturated"}
+before any scaling arithmetic runs. \code{df} and \code{srmr} still report.
 
 If you cross-check against lavaan, match the variant. The scaled \code{chisq},
 \code{pvalue}, \code{rmsea} and \code{cfi} here are built with the definitions lavaan calls

--- a/tests/testthat/test-axes-scaled-fit.R
+++ b/tests/testthat/test-axes-scaled-fit.R
@@ -1394,7 +1394,8 @@ test_that("AC8: scaling-surface degeneracy refusals nest inside the SE helper's,
     # degeneracy, the SE helper refuses with the same literal.
     check_nested <- function(sig, what) {
       r <- m89_reasons(sig, pp, df, bdf, m$zeta1)
-      if (!is.null(r$sf) && r$sf %in% c("ill_conditioned", "singular")) {
+      if (!is.null(r$sf) &&
+          r$sf %in% c("ill_conditioned", "indefinite", "singular")) {
         expect_identical(
           r$se, r$sf,
           label = sprintf("%s: SE helper reason", what),
@@ -1433,15 +1434,16 @@ test_that("AC8: scaling-surface degeneracy refusals nest inside the SE helper's,
 
     # One non-unit-diagonal indefinite matrix per map: indefiniteness is
     # metric-invariant (cov2cor() is a congruence; Sylvester's law of inertia
-    # preserves eigenvalue signs), so BOTH surfaces refuse it, same literal.
+    # preserves eigenvalue signs), so BOTH surfaces refuse it, same literal --
+    # since M90's partition, the literal that names the model defect.
     dd <- diag(seq(0.5, 2, length.out = p))
     ind <- dd %*% pp$sigma %*% dd
     dimnames(ind) <- dimnames(pp$sigma)
     ind[1L, 2L] <- ind[2L, 1L] <- 1.5 * sqrt(ind[1L, 1L] * ind[2L, 2L])
     r <- check_nested(ind, sprintf("p %d indefinite", p))
-    expect_identical(r$sf, "ill_conditioned",
+    expect_identical(r$sf, "indefinite",
                      label = sprintf("p %d indefinite, scaling surface", p))
-    expect_identical(r$se, "ill_conditioned",
+    expect_identical(r$se, "indefinite",
                      label = sprintf("p %d indefinite, SE helper", p))
 
     # One near-singular matrix per map (one item duplicated, plus a 1e-9 ridge
@@ -1669,6 +1671,83 @@ test_that("AC3: the floor discriminates its p factor at the threshold", {
   }
 })
 
+test_that("M90 AC2: within the refusal region, deep negativity says 'indefinite', roundoff-level says 'ill_conditioned'", {
+  # The two anchors, each named by construction and metric (M90 AC2). The
+  # nestedness-grid indefinite probe is deeply indefinite in BOTH metrics
+  # (cov2cor lambda_min = -0.5 at p = 24, measured at the replan audit), far
+  # past the convergence-noise band -lambda_max*sqrt(p*eps), so the criterion
+  # now names the model defect instead of hiding it under the numerical
+  # caution.
+  pp <- probe_octant()
+  p <- nrow(pp$sigma)
+  dd <- diag(seq(0.5, 2, length.out = p))
+  ind <- dd %*% pp$sigma %*% dd
+  dimnames(ind) <- dimnames(pp$sigma)
+  ind[1L, 2L] <- ind[2L, 1L] <- 1.5 * sqrt(ind[1L, 1L] * ind[2L, 2L])
+
+  R <- stats::cov2cor(ind)
+  evR <- eigen(R, symmetric = TRUE, only.values = TRUE)$values
+  expect_lt(evR[p], -0.4)  # the anchor is DEEP negativity, not roundoff
+  expect_identical(axes_sigma_degenerate(R), "indefinite")
+  # Indefiniteness is metric-invariant (Sylvester), and the raw matrix is
+  # also far past its own band -- the two arms agree on this probe.
+  expect_identical(axes_sigma_degenerate(ind), "indefinite")
+
+  # An EXACTLY singular matrix (duplicated item): its computed smallest
+  # eigenvalue is roundoff-negative (|lambda_min| ~ 1e-15, measured
+  # -9.32e-16 at the replan audit), inside the noise band -- a numerical
+  # caution, never a claim the user's model is indefinite.
+  sing <- pp$sigma
+  sing[2L, ] <- sing[1L, ]
+  sing[, 2L] <- sing[, 1L]
+  evS <- eigen(sing, symmetric = TRUE, only.values = TRUE)$values
+  expect_lt(abs(evS[p]), 1e-13)
+  expect_identical(axes_sigma_degenerate(sing), "ill_conditioned")
+})
+
+
+test_that("M90 AC6: the partition flips exactly at -lambda_max*sqrt(p*eps), at two p, two scales, two forms", {
+  # Near-threshold probes on the PARTITION (the refusal floor has its own
+  # battery above): lambda_min at 0.5x and 2x the band, per p, at two
+  # lambda_max scales and two construction forms. Far-field anchors cannot
+  # detect a missing/squared p or a dropped lambda_max factor; these cells
+  # can, and the three mutants are each verified to redden against this
+  # battery (work log). p = 3 is excluded deliberately: there the 2x factor
+  # no longer separates the squared-p mutant.
+  set.seed(421)
+  for (p in c(24L, 8L)) {
+    t_ <- sqrt(p * .Machine$double.eps)
+    Q <- qr.Q(qr(matrix(stats::rnorm(p * p), p, p)))
+    for (L in c(1, 1e3)) {
+      for (m in c(0.5, 2)) {
+        want <- if (m > 1) "indefinite" else "ill_conditioned"
+
+        # Form 1: rank-one negative perturbation of L*I. Eigenvalues exactly
+        # L (multiplicity p-1) and -m*t_*L, so lambda_min/lambda_max = -m*t_.
+        v <- rep(1 / sqrt(p), p)
+        S1 <- L * (diag(p) - (1 + m * t_) * tcrossprod(v))
+        S1 <- (S1 + t(S1)) / 2
+        expect_identical(
+          axes_sigma_degenerate(S1), want,
+          label = sprintf("rank-one: p %d, L %g, %gx band", p, L, m)
+        )
+
+        # Form 2: eigen-recomposition with a spread spectrum under a random
+        # (seeded) orthogonal basis -- same lambda_min/lambda_max, different
+        # matrix form.
+        vals <- c(L, seq(L / 2, L / 10, length.out = p - 2L), -m * t_ * L)
+        S2 <- Q %*% diag(vals) %*% t(Q)
+        S2 <- (S2 + t(S2)) / 2
+        expect_identical(
+          axes_sigma_degenerate(S2), want,
+          label = sprintf("recomposed: p %d, L %g, %gx band", p, L, m)
+        )
+      }
+    }
+  }
+})
+
+
 test_that("the non-inflation (indefinite) form is refused by both surfaces with one literal", {
   pp <- probe_octant()
   p <- nrow(pp$sigma)
@@ -1692,12 +1771,15 @@ test_that("the non-inflation (indefinite) form is refused by both surfaces with 
   expect_false(is.character(raw))
   expect_true(all(is.finite(raw$naive)))
 
-  # Both consumers refuse it under the stated criterion (the matrix is
-  # indefinite: its smallest eigenvalue is negative), naming the shared
-  # literal -- before M89 both fell to the emergent "indefinite"/NaN door.
+  # Both consumers refuse it under the stated criterion, naming the shared
+  # literal. The matrix is DEEPLY indefinite (lambda_min = -0.56 raw, -48 in
+  # the correlation metric -- measured, far past the noise band), so since
+  # M90's partition the criterion says "indefinite" for the honest reason;
+  # before M89 both fell to an emergent "indefinite"/NaN door, and between
+  # M89 and M90 the criterion hid the model defect under "ill_conditioned".
   r <- m89_reasons(sig, pp, df, bdf)
-  expect_identical(r$se, "ill_conditioned", label = "near-zero d44, SE surface")
-  expect_identical(r$sf, "ill_conditioned",
+  expect_identical(r$se, "indefinite", label = "near-zero d44, SE surface")
+  expect_identical(r$sf, "indefinite",
                    label = "near-zero d44, scaling surface")
 })
 

--- a/tests/testthat/test-axes-scaled-fit.R
+++ b/tests/testthat/test-axes-scaled-fit.R
@@ -1608,6 +1608,44 @@ test_that("AC2/AC3: the committed exemplar B is refused by both surfaces at p = 
 })
 
 
+test_that("M90 AC5: the cval backstop is not reached by criterion-accepted draws; the known negative-cval matrix is refused upstream", {
+  # Smoke tier of the recorded AC5 search (work log: 30,000 accepted draws
+  # spanning p in {3, 8, 24} + adversarial hill-climbs, 0 reaches, nearest
+  # miss cval = +1.2e-5 at p = 3 / df = 1 -- the one map family whose cval
+  # approaches 0+). This seeded subset re-runs the most cancellable family:
+  # every criterion-accepted draw must COMPUTE (reason NULL, finite positive
+  # scale), i.e. never fall through to the backstop, whose literal on an
+  # accepted draw could only come from the cval branch.
+  set.seed(20260816)
+  ang <- c(0, 0, 90)
+  scl <- c("A", "A", "B")
+  nm <- c("i1", "i2", "i3")
+  n_acc <- 0L
+  for (i in 1:400) {
+    S <- stats::cov2cor(drop(stats::rWishart(1L, 4L, diag(3))))
+    if (!is.null(axes_sigma_degenerate(S))) next
+    n_acc <- n_acc + 1L
+    dimnames(S) <- list(nm, nm)
+    got <- axes_scaling_factor(S, nm, ang, scl,
+                               fit_zeta1 = FALSE, fit_zeta2 = FALSE,
+                               df = 1, baseline_df = 3)
+    expect_null(got$reason, label = sprintf("accepted draw %d computes", i))
+    expect_true(got$scale > 0, label = sprintf("accepted draw %d cval > 0", i))
+  }
+  expect_gt(n_acc, 100L)  # the smoke family actually exercised acceptance
+
+  # The upstream guard fires on the strongest known candidate: exemplar B is
+  # the one matrix measured to produce cval < 0 in doubles (true cval
+  # +0.0556, RR18), and the degeneracy criterion -- not the backstop --
+  # is what refuses it. Asserted at the criterion itself, so the refusal's
+  # identity is pinned, not inferred from a shared literal.
+  fp <- test_path("..", "..", "cairn", "reviews", "rb18-counterexample-b.rds")
+  skip_if_not(file.exists(fp), "cairn/ fixture absent (installed package)")
+  fx <- readRDS(fp)
+  expect_identical(axes_sigma_degenerate(fx$S), "ill_conditioned")
+})
+
+
 test_that("AC3: tau is a named constant, and the floored criterion accepts all three probe-map fits", {
   skip_if_not_installed("lavaan")
   # The accuracy target is a named constant beside the criterion, not an

--- a/tests/testthat/test-axes-scaled-fit.R
+++ b/tests/testthat/test-axes-scaled-fit.R
@@ -1646,6 +1646,55 @@ test_that("M90 AC5: the cval backstop is not reached by criterion-accepted draws
 })
 
 
+test_that("M90 AC5: the backstop's own literal is 'ill_conditioned' (branch WIRING only; the criterion is mocked away)", {
+  # This mock proves the branch's wiring, never the condition that selects
+  # it (the M62 mock doctrine): the degeneracy criterion is stubbed to
+  # accept everything, so exemplar B -- whose double-precision cval is
+  # negative (-0.216) while its exact value is +0.0556 (RR18) -- flows past
+  # the door it is really refused at and lands in the final backstop. The
+  # unmocked path is pinned by the smoke test above (accepted draws never
+  # get here) and by the exemplar-B criterion assertion; this test pins the
+  # literal the backstop itself emits — a literal the recorded search found
+  # no accepted input reaching (never "unreachable"; see the backstop
+  # comment). Under the stub the backstop is the only remaining site in this
+  # function that can emit this literal, so the assertion is site-exclusive.
+  fp <- test_path("..", "..", "cairn", "reviews", "rb18-counterexample-b.rds")
+  skip_if_not(file.exists(fp), "cairn/ fixture absent (installed package)")
+  fx <- readRDS(fp)
+  testthat::local_mocked_bindings(
+    axes_sigma_degenerate = function(sigma) NULL
+  )
+  expect_warning(
+    got <- axes_scaling_factor(fx$S, rownames(fx$S), as.numeric(fx$ia),
+                               c("A", "B", "C"),
+                               fit_zeta1 = FALSE, fit_zeta2 = FALSE,
+                               df = 1, baseline_df = 3),
+    "could not be computed"
+  )
+  expect_identical(got$reason, "ill_conditioned")
+  expect_identical(got$scale, NA_real_)
+})
+
+
+test_that("M90 AC7: an NA fitted diagonal refuses with exactly ONE warning on the SE surface (the hoist is load-bearing)", {
+  # The finiteness hoist exists so cov2cor() never runs on an NA/NaN
+  # diagonal: cov2cor() emits its own warning there, and the M71 contract is
+  # exactly one warning per refusal. Reverting the hoist alone would leave
+  # every literal correct and double the warning -- only this count sees it.
+  # (The sibling surface's count is pinned in its own test above.)
+  pp <- probe_octant()
+  sig <- pp$sigma
+  sig[4L, 4L] <- NA_real_
+  w <- testthat::capture_warnings(
+    got <- axes_corrected_se(sig, pp$names, pp$item_angle, pp$scale,
+                             n = 600, fit_zeta1 = TRUE, fit_zeta2 = FALSE)
+  )
+  expect_length(w, 1L)
+  expect_match(w, "could not be computed", fixed = TRUE)
+  expect_identical(got$reason, "singular")
+})
+
+
 test_that("AC3: tau is a named constant, and the floored criterion accepts all three probe-map fits", {
   skip_if_not_installed("lavaan")
   # The accuracy target is a named constant beside the criterion, not an
@@ -1785,6 +1834,9 @@ test_that("M90 AC2: within the refusal region, deep negativity says 'indefinite'
   sing <- pp$sigma
   sing[2L, ] <- sing[1L, ]
   sing[, 2L] <- sing[, 1L]
+  # The probe is unit-diagonal, so its cov2cor form is the same matrix --
+  # this call IS the criterion's cov2cor-metric evaluation, as AC2 labels it.
+  expect_true(isTRUE(all.equal(stats::cov2cor(sing), sing)))
   evS <- eigen(sing, symmetric = TRUE, only.values = TRUE)$values
   expect_lt(abs(evS[p]), 1e-13)
   expect_identical(axes_sigma_degenerate(sing), "ill_conditioned")
@@ -1857,8 +1909,8 @@ test_that("the non-inflation (indefinite) form is refused by both surfaces with 
   expect_true(all(is.finite(raw$naive)))
 
   # Both consumers refuse it under the stated criterion, naming the shared
-  # literal. The matrix is DEEPLY indefinite (lambda_min = -0.56 raw, -48 in
-  # the correlation metric -- measured, far past the noise band), so since
+  # literal. The matrix is DEEPLY indefinite (lambda_min = -0.382 raw, -38.3
+  # in the correlation metric -- measured, far past the noise band), so since
   # M90's partition the criterion says "indefinite" for the honest reason;
   # before M89 both fell to an emergent "indefinite"/NaN door, and between
   # M89 and M90 the criterion hid the model defect under "ill_conditioned".

--- a/tests/testthat/test-axes-scaled-fit.R
+++ b/tests/testthat/test-axes-scaled-fit.R
@@ -1462,6 +1462,53 @@ test_that("AC8: scaling-surface degeneracy refusals nest inside the SE helper's,
 })
 
 
+test_that("M90 AC7: when the two SE arms disagree on the label, the cov2cor arm's literal is the one reported", {
+  # The partition is not congruence-invariant: cov2cor() preserves eigenvalue
+  # SIGNS (Sylvester) but moves the RATIO the partition tests. This probe is
+  # built to split the arms -- a rank-one indefinite matrix at 2x the band
+  # (cov2cor arm: "indefinite") congruence-inflated so the raw lambda_max
+  # explodes and the raw ratio falls inside the band (raw arm:
+  # "ill_conditioned"). Measured before the M90 arm-order inversion: the
+  # helper reported the raw arm's "ill_conditioned" while the scaling
+  # surface said "indefinite" -- the same-literal half of the nestedness
+  # contract dying in the dependent. The cov2cor arm is the arm
+  # axes_scaling_factor() prices, so consulting it first restores pointwise
+  # literal agreement wherever both surfaces refuse.
+  p <- 24L
+  t_ <- sqrt(p * .Machine$double.eps)
+  v <- rep(1 / sqrt(p), p)
+  S <- diag(p) - (1 + 2 * t_) * tcrossprod(v)
+  D <- diag(c(1e4, rep(1, p - 1L)))
+  Sr <- D %*% S %*% D
+  Sr <- (Sr + t(Sr)) / 2
+  nm <- sprintf("i%02d", seq_len(p))
+  dimnames(Sr) <- list(nm, nm)
+
+  # The split is real on this matrix: the two arms genuinely disagree.
+  expect_identical(axes_sigma_degenerate(stats::cov2cor(Sr)), "indefinite")
+  expect_identical(axes_sigma_degenerate(Sr), "ill_conditioned")
+
+  ang <- rep(c(0, 90, 180, 270), each = 6L)
+  scl <- rep(LETTERS[1:8], each = 3L)
+  se <- suppressWarnings(
+    axes_corrected_se(Sr, nm, ang, scl, n = 600,
+                      fit_zeta1 = TRUE, fit_zeta2 = FALSE)
+  )
+  expect_identical(se$reason, "indefinite")
+
+  # And the scaling surface agrees, so the nestedness contract holds with
+  # one literal on a matrix where only the arm order makes that true.
+  d <- axes_se_derivs(ang, scl, NULL, TRUE, FALSE)
+  sf <- suppressWarnings(
+    axes_scaling_factor(Sr, nm, ang, scl, fit_zeta1 = TRUE,
+                        fit_zeta2 = FALSE,
+                        df = p * (p + 1) / 2 - length(d$mats),
+                        baseline_df = p * (p - 1) / 2)
+  )
+  expect_identical(sf$reason, "indefinite")
+})
+
+
 test_that("AC2: the non-finite diagonal doors keep one vocabulary on both surfaces", {
   pp <- probe_octant()
   p <- nrow(pp$sigma)

--- a/tests/testthat/test-axes-scaled-fit.R
+++ b/tests/testthat/test-axes-scaled-fit.R
@@ -383,6 +383,45 @@ test_that("AC1: the factor refuses rather than guessing when its inputs are wron
 })
 
 
+test_that("M90 AC1: a saturated model (df = 0) is refused as 'saturated', not 'indefinite'", {
+  # The deterministic saturated construction (RR18 BC4): p = 3, scales A/A/B
+  # with zeta1 fitted gives q = 6 = p(p+1)/2, so df = 0 and the cval line's
+  # division by df has no chi-square to scale. Before M90 this reached
+  # cval = Inf and reported "indefinite" -- a statement about the user's
+  # model that a saturated model never licenses. The guard sits after the
+  # two df-consistency guards (a df = 0 that does NOT match the derivative
+  # set must still refuse "df_mismatch") and before any matrix computation.
+  S <- matrix(c(1, .5, .3, .5, 1, .4, .3, .4, 1), 3L, 3L)
+  nm <- c("i1", "i2", "i3")
+  dimnames(S) <- list(nm, nm)
+  ang <- c(0, 0, 90)
+  scl <- c("A", "A", "B")
+
+  d <- axes_se_derivs(ang, scl, NULL, TRUE, FALSE)
+  expect_identical(length(d$mats), 6L)  # q = p(p+1)/2: saturated
+
+  expect_warning(
+    got <- axes_scaling_factor(S, nm, ang, scl,
+                               fit_zeta1 = TRUE, fit_zeta2 = FALSE,
+                               df = 0, baseline_df = 3),
+    "could not be computed"
+  )
+  expect_identical(got$reason, "saturated")
+  expect_identical(got$scale, NA_real_)
+  expect_identical(got$baseline, NA_real_)
+
+  # Guard order: a zero df inconsistent with the derivative set is a
+  # df_mismatch, not a saturation -- the df-consistency guards run first.
+  pp <- probe_octant()
+  got <- suppressWarnings(
+    axes_scaling_factor(pp$sigma, pp$names, pp$item_angle, pp$scale,
+                        fit_zeta1 = TRUE, fit_zeta2 = FALSE,
+                        df = 0, baseline_df = nrow(pp$sigma) * (nrow(pp$sigma) - 1) / 2)
+  )
+  expect_identical(got$reason, "df_mismatch")
+})
+
+
 test_that("AC1: lavaan still forms rmsea, cfi and pvalue the way the scaler assumes", {
   skip_if_not_installed("lavaan")
   # The scaler does not re-derive lavaan's fit indices -- it recomputes them

--- a/tests/testthat/test-axes-scaled-fit.R
+++ b/tests/testthat/test-axes-scaled-fit.R
@@ -1608,7 +1608,7 @@ test_that("AC2/AC3: the committed exemplar B is refused by both surfaces at p = 
 })
 
 
-test_that("M90 AC5: the cval backstop is not reached by criterion-accepted draws; the known negative-cval matrix is refused upstream", {
+test_that("M90 AC5: criterion-accepted draws from the most cancellable recorded family never reach the backstop", {
   # Smoke tier of the recorded AC5 search (work log: 30,000 accepted draws
   # spanning p in {3, 8, 24} + adversarial hill-climbs, 0 reaches, nearest
   # miss cval = +1.2e-5 at p = 3 / df = 1 -- the one map family whose cval
@@ -1633,12 +1633,14 @@ test_that("M90 AC5: the cval backstop is not reached by criterion-accepted draws
     expect_true(got$scale > 0, label = sprintf("accepted draw %d cval > 0", i))
   }
   expect_gt(n_acc, 100L)  # the smoke family actually exercised acceptance
+})
 
-  # The upstream guard fires on the strongest known candidate: exemplar B is
-  # the one matrix measured to produce cval < 0 in doubles (true cval
-  # +0.0556, RR18), and the degeneracy criterion -- not the backstop --
-  # is what refuses it. Asserted at the criterion itself, so the refusal's
-  # identity is pinned, not inferred from a shared literal.
+
+test_that("M90 AC5: the one recorded negative-cval matrix is refused by the criterion, not the backstop", {
+  # Exemplar B is the one matrix on record measured to compute cval < 0 in
+  # doubles (true cval +0.0556, RR18), and the degeneracy criterion -- not
+  # the backstop -- is what refuses it. Asserted at the criterion itself, so
+  # the refusal's identity is pinned, not inferred from a shared literal.
   fp <- test_path("..", "..", "cairn", "reviews", "rb18-counterexample-b.rds")
   skip_if_not(file.exists(fp), "cairn/ fixture absent (installed package)")
   fx <- readRDS(fp)
@@ -1654,7 +1656,7 @@ test_that("M90 AC5: the backstop's own literal is 'ill_conditioned' (branch WIRI
   # the door it is really refused at and lands in the final backstop. The
   # unmocked path is pinned by the smoke test above (accepted draws never
   # get here) and by the exemplar-B criterion assertion; this test pins the
-  # literal the backstop itself emits — a literal the recorded search found
+  # literal the backstop itself emits -- a literal the recorded search found
   # no accepted input reaching (never "unreachable"; see the backstop
   # comment). Under the stub the backstop is the only remaining site in this
   # function that can emit this literal, so the assertion is site-exclusive.


### PR DESCRIPTION
Splits the fitted-matrix refusal vocabulary in `axes_reliability()`'s two consumers: a decisively indefinite fitted correlation structure reports "indefinite" (a statement about the model), roundoff-level negativity / singularity / ill-conditioning report "ill_conditioned" (a numerical caution); a saturated model (df = 0) is refused as "saturated" before any scaling arithmetic; the final scaling-factor backstop stops claiming indefiniteness it cannot diagnose; and when the SE helper's two arms disagree on the label, the correlation-metric arm's literal is the one reported, keeping the two surfaces in exact agreement.

Milestone: cairn/milestones/M90-degeneracy-reason-vocabulary.md (RR18 BC4-BC6 + replan-audit repairs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)