### PR TITLE
M97: Make the contributor docs describe this repo

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,12 +5,10 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^LICENSE\.md$
-^\.travis\.yml$
 ^cran-comments\.md$
 ^codecov\.yml$
 ^README\.Rmd$
 ^README-.*\.png$
-^CONDUCT\.md$
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,25 +1,126 @@
-# Contributor Code of Conduct
+# Contributor Covenant Code of Conduct
 
-As contributors and maintainers of this project, we pledge to respect all people who 
-contribute through reporting issues, posting feature requests, updating documentation,
-submitting pull requests or patches, and other activities.
+## Our Pledge
 
-We are committed to making participation in this project a harassment-free experience for
-everyone, regardless of level of experience, gender, gender identity and expression,
-sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
 
-Examples of unacceptable behavior by participants include the use of sexual language or
-imagery, derogatory comments or personal attacks, trolling, public or private harassment,
-insults, or other unprofessional conduct.
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments,
-commits, code, wiki edits, issues, and other contributions that are not aligned to this 
-Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed 
-from the project team.
+## Our Standards
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by 
-opening an issue or contacting one or more of the project maintainers.
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-This Code of Conduct is adapted from the Contributor Covenant 
-(https://www.contributor-covenant.org), version 1.0.0, available at 
-https://contributor-covenant.org/version/1/0/0/.
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at me@jmgirard.com. 
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][https://github.com/mozilla/inclusion].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,13 +26,17 @@ agree the change is wanted before you spend time on it:
 ### Pull request process
 
 *  We recommend that you create a Git branch for each pull request (PR).  
-*  Look at the Travis and AppVeyor build status before and after making changes.
-The `README` should contain badges for any continuous integration services used
-by the package.  
-*  New code should follow the tidyverse [style guide](https://style.tidyverse.org).
-You can use the [styler](https://CRAN.R-project.org/package=styler) package to
-apply these styles, but please don't restyle code that has nothing to do with 
-your PR.  
+*  Pull requests are checked by the `R-CMD-check.yaml` GitHub Actions workflow.
+A PR touching `R/`, `src/`, `tests/`, `vignettes/`, `data/`, `inst/`,
+`DESCRIPTION` or `NAMESPACE` runs `R CMD check` on Windows, macOS and Ubuntu;
+any other PR gets a single Ubuntu job. Check that it is green before and after
+your changes. (Pushes to `master` run a wider matrix that adds R-devel and
+oldrel.) `README.md` carries a badge for this workflow and for the coverage and
+pkgdown ones.  
+*  New code should match existing code style. This package is base R with
+minimal dependencies and no automatic formatter is run over it, so follow the
+conventions of the file you are editing, and please don't restyle code that has
+nothing to do with your PR.  
 *  We use [roxygen2](https://cran.r-project.org/package=roxygen2), with
 [Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/markdown.html), 
 for documentation.  

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -38,25 +38,27 @@ agree the change is wanted before you spend time on it:
 ### Pull request process
 
 *  We recommend that you create a Git branch for each pull request (PR).  
-*  Pull requests are checked by the `R-CMD-check.yaml` GitHub Actions workflow.
-A PR touching `R/`, `src/`, `tests/`, `vignettes/`, `data/`, `inst/`,
-`DESCRIPTION` or `NAMESPACE` runs `R CMD check` on Windows, macOS and Ubuntu;
-any other PR gets a single Ubuntu job. Check that it is green before and after
-your changes. (Pushes to `master` run a wider matrix that adds R-devel and
-oldrel.) `README.md` carries a badge for this workflow and for the coverage and
-pkgdown ones.  
-*  New code should match existing code style. This package is base R with
-minimal dependencies and no automatic formatter is run over it, so follow the
-conventions of the file you are editing, and please don't restyle code that has
-nothing to do with your PR.  
+*  Pull requests are checked by GitHub Actions: `R-CMD-check.yaml` runs
+`R CMD check`, and `pkgdown.yaml` rebuilds the documentation site. How wide the
+check matrix goes depends on which paths your PR touches — `tools/ci-matrix.R`
+holds that rule and the platform list. A PR touching only tracking files,
+`man/`, or `README.md` may not trigger a check run at all. Please make sure
+whatever does run is green before and after your changes.  
+*  `README.md` carries badges for these workflows. Note that the coverage badge
+tracks `master`, not your PR.  
+*  New code should match existing code style. This package keeps to base-R
+style with few dependencies (its numeric core is C++ via Rcpp), and no
+automatic formatter is run over it, so follow the conventions of the file you
+are editing, and please don't restyle code that has nothing to do with your PR.  
 *  We use [roxygen2](https://cran.r-project.org/package=roxygen2), with
 [Markdown syntax](https://roxygen2.r-lib.org/articles/rd-formatting.html), 
 for documentation.  
 *  We use [testthat](https://cran.r-project.org/package=testthat). Contributions
 with test cases included are easier to accept.  
-*  For user-facing changes, add a bullet to the top of `NEWS.md` below the
-current development version header describing the changes made followed by your
-GitHub username, and links to relevant issue(s)/PR(s).
+*  For user-facing changes, add a bullet at the top of `NEWS.md` — under the
+development-version heading if one is open, otherwise above the most recent
+release heading — describing the change, followed by your GitHub username and
+links to the relevant issue(s)/PR(s).
 
 ### Code of Conduct
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,7 +50,7 @@ minimal dependencies and no automatic formatter is run over it, so follow the
 conventions of the file you are editing, and please don't restyle code that has
 nothing to do with your PR.  
 *  We use [roxygen2](https://cran.r-project.org/package=roxygen2), with
-[Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/markdown.html), 
+[Markdown syntax](https://roxygen2.r-lib.org/articles/rd-formatting.html), 
 for documentation.  
 *  We use [testthat](https://cran.r-project.org/package=testthat). Contributions
 with test cases included are easier to accept.  

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,6 +12,18 @@ the GitHub web interface, so long as the changes are made in the _source_ file.
 *  YES: you edit a roxygen comment in a `.R` file below `R/`.
 *  NO: you edit an `.Rd` file below `man/`.
 
+### Generated files
+
+Some files in this repository are generated, and a hand edit to one is
+overwritten the next time it is rebuilt. Never edit these directly — change the
+source and regenerate:
+
+*  `man/*.Rd` and `NAMESPACE` — regenerate with `devtools::document()` after
+changing a roxygen comment.  
+*  `R/RcppExports.R` and `src/RcppExports.cpp` — regenerate with
+`Rcpp::compileAttributes()` after changing anything below `src/`.  
+*  `README.md` — knitted from `README.Rmd` by `devtools::build_readme()`.  
+
 ### Prerequisites
 
 Before you make a substantial pull request, please raise it first, so we can

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to circumplex
 
-This outlines how to propose a change to circumplex. For more detailed
-info about contributing to this, and other tidyverse packages, please see the
-[**development contributing guide**](https://rstd.io/tidy-contrib).
+This outlines how to propose a change to circumplex. The package is maintained
+by one person, so the surest route to a merged change is to agree on the
+problem before you write the fix.
 
 ### Fixing typos
 
@@ -14,10 +14,14 @@ the GitHub web interface, so long as the changes are made in the _source_ file.
 
 ### Prerequisites
 
-Before you make a substantial pull request, you should always file an issue and
-make sure someone from the team agrees that it’s a problem. If you’ve found a
-bug, create an associated issue and illustrate the bug with a minimal 
-[reprex](https://www.tidyverse.org/help/#reprex).
+Before you make a substantial pull request, please raise it first, so we can
+agree the change is wanted before you spend time on it:
+
+*  A bug → open an
+   [issue](https://github.com/jmgirard/circumplex/issues) illustrating it with a
+   minimal [reprex](https://reprex.tidyverse.org/).
+*  A feature idea, or a question about how something works → open a
+   [discussion](https://github.com/jmgirard/circumplex/discussions).
 
 ### Pull request process
 
@@ -43,6 +47,3 @@ GitHub username, and links to relevant issue(s)/PR(s).
 Please note that the circumplex project is released with a
 [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this
 project you agree to abide by its terms.
-
-### See tidyverse [development contributing guide](https://rstd.io/tidy-contrib)
-for further details.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
-Please briefly describe your problem and what output you expect. If you have a question, please don't use this form. Instead, ask on <https://stackoverflow.com/> or <https://community.rstudio.com/>.
+Please briefly describe your problem and what output you expect. If you have a question rather than a bug to report, please don't use this form — open a [discussion](https://github.com/jmgirard/circumplex/discussions) instead.
 
-Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](https://reprex.tidyverse.org/) before, start by reading <https://www.tidyverse.org/help/#reprex>.
+Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](https://reprex.tidyverse.org/) before, start there.
 
 ---
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,35 +1,30 @@
 # Getting help with circumplex
 
-Thanks for using circumplex. Before filing an issue, there are a few places
-to explore and pieces to put together to make the process as smooth as possible.
+Thanks for using circumplex. Before filing an issue, there are a few places to
+explore and pieces to put together to make the process as smooth as possible.
 
-Start by making a minimal **repr**oducible **ex**ample using the 
-[reprex](https://reprex.tidyverse.org/) package. If you haven't heard of or used 
-reprex before, you're in for a treat! Seriously, reprex will make all of your 
-R-question-asking endeavors easier (which is a pretty insane ROI for the five to 
-ten minutes it'll take you to learn what it's all about). For additional reprex
-pointers, check out the [Get help!](https://www.tidyverse.org/help/) section of
-the tidyverse site.
+Start by making a minimal **repr**oducible **ex**ample using the
+[reprex](https://reprex.tidyverse.org/) package. A reprex lets someone else see
+exactly what you are seeing, and often surfaces the answer while you build it.
 
-Armed with your reprex, the next step is to figure out [where to ask](https://www.tidyverse.org/help/#where-to-ask). 
+Armed with your reprex, pick where to ask:
 
-  * If it's a question: start with [community.rstudio.com](https://community.rstudio.com/), 
-    and/or StackOverflow. There are more people there to answer questions.  
-  * If it's a bug: you're in the right place, file an issue.  
-  * If you're not sure: let the community help you figure it out! If your 
-    problem _is_ a bug or a feature request, you can easily return here and 
-    report it. 
+  * **A question** — how a function works, which method suits your data, how to
+    read a result: open a
+    [discussion](https://github.com/jmgirard/circumplex/discussions).
+  * **A bug** — something the package does that it clearly should not:
+    you're in the right place,
+    [file an issue](https://github.com/jmgirard/circumplex/issues).
+  * **Not sure which?** Start a discussion. If it turns out to be a bug, it can
+    be moved to an issue from there.
 
-Before opening a new issue, be sure to [search issues and pull requests](https://github.com/tidyverse/circumplex/issues) to make sure the 
-bug hasn't been reported and/or already fixed in the development version. By 
-default, the search will be pre-populated with `is:issue is:open`. You can 
-[edit the qualifiers](https://help.github.com/articles/searching-issues-and-pull-requests/) 
-(e.g. `is:pr`, `is:closed`) as needed. For example, you'd simply
-remove `is:open` to search _all_ issues in the repo, open or closed.
-
-
-If you _are_ in the right place, and need to file an issue, please review the 
-["File issues"](https://www.tidyverse.org/contribute/#issues) paragraph from 
-the tidyverse contributing guidelines.
+Before opening a new issue, please
+[search the issues and pull requests](https://github.com/jmgirard/circumplex/issues)
+to check that the problem hasn't already been reported, or already fixed in the
+development version. By default that search is pre-populated with
+`is:issue is:open`; you can
+[edit the qualifiers](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests)
+(e.g. `is:pr`, `is:closed`) as needed — removing `is:open` searches all issues,
+open or closed.
 
 Thanks for your help!

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -15,7 +15,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M94 | Print the fired-marker list on the bootstrap path | done | — | normal | milestones/archive/M94-bootstrap-marker-list.md |
 | M95 | Stop running the suite twice on every pull request | done | — | normal | milestones/archive/M95-ci-trigger-economy.md |
 | M96 | Say something when master goes red | done | M95 | normal | milestones/archive/M96-master-red-alert.md |
-| M97 | Make the contributor docs describe this repo | in-progress | — | normal | milestones/M97-contributor-docs-refresh.md |
+| M97 | Make the contributor docs describe this repo | review | — | normal | milestones/M97-contributor-docs-refresh.md |
 
 ## Candidates
 

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -15,7 +15,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M94 | Print the fired-marker list on the bootstrap path | done | — | normal | milestones/archive/M94-bootstrap-marker-list.md |
 | M95 | Stop running the suite twice on every pull request | done | — | normal | milestones/archive/M95-ci-trigger-economy.md |
 | M96 | Say something when master goes red | done | M95 | normal | milestones/archive/M96-master-red-alert.md |
-| M97 | Make the contributor docs describe this repo | planned | — | normal | milestones/M97-contributor-docs-refresh.md |
+| M97 | Make the contributor docs describe this repo | in-progress | — | normal | milestones/M97-contributor-docs-refresh.md |
 
 ## Candidates
 

--- a/cairn/milestones/M97-contributor-docs-refresh.md
+++ b/cairn/milestones/M97-contributor-docs-refresh.md
@@ -113,7 +113,7 @@ GitHub renders them, and act on what they say.
       help links (L3).
 - [x] **T6** — CODE_OF_CONDUCT.md: replace with Contributor Covenant 2.1;
       enforcement contact = DESCRIPTION's `cre` email.
-- [ ] **T7** — Delete the two dead `.Rbuildignore` entries (L8, L13); confirm
+- [x] **T7** — Delete the two dead `.Rbuildignore` entries (L8, L13); confirm
       `devtools::check()` is unaffected.
 - [ ] **T8** — Run and log the AC4 pre/post sweep, the AC5 host enumeration, and
       the AC6 status probes; check tail bytes of every rewritten file
@@ -135,6 +135,7 @@ GitHub renders them, and act on what they say.
 - 2026-08-19: T5 — ISSUE_TEMPLATE.md's question venues (StackOverflow, community.rstudio.com) replaced by this repo's Discussions; the tidyverse help pointer dropped and the reprex link repointed to `reprex.tidyverse.org`.
 - 2026-08-19: **amendment (substantive), AC7** — the pinned source `https://www.contributor-covenant.org/version/2/1/code_of_conduct.md` returns HTTP 404 (a 3449-byte "Page not found" page), making AC7 unsatisfiable as planned. Amended at a mini gate to the usethis 3.2.1 bundled template, which Jeff confirms is where these files originally came from; the upstream raw markdown was rejected as the pin because it carries a Hugo TOML front-matter block and unwrapped lines, so a shipped copy would differ from it on nearly every line. Amended wording was audited first by a fresh-context [O] reader that did not author it, returning four findings, all applied: the normative reference was machine-local (deliverable SHA now the primary check, template SHA inline as provenance); "the placeholder carries the email" was backwards; the `grep -F` probe was location-free and was dropped; and "exactly one changed line" silently rode two coincidences now named in the criterion (both strings are 15 characters, and template line 62 is the file's only line ending in a trailing space).
 - 2026-08-19: T6 — CODE_OF_CONDUCT.md replaced (Contributor Covenant 1.0.0, 1396 bytes, no enforcement contact → 2.1 with `me@jmgirard.com`). AC7 verified independently in-session: template SHA-256 `e45d34f5…a499a`, deliverable SHA-256 `4828e2a2…1b87f4`, `diff` output exactly `62c62`, line 62's trailing space present in `od -c`, and the text's own 2.1 attribution at line 118.
+- 2026-08-19: T7 — the two dead `.Rbuildignore` entries deleted. Both verified dead first: no top-level file matches either pattern, and `.travis.yml`/`CONDUCT.md` were last touched in the pre-cairn Travis era (a95585ab, 34592d96, d685b51a). `R CMD build` succeeds afterwards and the tarball still excludes `.github`, `cairn`, `tools` and `devel`.
 
 ## Decisions
 

--- a/cairn/milestones/M97-contributor-docs-refresh.md
+++ b/cairn/milestones/M97-contributor-docs-refresh.md
@@ -103,7 +103,7 @@ GitHub renders them, and act on what they say.
 - [x] **T4** — SUPPORT.md: fix the issue-search link (L23) to DESCRIPTION's
       `BugReports:` value; replace the tidyverse help venues (L11, L14, L16,
       L32) and framing; keep reprex.
-- [ ] **T5** — ISSUE_TEMPLATE.md: replace the stale question venues (L1) and
+- [x] **T5** — ISSUE_TEMPLATE.md: replace the stale question venues (L1) and
       help links (L3).
 - [ ] **T6** — CODE_OF_CONDUCT.md: replace with Contributor Covenant 2.1;
       enforcement contact = DESCRIPTION's `cre` email.
@@ -126,6 +126,7 @@ GitHub renders them, and act on what they say.
 - 2026-08-19: T2 — PR-process section rewritten; AC1 probes green (`R-CMD-check.yaml` 1 match, `match existing code style` 1 match, workflow file present). The CI sentence was first drafted as "every pull request ... across several platforms and R versions" and corrected against `tools/ci-matrix.R:23-38`: only a PR touching the escalation set gets the three release platforms, any other PR gets one Ubuntu job, and the five-config matrix with R-devel/oldrel is the push-to-master matrix.
 - 2026-08-19: T3 — "Generated files" section added after "Fixing typos"; AC2 probes green (all six strings >=1 match: `R/RcppExports.R` 1, `src/RcppExports.cpp` 1, `man/*.Rd` 1, `NAMESPACE` 2, `devtools::document()` 1, `Rcpp::compileAttributes()` 1). README.md/README.Rmd added as a third generated pair from PROFILE.md's consistency-gate slot.
 - 2026-08-19: T4 — SUPPORT.md rewritten around this repo's own venues (Discussions for questions, Issues for bugs). AC3 probe green: the only `github.com/<owner>/circumplex` URLs are `jmgirard/...discussions` and `jmgirard/...issues`, and the issue-search link's origin-plus-path string-equals DESCRIPTION's `BugReports:` value with no query. The wrong-repo link (`github.com/tidyverse/circumplex/issues`) and the four tidyverse help venues are gone; the stale `help.github.com` qualifier link was repointed to `docs.github.com`.
+- 2026-08-19: T5 — ISSUE_TEMPLATE.md's question venues (StackOverflow, community.rstudio.com) replaced by this repo's Discussions; the tidyverse help pointer dropped and the reprex link repointed to `reprex.tidyverse.org`.
 
 ## Decisions
 

--- a/cairn/milestones/M97-contributor-docs-refresh.md
+++ b/cairn/milestones/M97-contributor-docs-refresh.md
@@ -100,7 +100,7 @@ GitHub renders them, and act on what they say.
       styler/style-guide bullet (L28-31) with CLAUDE.md's rule.
 - [x] **T3** — CONTRIBUTING.md: add the generated-files section (four paths, two
       regeneration commands), extending the `man/` warning at L12-13.
-- [ ] **T4** — SUPPORT.md: fix the issue-search link (L23) to DESCRIPTION's
+- [x] **T4** — SUPPORT.md: fix the issue-search link (L23) to DESCRIPTION's
       `BugReports:` value; replace the tidyverse help venues (L11, L14, L16,
       L32) and framing; keep reprex.
 - [ ] **T5** — ISSUE_TEMPLATE.md: replace the stale question venues (L1) and
@@ -125,6 +125,7 @@ GitHub renders them, and act on what they say.
 - 2026-08-19: T1 — CONTRIBUTING.md framing, prerequisites, and closing section rewritten: the tidy-contrib pointers (L3-5, L47-48) removed, the "someone from the team" prerequisite replaced by an issue-for-bugs / discussion-for-features split (Discussions is enabled and in live use, 2 threads), and the reprex link repointed from `www.tidyverse.org/help/#reprex` to `reprex.tidyverse.org` (AC5's sole permitted exception).
 - 2026-08-19: T2 — PR-process section rewritten; AC1 probes green (`R-CMD-check.yaml` 1 match, `match existing code style` 1 match, workflow file present). The CI sentence was first drafted as "every pull request ... across several platforms and R versions" and corrected against `tools/ci-matrix.R:23-38`: only a PR touching the escalation set gets the three release platforms, any other PR gets one Ubuntu job, and the five-config matrix with R-devel/oldrel is the push-to-master matrix.
 - 2026-08-19: T3 — "Generated files" section added after "Fixing typos"; AC2 probes green (all six strings >=1 match: `R/RcppExports.R` 1, `src/RcppExports.cpp` 1, `man/*.Rd` 1, `NAMESPACE` 2, `devtools::document()` 1, `Rcpp::compileAttributes()` 1). README.md/README.Rmd added as a third generated pair from PROFILE.md's consistency-gate slot.
+- 2026-08-19: T4 — SUPPORT.md rewritten around this repo's own venues (Discussions for questions, Issues for bugs). AC3 probe green: the only `github.com/<owner>/circumplex` URLs are `jmgirard/...discussions` and `jmgirard/...issues`, and the issue-search link's origin-plus-path string-equals DESCRIPTION's `BugReports:` value with no query. The wrong-repo link (`github.com/tidyverse/circumplex/issues`) and the four tidyverse help venues are gone; the stale `help.github.com` qualifier link was repointed to `docs.github.com`.
 
 ## Decisions
 

--- a/cairn/milestones/M97-contributor-docs-refresh.md
+++ b/cairn/milestones/M97-contributor-docs-refresh.md
@@ -1,11 +1,11 @@
 # M97: Make the contributor docs describe this repo
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** GP3
-- **Branch/PR:** —
+- **Branch/PR:** `m97-contributor-docs-refresh`
 
 ## Goal
 
@@ -121,6 +121,7 @@ GitHub renders them, and act on what they say.
 - 2026-08-19: plan gate chose hand-run, logged sweeps over a committed testthat fence because a checker over these docs can only fence recalled literals, not stale advice (the D-090 shape; the M96 lesson that a guard proving a negative over an open-ended grammar "loses to the next construct"); falsified by a post-merge reintroduction of any retired literal that a reviewer misses.
 - 2026-08-19: plan gate chose a full rewrite over a minimal edit of the false claims alone, because the audit showed a minimal edit leaves the stale claim standing in paraphrase (a "check the CI services listed in the README" rewrite passes every literal grep); falsified by the rewrite introducing a new inaccuracy the greps cannot see.
 - 2026-08-19: plan chose deleting the dead `.Rbuildignore` entries over exempting `.Rbuildignore` from AC4's sweep, because the entries name files that do not exist and cannot return; falsified by either pattern turning out to still match something `R CMD build` needs excluded.
+- 2026-08-19: implement session started; branch `m97-contributor-docs-refresh` cut from pushed master (908b65e0), tree clean.
 
 ## Decisions
 

--- a/cairn/milestones/M97-contributor-docs-refresh.md
+++ b/cairn/milestones/M97-contributor-docs-refresh.md
@@ -150,4 +150,88 @@ GitHub renders them, and act on what they say.
 
 ## Decisions
 
+- 2026-08-19 (AC7 source pin): Contributor Covenant 2.1 is taken from usethis
+  3.2.1's bundled template, not from contributor-covenant.org. The planned URL
+  404s, and the upstream raw markdown carries a Hugo TOML front-matter block and
+  unwrapped lines, so a shipped copy could not be diffed against it meaningfully.
+  usethis is also where these `.github/` files originally came from (Jeff,
+  2026-08-19). Reopens if usethis stops bundling 2.1, or if the contact changes.
+- 2026-08-19 (AC6 exemption): `.github/CODE_OF_CONDUCT.md:121`'s `[text][url]`
+  reference link is malformed verbatim upstream and unmodifiable under AC7's
+  byte pin, so it is exempt from the URL probe rather than repaired; its target
+  `https://github.com/mozilla/inclusion` was probed by hand (200). A URL failing
+  elsewhere in that vendored file is raised here as a decision, never silently
+  edited. Reopens if upstream repairs the line.
+
 ## Review
+
+**PR:** [#126](https://github.com/jmgirard/circumplex/pull/126) · reviewed 2026-08-19.
+
+**Acceptance criteria — fresh evidence** (all re-derived at review; implement had
+pre-ticked the boxes, so every one was re-run independently here):
+
+- AC1 — `grep -F` over the PR-process section alone: `R-CMD-check.yaml` 1 match,
+  `match existing code style` 1 match; `R-CMD-check.yaml` present in
+  `.github/workflows/`. Re-run after the gate's fix-now rewrite: still 1 and 1.
+- AC2 — all six strings >=1 match in `.github/CONTRIBUTING.md` (`R/RcppExports.R`
+  1, `src/RcppExports.cpp` 1, `man/*.Rd` 1, `NAMESPACE` 2, `devtools::document()`
+  1, `Rcpp::compileAttributes()` 1).
+- AC3 — the only `github.com/<owner>/circumplex` URLs in `SUPPORT.md` are
+  `jmgirard/…/issues` and `jmgirard/…/discussions`; the issue-search link
+  string-equals `DESCRIPTION`'s `BugReports:`.
+- AC4 — per-literal sweep over `git ls-files` (excl. `NEWS.md`, `cairn/`):
+  pre-change against `master` Travis 2, AppVeyor 1, styler 1,
+  style.tidyverse.org 1, tidy-contrib 1, tidyverse/circumplex 1,
+  community.rstudio.com 2 — every literal >=1, so the instrument discriminates;
+  post-change 0 for all seven.
+- AC5 — hosts in the four files: github.com 7, www.contributor-covenant.org 4,
+  reprex.tidyverse.org 3 (the permitted exception), cran.r-project.org 2,
+  roxygen2.r-lib.org 1, docs.github.com 1. No banned host; the only tidyverse
+  mentions are the three reprex links.
+- AC6 — all 12 http(s) URLs returned 200 on `curl -sIL --max-time 20`; no GET
+  fallback needed. Line 121 exempt per the Decisions entry, its target probed 200.
+- AC7 — template SHA-256 `e45d34f5…a499a`, deliverable SHA-256
+  `4828e2a2…1b87f4`, `diff` output exactly `62c62`, contact present.
+
+**Consistency gate:** `cairn_validate` all checks passed (47 advisory work-log
+warnings, 46 pre-existing on M7). `devtools::document()` no diff, 0
+`resolve link` warnings. README in sync; no generated files touched.
+`pkgdown::check_pkgdown()` no problems. `devtools::check()` **Status: OK** (0
+errors / 0 warnings / 0 notes). `devtools::test()` 8395 pass / 0 fail / 5
+lavaan warnings / 3 skips. Master watches: newest `R-CMD-check.yaml` push
+verdict success, newest `test-coverage.yaml` verdict success (cross-checked
+without `--event` per M96). `tools/check-master-red-alert.R` and
+`tools/master-red-alert-dryrun.R` both exit 0. No principle changed, so
+`cairn_impact` skipped.
+
+**Review — three lenses.** [S] blame-history: no concerning findings; it pinned
+the deleted `.Rbuildignore` entries' provenance (`.travis.yml` removed in
+d7607650, `CONDUCT.md` relocated in cd427514, both pre-cairn) and confirmed
+`^\.github$` already covers the relocated file. [S] prior-PR-comments: one
+finding (the CI escalation set, same defect class M95's review taught in this
+exact file); the `pulls/comments` probe returned `[]`, confirming M91's
+measurement that GitHub threads are empty here. [O] diff-bug: 11 ranked
+findings.
+
+**Findings and disposition** (12 total across lenses; 8 actioned, 4 rejected):
+
+- F1 CI escalation set incomplete (8 of `ESCALATION_SET`'s 11 paths listed,
+  making the "any other PR" clause false), F2 `paths-ignore` means some PRs run
+  no check at all, F3 `pkgdown.yaml` also gates PRs, F4 the prose duplicated CI
+  config literals against `R-CMD-check.yaml:26`'s single-source rule, F9 the
+  coverage badge tracks master since M95 — **fixed now, one rewrite**, at Jeff's
+  direction: the enumeration was removed rather than completed, pointing at
+  `tools/ci-matrix.R` as the source of truth (M93's rule; the M87 lesson that a
+  hand-pinned enumeration of a moving artifact cannot stay true).
+- F5 the two amendments lived only in the work log — **fixed now**: recorded as
+  milestone-local Decisions entries above.
+- F7 the `NEWS.md` bullet instruction referenced a development-version header
+  that does not exist (`# circumplex 2.0.0`, DESCRIPTION 2.0.0) — **fixed now**.
+- F8 "base R with minimal dependencies" could read as "no compiled code" though
+  the package ships `src/` C++ via Rcpp — **fixed now**, phrasing tightened.
+- F6 `CODE_OF_CONDUCT.md:121` renders as literal bracket text — **rejected as a
+  file change** (inherited verbatim from upstream, unmodifiable under AC7) and
+  **declined as a candidate row** at Jeff's selection.
+- F10 "start there" has a weak antecedent, F11 SUPPORT.md dropped the old "File
+  issues" pointer — **rejected**: cosmetic, and F11 is arguably an improvement
+  over a tidyverse-authority link.

--- a/cairn/milestones/M97-contributor-docs-refresh.md
+++ b/cairn/milestones/M97-contributor-docs-refresh.md
@@ -98,7 +98,7 @@ GitHub renders them, and act on what they say.
 - [x] **T2** — CONTRIBUTING.md: rewrite the PR-process section — replace the
       Travis/AppVeyor bullet (L25-27) with the actual workflows, and the
       styler/style-guide bullet (L28-31) with CLAUDE.md's rule.
-- [ ] **T3** — CONTRIBUTING.md: add the generated-files section (four paths, two
+- [x] **T3** — CONTRIBUTING.md: add the generated-files section (four paths, two
       regeneration commands), extending the `man/` warning at L12-13.
 - [ ] **T4** — SUPPORT.md: fix the issue-search link (L23) to DESCRIPTION's
       `BugReports:` value; replace the tidyverse help venues (L11, L14, L16,
@@ -124,6 +124,7 @@ GitHub renders them, and act on what they say.
 - 2026-08-19: implement session started; branch `m97-contributor-docs-refresh` cut from pushed master (908b65e0), tree clean.
 - 2026-08-19: T1 — CONTRIBUTING.md framing, prerequisites, and closing section rewritten: the tidy-contrib pointers (L3-5, L47-48) removed, the "someone from the team" prerequisite replaced by an issue-for-bugs / discussion-for-features split (Discussions is enabled and in live use, 2 threads), and the reprex link repointed from `www.tidyverse.org/help/#reprex` to `reprex.tidyverse.org` (AC5's sole permitted exception).
 - 2026-08-19: T2 — PR-process section rewritten; AC1 probes green (`R-CMD-check.yaml` 1 match, `match existing code style` 1 match, workflow file present). The CI sentence was first drafted as "every pull request ... across several platforms and R versions" and corrected against `tools/ci-matrix.R:23-38`: only a PR touching the escalation set gets the three release platforms, any other PR gets one Ubuntu job, and the five-config matrix with R-devel/oldrel is the push-to-master matrix.
+- 2026-08-19: T3 — "Generated files" section added after "Fixing typos"; AC2 probes green (all six strings >=1 match: `R/RcppExports.R` 1, `src/RcppExports.cpp` 1, `man/*.Rd` 1, `NAMESPACE` 2, `devtools::document()` 1, `Rcpp::compileAttributes()` 1). README.md/README.Rmd added as a third generated pair from PROFILE.md's consistency-gate slot.
 
 ## Decisions
 

--- a/cairn/milestones/M97-contributor-docs-refresh.md
+++ b/cairn/milestones/M97-contributor-docs-refresh.md
@@ -95,7 +95,7 @@ GitHub renders them, and act on what they say.
 - [x] **T1** — CONTRIBUTING.md: rewrite the framing (L3-5, L47-48) and the
       "someone from the team agrees" prerequisite (L17-18) for a
       solo-maintainer, non-tidyverse package.
-- [ ] **T2** — CONTRIBUTING.md: rewrite the PR-process section — replace the
+- [x] **T2** — CONTRIBUTING.md: rewrite the PR-process section — replace the
       Travis/AppVeyor bullet (L25-27) with the actual workflows, and the
       styler/style-guide bullet (L28-31) with CLAUDE.md's rule.
 - [ ] **T3** — CONTRIBUTING.md: add the generated-files section (four paths, two
@@ -123,6 +123,7 @@ GitHub renders them, and act on what they say.
 - 2026-08-19: plan chose deleting the dead `.Rbuildignore` entries over exempting `.Rbuildignore` from AC4's sweep, because the entries name files that do not exist and cannot return; falsified by either pattern turning out to still match something `R CMD build` needs excluded.
 - 2026-08-19: implement session started; branch `m97-contributor-docs-refresh` cut from pushed master (908b65e0), tree clean.
 - 2026-08-19: T1 — CONTRIBUTING.md framing, prerequisites, and closing section rewritten: the tidy-contrib pointers (L3-5, L47-48) removed, the "someone from the team" prerequisite replaced by an issue-for-bugs / discussion-for-features split (Discussions is enabled and in live use, 2 threads), and the reprex link repointed from `www.tidyverse.org/help/#reprex` to `reprex.tidyverse.org` (AC5's sole permitted exception).
+- 2026-08-19: T2 — PR-process section rewritten; AC1 probes green (`R-CMD-check.yaml` 1 match, `match existing code style` 1 match, workflow file present). The CI sentence was first drafted as "every pull request ... across several platforms and R versions" and corrected against `tools/ci-matrix.R:23-38`: only a PR touching the escalation set gets the three release platforms, any other PR gets one Ubuntu job, and the five-config matrix with R-devel/oldrel is the push-to-master matrix.
 
 ## Decisions
 

--- a/cairn/milestones/M97-contributor-docs-refresh.md
+++ b/cairn/milestones/M97-contributor-docs-refresh.md
@@ -35,24 +35,24 @@ GitHub renders them, and act on what they say.
 
 ## Acceptance criteria
 
-- [ ] **AC1** — `.github/CONTRIBUTING.md`'s pull-request section names
+- [x] **AC1** — `.github/CONTRIBUTING.md`'s pull-request section names
       `R-CMD-check.yaml` (the workflow that gates PRs) and states CLAUDE.md's
       "match existing code style" rule in place of an external style guide.
       Verified by `grep -F` over the PR-process section for `R-CMD-check.yaml`
       and for `match existing code style` (each ≥1 match), and by confirming
       `R-CMD-check.yaml` is present in `ls .github/workflows/`.
-- [ ] **AC2** — `.github/CONTRIBUTING.md` names all four generated-file paths
+- [x] **AC2** — `.github/CONTRIBUTING.md` names all four generated-file paths
       CLAUDE.md forbids hand-editing (`R/RcppExports.R`, `src/RcppExports.cpp`,
       `man/*.Rd`, `NAMESPACE`) and both regeneration commands
       (`devtools::document()`, `Rcpp::compileAttributes()`). Verified by
       `grep -F` for each of the six strings over that file, each ≥1 match.
-- [ ] **AC3** — `.github/SUPPORT.md` carries no `github.com/<owner>/circumplex`
+- [x] **AC3** — `.github/SUPPORT.md` carries no `github.com/<owner>/circumplex`
       URL whose owner is not `jmgirard`, and its issue-search link's
       origin-plus-path equals `DESCRIPTION`'s `BugReports:` value (a query
       string is permitted). Verified by
       `grep -Eo 'https://github\.com/[^/]+/circumplex[^ )>]*'` over the file and
       comparing each match against that field.
-- [ ] **AC4** — A case-insensitive `grep -Fin -e` sweep for seven retired
+- [x] **AC4** — A case-insensitive `grep -Fin -e` sweep for seven retired
       literals (`Travis`, `AppVeyor`, `styler`, `style.tidyverse.org`,
       `tidy-contrib`, `tidyverse/circumplex`, `community.rstudio.com`) over the
       file list `git ls-files` produces — excluding `NEWS.md` (release history)
@@ -60,19 +60,26 @@ GitHub renders them, and act on what they say.
       there) — returns **no match**. Recorded per literal both before and after
       the change: each literal must show ≥1 pre-change match, and a literal
       showing none invalidates the sweep rather than passing it.
-- [ ] **AC5** — No URL in the four `.github/` files has a host in
+- [x] **AC5** — No URL in the four `.github/` files has a host in
       {`tidyverse.org` and its subdomains, `rstudio.com` and its subdomains,
       `posit.co`, `rstd.io`}, the sole exception being `reprex.tidyverse.org`
       (the reprex package's own documentation), and no bare hostname from that
       same list appears as link text. Verified by enumerating with
       `grep -Eo '(https?://)?[a-z0-9.-]+\.(org|com|io)[^ )>]*'` over exactly
       those four files and extracting each host.
-- [ ] **AC6** — Every http(s) URL enumerated by AC5 (trailing `>`, `)`, `.`, `,`
-      stripped) resolved 2xx/3xx on its recorded probe:
-      `curl -sIL -o /dev/null -w '%{http_code}'`, and on a 403/405/429 a
-      documented GET retry (`curl -sL -o /dev/null -w '%{http_code}' -A <browser
-      UA>`) whose own code must be 2xx/3xx. Any URL not reaching 2xx/3xx on
-      either probe is repaired or removed. Statuses recorded in the work log.
+- [x] **AC6** — Every http(s) URL enumerated by AC5 (trailing `>`, `)`, `]`,
+      `.`, `,` stripped repeatedly until none remain, i.e. `sed 's/[]>).,]*$//'`)
+      resolved 2xx/3xx on its recorded probe:
+      `curl -sIL -o /dev/null -w '%{http_code}' --max-time 20`, and on a
+      403/405/429 a documented GET retry (same with `-L` and a browser UA) whose
+      own code must be 2xx/3xx. Any URL not reaching 2xx/3xx is repaired or
+      removed, except in `.github/CODE_OF_CONDUCT.md`, where AC7's byte-equality
+      pin governs: a failing URL there is recorded and raised as a decision,
+      never silently edited. Exempt from the probe: that file's line 121, whose
+      `[text][url]` reference-link syntax is malformed verbatim upstream and
+      renders as plain text rather than a link; its target
+      `https://github.com/mozilla/inclusion` is recorded as manually probed
+      (200). Statuses recorded in the work log.
 - [x] **AC7** — `.github/CODE_OF_CONDUCT.md` is Contributor Covenant 2.1 as
       bundled by usethis 3.2.1 (template SHA-256
       `e45d34f51a88827f03e9bc868aabb872ccae96434a8c14c469a44147825a499a`), with
@@ -115,7 +122,7 @@ GitHub renders them, and act on what they say.
       enforcement contact = DESCRIPTION's `cre` email.
 - [x] **T7** — Delete the two dead `.Rbuildignore` entries (L8, L13); confirm
       `devtools::check()` is unaffected.
-- [ ] **T8** — Run and log the AC4 pre/post sweep, the AC5 host enumeration, and
+- [x] **T8** — Run and log the AC4 pre/post sweep, the AC5 host enumeration, and
       the AC6 status probes; check tail bytes of every rewritten file
       (`tail -6 f | od -c`, M34 lesson); confirm `pkgdown::check_pkgdown()`
       passes.
@@ -136,6 +143,9 @@ GitHub renders them, and act on what they say.
 - 2026-08-19: **amendment (substantive), AC7** — the pinned source `https://www.contributor-covenant.org/version/2/1/code_of_conduct.md` returns HTTP 404 (a 3449-byte "Page not found" page), making AC7 unsatisfiable as planned. Amended at a mini gate to the usethis 3.2.1 bundled template, which Jeff confirms is where these files originally came from; the upstream raw markdown was rejected as the pin because it carries a Hugo TOML front-matter block and unwrapped lines, so a shipped copy would differ from it on nearly every line. Amended wording was audited first by a fresh-context [O] reader that did not author it, returning four findings, all applied: the normative reference was machine-local (deliverable SHA now the primary check, template SHA inline as provenance); "the placeholder carries the email" was backwards; the `grep -F` probe was location-free and was dropped; and "exactly one changed line" silently rode two coincidences now named in the criterion (both strings are 15 characters, and template line 62 is the file's only line ending in a trailing space).
 - 2026-08-19: T6 — CODE_OF_CONDUCT.md replaced (Contributor Covenant 1.0.0, 1396 bytes, no enforcement contact → 2.1 with `me@jmgirard.com`). AC7 verified independently in-session: template SHA-256 `e45d34f5…a499a`, deliverable SHA-256 `4828e2a2…1b87f4`, `diff` output exactly `62c62`, line 62's trailing space present in `od -c`, and the text's own 2.1 attribution at line 118.
 - 2026-08-19: T7 — the two dead `.Rbuildignore` entries deleted. Both verified dead first: no top-level file matches either pattern, and `.travis.yml`/`CONDUCT.md` were last touched in the pre-cairn Travis era (a95585ab, 34592d96, d685b51a). `R CMD build` succeeds afterwards and the tarball still excludes `.github`, `cairn`, `tools` and `devel`.
+- 2026-08-19: **amendment (substantive), AC6** — running the criterion exposed `.github/CODE_OF_CONDUCT.md:121`, `[Mozilla's code of conduct enforcement ladder][https://github.com/mozilla/inclusion].`: reference-link syntax with no matching definition, malformed verbatim in the upstream Contributor Covenant 2.1 text and unmodifiable under AC7's byte pin, so it renders as plain text rather than a link. Amended at a mini gate after a fresh-context [O] reader audited the proposed wording and refuted the first draft of it: adding `]` to the strip list fixes nothing, because the token ends in `.` not `]` and a single ordered pass leaves `...inclusion]`. Adopted instead: a repeated strip (`sed 's/[]>).,]*$//'`), a named exemption for line 121 with its manually probed 200 on the record, `--max-time 20` on both probes, and an explicit resolution of the latent AC6/AC7 conflict (a failing URL in the vendored file is raised as a decision, never silently edited).
+- 2026-08-19: T8 — AC4 sweep green: all seven literals show >=1 pre-change match against master 908b65e0 (Travis 2, AppVeyor 1, styler 1, style.tidyverse.org 1, tidy-contrib 1, tidyverse/circumplex 1, community.rstudio.com 2) and 0 post-change, so the instrument discriminates rather than passing vacuously. AC5 green: the four files' hosts are github.com (7), www.contributor-covenant.org (4), reprex.tidyverse.org (3, the permitted exception), cran.r-project.org (3), docs.github.com (1); no banned host, and the only tidyverse mentions are the three reprex links. AC6 green: all 12 URLs returned 200 on HEAD, no GET fallback needed. A first AC5 run reported a false "(none)" because zsh does not word-split unquoted parameters, so the grep read no file at all — re-run against explicit paths (the M95-family lesson, a check passing by not checking).
+- 2026-08-19: T8 — one genuine link rot repaired en route: CONTRIBUTING.md's roxygen2 Markdown-syntax link (`cran.r-project.org/web/packages/roxygen2/vignettes/markdown.html`) returned 404 and was repointed to `https://roxygen2.r-lib.org/articles/rd-formatting.html` (200). Tail bytes of all four rewritten files clean (each ends in a single newline, no leaked scaffolding; M34). `pkgdown::check_pkgdown()`: no problems found.
 
 ## Decisions
 

--- a/cairn/milestones/M97-contributor-docs-refresh.md
+++ b/cairn/milestones/M97-contributor-docs-refresh.md
@@ -73,12 +73,18 @@ GitHub renders them, and act on what they say.
       documented GET retry (`curl -sL -o /dev/null -w '%{http_code}' -A <browser
       UA>`) whose own code must be 2xx/3xx. Any URL not reaching 2xx/3xx on
       either probe is repaired or removed. Statuses recorded in the work log.
-- [ ] **AC7** — `.github/CODE_OF_CONDUCT.md` is Contributor Covenant 2.1 from
-      `https://www.contributor-covenant.org/version/2/1/code_of_conduct.md`
-      (its SHA-256 recorded in the work log), differing from that source only on
-      the `[INSERT CONTACT METHOD]` line, which carries the `cre` email in
-      `DESCRIPTION`'s `Authors@R` (`me@jmgirard.com`). Verified by that diff and
-      by `grep -F` for the address (≥1 match).
+- [x] **AC7** — `.github/CODE_OF_CONDUCT.md` is Contributor Covenant 2.1 as
+      bundled by usethis 3.2.1 (template SHA-256
+      `e45d34f51a88827f03e9bc868aabb872ccae96434a8c14c469a44147825a499a`), with
+      template line 62's `{{{ contact }}}` placeholder replaced by the `cre`
+      email in `DESCRIPTION`'s `Authors@R` (`me@jmgirard.com`). Verified by
+      `shasum -a 256 .github/CODE_OF_CONDUCT.md` equalling
+      `4828e2a242cad5e7d7f0f0c47eefe57ff0e66273ba6db3f90f227bb6ab1b87f4`, and,
+      where usethis 3.2.1 is installed, by `diff` against the template showing
+      exactly `62c62` with no additions or deletions. The substitution is
+      length-preserving (15 characters either way) so the template's hard wrap
+      is unchanged, and template line 62's trailing space is preserved
+      byte-for-byte.
 
 ## Coverage
 
@@ -105,7 +111,7 @@ GitHub renders them, and act on what they say.
       L32) and framing; keep reprex.
 - [x] **T5** — ISSUE_TEMPLATE.md: replace the stale question venues (L1) and
       help links (L3).
-- [ ] **T6** — CODE_OF_CONDUCT.md: replace with Contributor Covenant 2.1;
+- [x] **T6** — CODE_OF_CONDUCT.md: replace with Contributor Covenant 2.1;
       enforcement contact = DESCRIPTION's `cre` email.
 - [ ] **T7** — Delete the two dead `.Rbuildignore` entries (L8, L13); confirm
       `devtools::check()` is unaffected.
@@ -127,6 +133,8 @@ GitHub renders them, and act on what they say.
 - 2026-08-19: T3 — "Generated files" section added after "Fixing typos"; AC2 probes green (all six strings >=1 match: `R/RcppExports.R` 1, `src/RcppExports.cpp` 1, `man/*.Rd` 1, `NAMESPACE` 2, `devtools::document()` 1, `Rcpp::compileAttributes()` 1). README.md/README.Rmd added as a third generated pair from PROFILE.md's consistency-gate slot.
 - 2026-08-19: T4 — SUPPORT.md rewritten around this repo's own venues (Discussions for questions, Issues for bugs). AC3 probe green: the only `github.com/<owner>/circumplex` URLs are `jmgirard/...discussions` and `jmgirard/...issues`, and the issue-search link's origin-plus-path string-equals DESCRIPTION's `BugReports:` value with no query. The wrong-repo link (`github.com/tidyverse/circumplex/issues`) and the four tidyverse help venues are gone; the stale `help.github.com` qualifier link was repointed to `docs.github.com`.
 - 2026-08-19: T5 — ISSUE_TEMPLATE.md's question venues (StackOverflow, community.rstudio.com) replaced by this repo's Discussions; the tidyverse help pointer dropped and the reprex link repointed to `reprex.tidyverse.org`.
+- 2026-08-19: **amendment (substantive), AC7** — the pinned source `https://www.contributor-covenant.org/version/2/1/code_of_conduct.md` returns HTTP 404 (a 3449-byte "Page not found" page), making AC7 unsatisfiable as planned. Amended at a mini gate to the usethis 3.2.1 bundled template, which Jeff confirms is where these files originally came from; the upstream raw markdown was rejected as the pin because it carries a Hugo TOML front-matter block and unwrapped lines, so a shipped copy would differ from it on nearly every line. Amended wording was audited first by a fresh-context [O] reader that did not author it, returning four findings, all applied: the normative reference was machine-local (deliverable SHA now the primary check, template SHA inline as provenance); "the placeholder carries the email" was backwards; the `grep -F` probe was location-free and was dropped; and "exactly one changed line" silently rode two coincidences now named in the criterion (both strings are 15 characters, and template line 62 is the file's only line ending in a trailing space).
+- 2026-08-19: T6 — CODE_OF_CONDUCT.md replaced (Contributor Covenant 1.0.0, 1396 bytes, no enforcement contact → 2.1 with `me@jmgirard.com`). AC7 verified independently in-session: template SHA-256 `e45d34f5…a499a`, deliverable SHA-256 `4828e2a2…1b87f4`, `diff` output exactly `62c62`, line 62's trailing space present in `od -c`, and the text's own 2.1 attribution at line 118.
 
 ## Decisions
 

--- a/cairn/milestones/M97-contributor-docs-refresh.md
+++ b/cairn/milestones/M97-contributor-docs-refresh.md
@@ -92,7 +92,7 @@ GitHub renders them, and act on what they say.
 
 ## Tasks
 
-- [ ] **T1** — CONTRIBUTING.md: rewrite the framing (L3-5, L47-48) and the
+- [x] **T1** — CONTRIBUTING.md: rewrite the framing (L3-5, L47-48) and the
       "someone from the team agrees" prerequisite (L17-18) for a
       solo-maintainer, non-tidyverse package.
 - [ ] **T2** — CONTRIBUTING.md: rewrite the PR-process section — replace the
@@ -122,6 +122,7 @@ GitHub renders them, and act on what they say.
 - 2026-08-19: plan gate chose a full rewrite over a minimal edit of the false claims alone, because the audit showed a minimal edit leaves the stale claim standing in paraphrase (a "check the CI services listed in the README" rewrite passes every literal grep); falsified by the rewrite introducing a new inaccuracy the greps cannot see.
 - 2026-08-19: plan chose deleting the dead `.Rbuildignore` entries over exempting `.Rbuildignore` from AC4's sweep, because the entries name files that do not exist and cannot return; falsified by either pattern turning out to still match something `R CMD build` needs excluded.
 - 2026-08-19: implement session started; branch `m97-contributor-docs-refresh` cut from pushed master (908b65e0), tree clean.
+- 2026-08-19: T1 — CONTRIBUTING.md framing, prerequisites, and closing section rewritten: the tidy-contrib pointers (L3-5, L47-48) removed, the "someone from the team" prerequisite replaced by an issue-for-bugs / discussion-for-features split (Discussions is enabled and in live use, 2 threads), and the reprex link repointed from `www.tidyverse.org/help/#reprex` to `reprex.tidyverse.org` (AC5's sole permitted exception).
 
 ## Decisions
 

--- a/cairn/milestones/M97-contributor-docs-refresh.md
+++ b/cairn/milestones/M97-contributor-docs-refresh.md
@@ -1,6 +1,6 @@
 # M97: Make the contributor docs describe this repo
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
@@ -146,6 +146,7 @@ GitHub renders them, and act on what they say.
 - 2026-08-19: **amendment (substantive), AC6** — running the criterion exposed `.github/CODE_OF_CONDUCT.md:121`, `[Mozilla's code of conduct enforcement ladder][https://github.com/mozilla/inclusion].`: reference-link syntax with no matching definition, malformed verbatim in the upstream Contributor Covenant 2.1 text and unmodifiable under AC7's byte pin, so it renders as plain text rather than a link. Amended at a mini gate after a fresh-context [O] reader audited the proposed wording and refuted the first draft of it: adding `]` to the strip list fixes nothing, because the token ends in `.` not `]` and a single ordered pass leaves `...inclusion]`. Adopted instead: a repeated strip (`sed 's/[]>).,]*$//'`), a named exemption for line 121 with its manually probed 200 on the record, `--max-time 20` on both probes, and an explicit resolution of the latent AC6/AC7 conflict (a failing URL in the vendored file is raised as a decision, never silently edited).
 - 2026-08-19: T8 — AC4 sweep green: all seven literals show >=1 pre-change match against master 908b65e0 (Travis 2, AppVeyor 1, styler 1, style.tidyverse.org 1, tidy-contrib 1, tidyverse/circumplex 1, community.rstudio.com 2) and 0 post-change, so the instrument discriminates rather than passing vacuously. AC5 green: the four files' hosts are github.com (7), www.contributor-covenant.org (4), reprex.tidyverse.org (3, the permitted exception), cran.r-project.org (3), docs.github.com (1); no banned host, and the only tidyverse mentions are the three reprex links. AC6 green: all 12 URLs returned 200 on HEAD, no GET fallback needed. A first AC5 run reported a false "(none)" because zsh does not word-split unquoted parameters, so the grep read no file at all — re-run against explicit paths (the M95-family lesson, a check passing by not checking).
 - 2026-08-19: T8 — one genuine link rot repaired en route: CONTRIBUTING.md's roxygen2 Markdown-syntax link (`cran.r-project.org/web/packages/roxygen2/vignettes/markdown.html`) returned 404 and was repointed to `https://roxygen2.r-lib.org/articles/rd-formatting.html` (200). Tail bytes of all four rewritten files clean (each ends in a single newline, no leaked scaffolding; M34). `pkgdown::check_pkgdown()`: no problems found.
+- 2026-08-19: all eight tasks done; `devtools::test()` clean (FAIL 0 | WARN 5 | SKIP 3 | PASS 8395; the five warnings are lavaan-emitted and pre-existing), `pkgdown::check_pkgdown()` no problems, `cairn_validate` all checks passed. Status → review.
 
 ## Decisions
 


### PR DESCRIPTION
Rewrites the four `.github/` contributor-facing documents so they describe this repo's actual practice rather than the usethis tidyverse template they were generated from.

- **CONTRIBUTING.md** — drops the tidyverse framing and the `rstd.io/tidy-contrib` pointers; replaces the Travis/AppVeyor bullet with what `R-CMD-check.yaml` actually does (derived from `tools/ci-matrix.R`); replaces the styler/tidyverse-style-guide bullet with this repo's own "match existing code style" rule; adds a "Generated files" section covering `man/*.Rd`, `NAMESPACE`, `R/RcppExports.R`, `src/RcppExports.cpp` and `README.md`; routes bugs to Issues and questions to Discussions.
- **SUPPORT.md** — fixes an issue-search link that pointed at `github.com/tidyverse/circumplex/issues` (wrong repo); replaces the tidyverse help venues with this repo's Discussions and Issues.
- **ISSUE_TEMPLATE.md** — question venue is now Discussions, not StackOverflow / community.rstudio.com.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 1.0.0 (no reporting contact) → 2.1 with the maintainer address.
- **.Rbuildignore** — removes two entries for files that no longer exist.

One genuine link rot repaired en route: the roxygen2 Markdown-syntax link returned 404 and now points at `roxygen2.r-lib.org/articles/rd-formatting.html`.

Tracking: `cairn/milestones/M97-contributor-docs-refresh.md`.