### PR TITLE
Run the FIML saturated-stage EM unaccelerated, fixing the Windows-only refusals

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,10 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    # hotfix-windows-fiml-em is TEMPORARY: this hotfix fixes a Windows-only
-    # test failure, so its evidence needs the full matrix pre-merge; the
-    # branch entry is reverted before merge.
-    branches: [main, master, hotfix-windows-fiml-em]
+    branches: [main, master]
     paths-ignore:
       - 'cairn/**'
       - 'man/**'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,7 +2,10 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    # hotfix-windows-fiml-em is TEMPORARY: this hotfix fixes a Windows-only
+    # test failure, so its evidence needs the full matrix pre-merge; the
+    # branch entry is reverted before merge.
+    branches: [main, master, hotfix-windows-fiml-em]
     paths-ignore:
       - 'cairn/**'
       - 'man/**'

--- a/NEWS.md
+++ b/NEWS.md
@@ -890,6 +890,20 @@ plotting layer has been rebuilt on a real ggplot2 coordinate system.
 
 ## Bug fixes
 
+* `axes_reliability(missing = "fiml")` no longer refuses, on Windows only,
+  data it estimates on other platforms. The saturated-stage EM that estimates
+  the standardizing moments now always runs unaccelerated: lavaan 0.7 defaults
+  that stage to SQUAREM acceleration, whose convergence on items with very few
+  observed responses proved platform-sensitive — an item observed 20 times out
+  of 300 estimated cleanly on macOS and Linux but stalled at any iteration cap
+  on Windows, so the same data raised "The saturated (EM) stage did not
+  converge" on one platform and not the others. The package's iteration cap
+  was calibrated under the unaccelerated EM, so this restores the measured
+  regime rather than adding a new one. Estimates on data with such
+  thinly-observed items may shift within the EM's own convergence tolerance
+  (differences on the order of 1e-3 in the estimated moments); healthy data is
+  unaffected in both value and speed.
+
 * `norm_standardize()`'s refusal of an off-metric normative sample now names
   the offending scales for every instrument. On the seven instruments whose
   normative data labels its scale column `Abbrev` rather than `Scale`, the

--- a/R/axes_fiml.R
+++ b/R/axes_fiml.R
@@ -63,10 +63,23 @@ axes_fiml_em_iter_max <- 50000L
 # and lavaan's own default applies -- the EM then stalls sooner on thin data and
 # the refusals below fire, which is a conservative failure rather than a wrong
 # number.
+#
+# Acceleration is pinned OFF wherever lavaan offers it (the 0.7 nested
+# spelling; 0.6 has no such option and iterates plainly already). lavaan 0.7
+# defaults the saturated-stage EM to SQUAREM acceleration, whose convergence
+# on thinly-covered cells proved platform-sensitive: the 20/300-coverage cell
+# the M65-D4 tests ride converged under acceleration on macOS and Linux but
+# stalled at ANY cap on Windows, so FIML refused data it is documented to
+# estimate, on one platform only. The 50000 cap and every measurement above
+# were made under the plain EM, so the pin restores the calibrated regime
+# rather than adding a new one; the cost on healthy data is nil (0.1-0.3 s
+# either way, measured above), and at thin cells the plain iterate sits in the
+# same EM-tolerance neighborhood as the accelerated one (max moment difference
+# 1.9e-3 on the 20/300 cell, measured 2026-08-17).
 axes_fiml_em_args <- function(cap = axes_fiml_em_iter_max) {
   opts <- names(lavaan::lavOptions())
   if ("em.h1.args" %in% opts) {
-    list(em.h1.args = list(max_iter = cap))
+    list(em.h1.args = list(max_iter = cap, acceleration = "none"))
   } else if ("em.h1.iter.max" %in% opts) {
     list(em.h1.iter.max = cap)
   } else {

--- a/tests/testthat/test-axes-fiml.R
+++ b/tests/testthat/test-axes-fiml.R
@@ -674,9 +674,15 @@ test_that("M65-D4: the EM cap is a backstop, not a routine limit", {
   mat <- fx$mat
   mat[21:nrow(mat), fx$cols[[1]]] <- NA_real_
   expect_true(axes_fiml_h1(as.data.frame(mat))$converged)
-  # ... and the constant is load-bearing rather than decorative -- but WHERE it
-  # is load-bearing turns out to depend on the lavaan installed, so the probe
-  # below asserts a different thing on each and never nothing on either.
+  # ... and the constant is load-bearing rather than decorative: at the plain
+  # EM this package now pins (see axes_fiml_em_args), this cell measurably
+  # stalls at lavaan's default cap of 500 and converges with room at the raised
+  # cap, on every platform and lavaan generation alike. This assertion was
+  # version-conditional while the package rode lavaan 0.7's SQUAREM default
+  # (which reached tolerance inside 500 here on macOS/Linux but stalled at any
+  # cap on Windows -- the CI failure the acceleration pin exists to fix); with
+  # the acceleration pinned off, the M65-D4 measurement is the behavior
+  # everywhere, so it is asserted unconditionally.
   expect_gt(axes_fiml_em_iter_max, 500L)
   stalled <- FALSE
   withCallingHandlers(
@@ -690,16 +696,26 @@ test_that("M65-D4: the EM cap is a backstop, not a routine limit", {
       invokeRestart("muffleWarning")
     }
   )
-  # lavaan 0.7 accelerates the h1 EM (SQUAREM by default); 0.6 iterates plainly.
-  # On 0.6 the default cap of 500 refuses this estimable cell, which is the
-  # measurement M65-D4 rests on. On 0.7 the acceleration reaches tolerance well
-  # inside 500 and the cap is doing nothing here -- so assert that, rather than
-  # asserting a 0.6 fact on a 0.7 machine or quietly skipping. The cap is
-  # retained on both: it costs nothing when the EM exits on tolerance, and 0.7's
-  # acceleration is not uniformly faster (it fails to converge at all on the
-  # near-singular cell the M60 re-assertion used to build).
-  accelerated <- "acceleration" %in% names(lavaan::lavOptions()$em.h1.args)
-  expect_identical(stalled, !accelerated)
+  expect_true(stalled)
+})
+
+test_that("the h1 EM runs unaccelerated wherever lavaan offers acceleration", {
+  skip_if_not_installed("lavaan")
+  # Regression test for the Windows CI failure (red since the FIML feature
+  # merged): lavaan 0.7 defaults its saturated-stage EM to SQUAREM
+  # acceleration, whose convergence on thinly-covered cells is
+  # platform-sensitive -- the 20/300 cell above converged under acceleration on
+  # macOS and Linux but stalled at ANY cap on Windows, so FIML refused data it
+  # is documented to estimate, on one platform only. The 50000 cap and every
+  # measurement justifying it (M65-D4) were made under the plain EM, so the
+  # args pin acceleration off wherever the option exists; lavaan 0.6 has no
+  # such option and iterates plainly already.
+  args <- axes_fiml_em_args(500L)
+  if ("em.h1.args" %in% names(lavaan::lavOptions())) {
+    expect_identical(args$em.h1.args$acceleration, "none")
+  } else {
+    expect_named(args, "em.h1.iter.max")
+  }
 })
 
 test_that("M65-D5: the EM cap is spelled for the lavaan actually installed", {


### PR DESCRIPTION
Master's R-CMD-check Windows job has failed on every push since the FIML feature merged (PR #91, 2026-07-27): five failures in `test-axes-fiml.R`, all the saturated (EM) stage failing to converge on fixtures the same lavaan 0.7-2 estimates cleanly on macOS and Linux.

**Cause:** lavaan 0.7 defaults the saturated-stage EM to SQUAREM acceleration. Its convergence on thinly-covered items is platform-sensitive — the 20/300-coverage cell the M65-D4 tests ride stalled at any iteration cap on Windows while converging inside 500 iterations elsewhere — so `axes_reliability(missing = "fiml")` refused, on Windows only, data it is documented to estimate.

**Fix:** `axes_fiml_em_args()` now pins `acceleration = "none"` wherever lavaan offers the option. The 50000-iteration cap and every measurement justifying it were made under the plain EM (the calibrated 0.35 s convergence on the 20/300 cell reproduces exactly), so this restores the measured regime rather than adding a new one. lavaan 0.6 has no acceleration option and iterates plainly already — no-op there.

**Regression tests:** the M65-D4 stall-at-500 assertion, previously conditional on the lavaan generation, is now unconditional (plain EM measurably stalls at 500 everywhere) and failed against the unfixed code; a new wiring test asserts the acceleration pin. The Windows CI job on this PR is the platform half of the evidence.

**Numeric note:** at thin-coverage cells the plain iterate sits in the same EM-tolerance neighborhood as the accelerated one (max moment difference 1.9e-3 measured on the 20/300 cell); healthy data is unaffected in value and speed. NEWS entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)