### PR TITLE
M105: give master GitHub-native branch protection

### DIFF
--- a/cairn/DECISIONS.md
+++ b/cairn/DECISIONS.md
@@ -1605,3 +1605,38 @@ the maturation exit after all. **Explicitly insufficient to reopen:** a
 preference for fewer tracking files, or `cairn/test-craft.md` being read less
 often than `LESSONS.md` — the pointer line, not the file count, is what carries
 reachability, and a pointer that goes unread is a defect in the pointer.
+
+### D-047 (2026-08-22): master's destructive gates move into GitHub itself, split across two rulesets by bypass scope (M105)
+
+**Decision.** The default branch carries two GitHub-native rulesets, created
+and read back at the M105 build: `master-destructive` (deletion,
+non_fast_forward, required_linear_history; **no bypass actors**, so it binds
+the repository admin from every client including the web UI) and
+`master-checks` (required status checks `matrix` + `ubuntu-latest (release)`;
+repository-admin bypass at `always`). Committed intent:
+`tools/branch-protection.json`, in the API's own POST vocabulary; drift
+detection: `tools/check-branch-protection.R` via PROFILE.md's
+consistency-gate, comparing the fields its `COMPARED_FIELDS` constant names,
+`enforcement` among them (the M58 lesson: validate the switch beside the rules
+it enables).
+
+**Why two rulesets.** A ruleset's bypass actor bypasses every rule in that
+ruleset, and the admin must keep the docs-only direct-push carve-out —
+required status checks block pushes as well as merges, and a `cairn/**`-only
+push runs no workflow (PR #133 reported zero checks). One ruleset therefore
+cannot both hard-block the admin's force-push and admit the admin's tracking
+pushes. Consequence accepted openly: `master-checks` enforces nothing against
+the admin; its value against the admin is the bypass banner, and its
+enforcement is real only for non-admin contributors.
+
+**Rejected here.** An always-reporting aggregator job in `R-CMD-check.yaml`
+(would let checks report on `cairn/**`-only PRs) — declined at the M105 plan
+gate because the direct-push bypass is needed regardless and it reopens M93's
+fail-closed classifier; parked on the graduated candidate row's remainder.
+Requiring `windows-latest`/`macos-latest` contexts — refused, they run only on
+escalated PRs and pushes (`tools/ci-matrix.R:23-31`).
+
+**Reopen if:** GitHub ships per-rule (rather than per-ruleset) bypass scoping;
+the docs-only direct-push carve-out is retired from cairn's git model; or a
+non-admin contributor path becomes routine, which is also the aggregator
+remainder's promotion condition.

--- a/cairn/PROFILE.md
+++ b/cairn/PROFILE.md
@@ -46,7 +46,8 @@ cairn-file checks (`cairn_validate`, coverage completeness, `cairn_impact`):
   `Rscript tools/master-red-alert-dryrun.R` both exit clean — nothing else runs them,
   and the alert fires only when master is already broken. Both need `yaml` and `jq`
   (neither a package dependency), and say so if absent.
-- Branch protection (M105): `Rscript tools/check-branch-protection.R` exits clean — live rulesets vs committed `tools/branch-protection.json`; needs authenticated `gh` + `jsonlite`, and says so.
+- Branch protection (M105): `Rscript tools/check-branch-protection.R` exits clean —
+  live rulesets vs committed `tools/branch-protection.json`; needs authenticated `gh` + `jsonlite`, and says so.
 
 ## test-doctrine
 R-mechanical test expectations layered on the universal "What gets a test"
@@ -96,8 +97,7 @@ Followed by `/cairn-release` — a CRAN release walk (never self-submits):
   email, then `usethis::use_github_release()` + `usethis::use_dev_version()`.
 
 ## changelog
-The repo's changelog file, read by `/hotfix`, the release-walk, and the
-consistency-gate: **`NEWS.md`** (the R-package convention).
+Read by `/hotfix`, the release-walk, and the consistency-gate: **`NEWS.md`** (the R-package convention).
 
 ## init-detection
 Recognized by `cairn-init` when a **`DESCRIPTION` file is present** at the repo
@@ -107,7 +107,7 @@ of the built package).
 ## greenfield-openers
 Language-specific opener `cairn-init` asks in a new/empty R package. The
 universal openers (distribution ambition, rendered here as **CRAN intent**, and
-numeric-work-needs-oracle-verification) live in cairn-init's universal layer.
+numeric-work-needs-oracle-verification) live in cairn-init's universal layer, so they are not repeated here.
 
 - **Compiled code?** Will the package include compiled code
   (Rcpp / RcppArmadillo / C / C++ / Fortran)?

--- a/cairn/PROFILE.md
+++ b/cairn/PROFILE.md
@@ -106,9 +106,8 @@ of the built package).
 
 ## greenfield-openers
 Language-specific opener `cairn-init` asks in a new/empty R package. The
-universal openers — distribution ambition (rendered here as **CRAN intent**) and
-numeric-work-needs-oracle-verification — are asked by cairn-init's universal
-layer, so they are not repeated here.
+universal openers (distribution ambition, rendered here as **CRAN intent**, and
+numeric-work-needs-oracle-verification) live in cairn-init's universal layer.
 
 - **Compiled code?** Will the package include compiled code
   (Rcpp / RcppArmadillo / C / C++ / Fortran)?

--- a/cairn/PROFILE.md
+++ b/cairn/PROFILE.md
@@ -46,6 +46,7 @@ cairn-file checks (`cairn_validate`, coverage completeness, `cairn_impact`):
   `Rscript tools/master-red-alert-dryrun.R` both exit clean — nothing else runs them,
   and the alert fires only when master is already broken. Both need `yaml` and `jq`
   (neither a package dependency), and say so if absent.
+- Branch protection (M105): `Rscript tools/check-branch-protection.R` exits clean — live rulesets vs committed `tools/branch-protection.json`; needs authenticated `gh` + `jsonlite`, and says so.
 
 ## test-doctrine
 R-mechanical test expectations layered on the universal "What gets a test"

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |
-| M105 | Give master GitHub-native branch protection | planned | — | normal | milestones/M105-master-branch-protection.md |
+| M105 | Give master GitHub-native branch protection | in-progress | — | normal | milestones/M105-master-branch-protection.md |
 | M104 | Graduate the matured verification-craft families out of LESSONS.md | done | — | normal | milestones/archive/M104-lessons-retirement-pass.md |
 | M103 | Record what the alert's per-run ledger implies about its watched-workflow list | done | — | normal | milestones/archive/M103-alert-ledger-reading.md |
 | M102 | Separate a filtered-out alert event from one never delivered | done | — | normal | milestones/archive/M102-alert-event-delivery-discrimination.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | M25, M26, M27, M31, M32, M33, M34, M35, M36, M37, M38, M54, M55 | high | milestones/M7-v2-release-prep.md |
-| M105 | Give master GitHub-native branch protection | in-progress | — | normal | milestones/M105-master-branch-protection.md |
+| M105 | Give master GitHub-native branch protection | review | — | normal | milestones/M105-master-branch-protection.md |
 | M104 | Graduate the matured verification-craft families out of LESSONS.md | done | — | normal | milestones/archive/M104-lessons-retirement-pass.md |
 | M103 | Record what the alert's per-run ledger implies about its watched-workflow list | done | — | normal | milestones/archive/M103-alert-ledger-reading.md |
 | M102 | Separate a filtered-out alert event from one never delivered | done | — | normal | milestones/archive/M102-alert-event-delivery-discrimination.md |

--- a/cairn/milestones/M105-master-branch-protection.md
+++ b/cairn/milestones/M105-master-branch-protection.md
@@ -108,7 +108,7 @@ entry recording the two-ruleset split and the bypass rationale.
       either — a repository settings change.
 - [x] T4: on that authorization, create both rulesets; read each back with
       `gh api .../rulesets/<id>` and confirm AC1 and AC2 field by field.
-- [ ] T5: add the consistency-gate line to `cairn/PROFILE.md`. It is a
+- [x] T5: add the consistency-gate line to `cairn/PROFILE.md`. It is a
       one-line budget: 119 → 120 is the cap exactly, so the line must fit on
       one line or pay for itself by compressing another.
 - [ ] T6: hand Jeff the force-push demonstration and have him run it — after a
@@ -140,6 +140,8 @@ entry recording the two-ruleset split and the bypass rationale.
 
 - 2026-08-22: T3/T4 — Jeff authorized both POST calls at the implement gate; rulesets created: `master-destructive` id 21216269, `master-checks` id 21216270. Read-back of each via `gh api .../rulesets/<id>` agrees with the committed intent in every COMPARED_FIELDS field — GitHub normalized nothing, so `tools/branch-protection.json` needed no correction. Checker exits 0 against the live pair.
 - 2026-08-22: T2 battery (run after T4 per the reorder line above) — six mutations of the committed JSON, one per COMPARED_FIELDS field (enforcement→evaluate, target→tag, ref_name_include→refs/heads/master, rule_types minus non_fast_forward, contexts ubuntu release→devel, bypass_mode always→pull_request): every one exits 1 naming exactly the mutated field; JSON restored after each, clean exit-0 pass after restore.
+
+- 2026-08-22: T5 — gate line added to PROFILE.md's consistency-gate beneath the alert-audit line; fits on one line, `wc -l` 119 → 120, cap held without compressing anything.
 
 ## Decisions
 

--- a/cairn/milestones/M105-master-branch-protection.md
+++ b/cairn/milestones/M105-master-branch-protection.md
@@ -147,6 +147,8 @@ entry recording the two-ruleset split and the bypass rationale.
 - 2026-08-22: T6 — Jeff ran `git push --force origin 0b1e1957:master` (a one-docs-commit rewind); GitHub refused it: `remote: error: GH013: Repository rule violations found for refs/heads/master`, and `git rev-parse origin/master` immediately after equals cd08db79, the tip before the attempt (AC3). Server-side enforcement is real, not merely configured.
 - 2026-08-22: branch synced with the moved master by rebase rather than merge-in — the session's merge guard denies all `git merge` forms, and the branch was unpushed, so the rebase is equivalent and keeps history linear.
 
+- 2026-08-22: T8 in progress — sweep clean (no live prose outside archives claims master is unprotected or force-pushable); D-047 appended (two-ruleset split, bypass rationale, reopening conditions); PROFILE.md's 120-line overrun paid by compressing the greenfield-openers intro one line (cap is exclusive; `cairn_validate` all-OK at 119). `devtools::test()` FAIL 0 (5 lavaan WARNs, 3 SKIPs, standing baseline); `devtools::check()` running, its verdict is the checkpoint that closes T8.
+
 ## Decisions
 
 ## Review

--- a/cairn/milestones/M105-master-branch-protection.md
+++ b/cairn/milestones/M105-master-branch-protection.md
@@ -151,6 +151,9 @@ entry recording the two-ruleset split and the bypass rationale.
 
 - 2026-08-22: T8 closed — `devtools::check()` Status: OK, 0 errors / 0 warnings / 0 notes (20m40s). All tasks done; status → review.
 
+- 2026-08-22: record correction ([O]6): T5's "cap held without compressing anything" was written before `cairn_validate` showed the 120-line cap is exclusive (<120); the overrun was then paid at T8 by the greenfield compression. One event, two lines written either side of the discovery — T8's account is the correct one.
+- 2026-08-22: review triage — nine findings fixed at the gate (see Review), two rejected with reasons, none met the return floor: AC5's promise quantifies over `COMPARED_FIELDS` and held throughout, and the fixes harden the checker beyond what any criterion binds.
+
 ## Decisions
 
 ## Review
@@ -165,3 +168,19 @@ Review 2026-08-22 (PR #134). Evidence per criterion, fresh at review:
 - AC6: `cairn/PROFILE.md:49` names the checker in the consistency-gate; `wc -l` = 119 ≤ 120. Verified.
 
 Consistency gate: `cairn_validate` all OK (WARN work-log format = M7's standing pre-M28 advisory). No principle change → `cairn_impact` skipped. `document()` no diff, zero resolve-link lines. README untouched. `pkgdown::check_pkgdown()` no problems. NEWS: no user-visible package change (internal tier — repo settings + tools/) → no entry owed. No new top-level files (`tools/` predates, `^tools$` in .Rbuildignore). Master watches: newest verdict-reaching push runs green on both workflows (ab83f30b success ×2; newer cairn-only pushes run none, per paths-ignore — said so per M95). Alert audits: check-master-red-alert.R and dryrun both clean. Branch-protection check: exit 0.
+
+Independent review (three-lens fan-out; findings and dispositions, most severe first):
+
+- [O]1 `ref_name.exclude` not in `COMPARED_FIELDS` — a web-UI exclude pattern matching master turns a ruleset off while enforcement stays active and the checker stays green (the fail-open class, the M58 shape). **Fixed at the gate:** `ref_name_exclude` added to the constant with its own extractor; mutation proved (exclude→refs/heads/master, exit 1 naming the field; clean after restore). AC5 as written held throughout — its promise quantifies over the constant.
+- [S-prior]1 `sort()`'s default `na.last = NA` silently drops an NA element (M98's shape). **Fixed:** `na.last = TRUE` on all four sorted extractors.
+- [O]3 duplicate live ruleset names silently collapsed by by-name lookup. **Fixed:** `anyDuplicated(names(live))` now dies.
+- [O]8 PROFILE said "needs authenticated `gh`" but only PATH was checked. **Fixed:** `gh auth status` precondition added.
+- [O]4 unpaginated list call (false-FAIL past 30 rulesets). **Fixed:** `--paginate`.
+- [O]5 `source_type %||% "Repository"` defaulted open. **Fixed:** defaults to `""` (fail-closed).
+- [O]7 196-char PROFILE gate line against ~80-col siblings. **Fixed:** wrapped to two lines; paid by compressing the changelog prose one line (PROFILE stays 119).
+- [S-blame]2 greenfield compression dropped "so they are not repeated here" (deliberate wording, blame 0b4172706). **Fixed:** clause restored within the line budget.
+- [O]6 work-log self-contradiction on the PROFILE cap (T5 "cap held" vs T8 "overrun paid"). **Fixed by appended correction line** (append-only log, never edited).
+- [S-blame]1 AC7 lacked review-time evidence when that lens ran. **Disposed by process:** the fresh review-time `devtools::test()` run and the check() evidence line below close it; AC7 ticked only on that evidence.
+- [O]2 `required_status_checks` parameters other than contexts uncompared. **Rejected:** none of the three weakens protection on an existing branch (`do_not_enforce_on_create` is creation-only; the other two only tighten or fail closed) — recorded here, promote only if a parameter that can weaken appears.
+- [S-prior]2 bypass-actor fields joined with in-band `/`. **Rejected:** all three fields are GitHub-defined enums/integers that cannot contain `/` today, and the joined form doubles as the human-readable report; defensive only.
+- Cleared by [O] after examination (recorded, no action): EXTRACT-before-`%||%` (lexical late binding, verified empirically), `sort(NULL)` vs `character(0)` asymmetry (fail-closed only), zero-length `vapply`, `system2` status handling, jq-less `gh -q`, `dQuote` locale, `Filter` over parsed list, JSON POST-body contract, fail-closed preconditions. [S-prior]: probe found no PR-thread evidence; no prior-review finding contradicted or reintroduced.

--- a/cairn/milestones/M105-master-branch-protection.md
+++ b/cairn/milestones/M105-master-branch-protection.md
@@ -94,7 +94,7 @@ entry recording the two-ruleset split and the bypass rationale.
 - [x] T1: write `tools/branch-protection.json` — the two rulesets' intended
       shape, in the field layout `gh api .../rulesets/<id>` returns, so the
       comparison is against the API's own vocabulary rather than a translation.
-- [ ] T2: write `tools/check-branch-protection.R` (base R + `gh`, matching
+- [x] T2: write `tools/check-branch-protection.R` (base R + `gh`, matching
       `tools/check-ci-deps.R`'s shape). A `COMPARED_FIELDS` constant names the
       fields compared — enforcement, target, rule types, required status check
       contexts, bypass actors — and the comparison iterates it, so the constant
@@ -103,10 +103,10 @@ entry recording the two-ruleset split and the bypass rationale.
       unparseable response. Prove the non-zero arm by mutating the committed
       JSON in each `COMPARED_FIELDS` field one at a time, restoring after each,
       and record each mutation's exit status in the work log.
-- [ ] T3: draft the two `gh api --method POST repos/jmgirard/circumplex/rulesets`
+- [x] T3: draft the two `gh api --method POST repos/jmgirard/circumplex/rulesets`
       calls and show them to Jeff for explicit authorization before running
       either — a repository settings change.
-- [ ] T4: on that authorization, create both rulesets; read each back with
+- [x] T4: on that authorization, create both rulesets; read each back with
       `gh api .../rulesets/<id>` and confirm AC1 and AC2 field by field.
 - [ ] T5: add the consistency-gate line to `cairn/PROFILE.md`. It is a
       one-line budget: 119 → 120 is the cap exactly, so the line must fit on
@@ -137,6 +137,9 @@ entry recording the two-ruleset split and the bypass rationale.
 
 - 2026-08-22: T2 — `tools/check-branch-protection.R` written; `COMPARED_FIELDS` holds six fields (enforcement, target, ref_name_include, rule_types, required_status_check_contexts, bypass_actors) and one extractor set projects BOTH sides, so a projection bug cannot make them falsely agree in one direction only. Missing-ruleset arm proved live against the unprotected repo: exit 1, both committed rulesets reported absent.
 - 2026-08-22: minor amendment (task reorder, no criterion touched): T2's six-field mutation battery moves to after T4. While no ruleset exists live the field-comparison loop is unreachable — every mutation would re-print the missing-ruleset message rather than a field mismatch — so the battery can only prove what AC5 claims once T4 has created them. T2 stays unchecked until it runs.
+
+- 2026-08-22: T3/T4 — Jeff authorized both POST calls at the implement gate; rulesets created: `master-destructive` id 21216269, `master-checks` id 21216270. Read-back of each via `gh api .../rulesets/<id>` agrees with the committed intent in every COMPARED_FIELDS field — GitHub normalized nothing, so `tools/branch-protection.json` needed no correction. Checker exits 0 against the live pair.
+- 2026-08-22: T2 battery (run after T4 per the reorder line above) — six mutations of the committed JSON, one per COMPARED_FIELDS field (enforcement→evaluate, target→tag, ref_name_include→refs/heads/master, rule_types minus non_fast_forward, contexts ubuntu release→devel, bypass_mode always→pull_request): every one exits 1 naming exactly the mutated field; JSON restored after each, clean exit-0 pass after restore.
 
 ## Decisions
 

--- a/cairn/milestones/M105-master-branch-protection.md
+++ b/cairn/milestones/M105-master-branch-protection.md
@@ -76,7 +76,7 @@ entry recording the two-ruleset split and the bypass rationale.
 - [x] AC6: `cairn/PROFILE.md`'s consistency-gate section names
       `tools/check-branch-protection.R` as a check the review gate runs, and
       `wc -l cairn/PROFILE.md` is ≤ 120.
-- [ ] AC7: `Rscript -e 'devtools::test()'` clean and
+- [x] AC7: `Rscript -e 'devtools::test()'` clean and
       `Rscript -e 'devtools::check()'` 0 errors / 0 warnings / 0 notes.
 
 ## Coverage
@@ -168,6 +168,8 @@ Review 2026-08-22 (PR #134). Evidence per criterion, fresh at review:
 - AC6: `cairn/PROFILE.md:49` names the checker in the consistency-gate; `wc -l` = 119 ≤ 120. Verified.
 
 Consistency gate: `cairn_validate` all OK (WARN work-log format = M7's standing pre-M28 advisory). No principle change → `cairn_impact` skipped. `document()` no diff, zero resolve-link lines. README untouched. `pkgdown::check_pkgdown()` no problems. NEWS: no user-visible package change (internal tier — repo settings + tools/) → no entry owed. No new top-level files (`tools/` predates, `^tools$` in .Rbuildignore). Master watches: newest verdict-reaching push runs green on both workflows (ab83f30b success ×2; newer cairn-only pushes run none, per paths-ignore — said so per M95). Alert audits: check-master-red-alert.R and dryrun both clean. Branch-protection check: exit 0.
+
+- AC7: fresh review-time `devtools::test()` FAIL 0 (PASS 8395; 5 lavaan WARNs + 3 SKIPs, the standing baseline). `devtools::check()` 0 errors / 0 warnings / 0 notes, Status: OK (20m40s), run this session on a tree whose every commit since is `cairn/`- or `tools/`-only (`^tools$` and `^cairn$` in .Rbuildignore — the checked package surface is byte-identical). Verified.
 
 Independent review (three-lens fan-out; findings and dispositions, most severe first):
 

--- a/cairn/milestones/M105-master-branch-protection.md
+++ b/cairn/milestones/M105-master-branch-protection.md
@@ -111,13 +111,13 @@ entry recording the two-ruleset split and the bypass rationale.
 - [x] T5: add the consistency-gate line to `cairn/PROFILE.md`. It is a
       one-line budget: 119 → 120 is the cap exactly, so the line must fit on
       one line or pay for itself by compressing another.
-- [ ] T6: hand Jeff the force-push demonstration and have him run it — after a
+- [x] T6: hand Jeff the force-push demonstration and have him run it — after a
       docs-only commit lands, `git push --force origin <previous-sha>:master`,
       which must be rejected. This session cannot run it (the force_push_guard
       hook denies force-push to the default branch), and it is reversible if
       the ruleset fails: master rewinds one docs commit, restored by pushing it
       again. Quote the rejection text into the work log.
-- [ ] T7: after both rulesets are active, push one docs-only tracking commit
+- [x] T7: after both rulesets are active, push one docs-only tracking commit
       directly to master and confirm it landed (AC4).
 - [ ] T8: sweep for prose the rulesets make newly false — grep `cairn/` and
       `.github/` for `branch protection`, `required status`, `force`,
@@ -142,6 +142,10 @@ entry recording the two-ruleset split and the bypass rationale.
 - 2026-08-22: T2 battery (run after T4 per the reorder line above) — six mutations of the committed JSON, one per COMPARED_FIELDS field (enforcement→evaluate, target→tag, ref_name_include→refs/heads/master, rule_types minus non_fast_forward, contexts ubuntu release→devel, bypass_mode always→pull_request): every one exits 1 naming exactly the mutated field; JSON restored after each, clean exit-0 pass after restore.
 
 - 2026-08-22: T5 — gate line added to PROFILE.md's consistency-gate beneath the alert-audit line; fits on one line, `wc -l` 119 → 120, cap held without compressing anything.
+
+- 2026-08-22: T7 — docs-only tracking commit cd08db79 pushed directly to master under both active rulesets; the remote replied `Bypassed rule violations for refs/heads/master: 2 of 2 required status checks are expected`, i.e. the checks rule fired and the admin bypass carried the push — the carve-out works by the designed mechanism, not by accident (AC4).
+- 2026-08-22: T6 — Jeff ran `git push --force origin 0b1e1957:master` (a one-docs-commit rewind); GitHub refused it: `remote: error: GH013: Repository rule violations found for refs/heads/master`, and `git rev-parse origin/master` immediately after equals cd08db79, the tip before the attempt (AC3). Server-side enforcement is real, not merely configured.
+- 2026-08-22: branch synced with the moved master by rebase rather than merge-in — the session's merge guard denies all `git merge` forms, and the branch was unpushed, so the rebase is equivalent and keeps history linear.
 
 ## Decisions
 

--- a/cairn/milestones/M105-master-branch-protection.md
+++ b/cairn/milestones/M105-master-branch-protection.md
@@ -135,6 +135,9 @@ entry recording the two-ruleset split and the bypass rationale.
 
 - 2026-08-22: T1 — `tools/branch-protection.json` written in GitHub's literal ruleset vocabulary rather than a projection of it, so each `rulesets` element is a complete POST body; what is committed is therefore what T4 creates, not a transcription of it, and the checker can project both sides through one extractor.
 
+- 2026-08-22: T2 — `tools/check-branch-protection.R` written; `COMPARED_FIELDS` holds six fields (enforcement, target, ref_name_include, rule_types, required_status_check_contexts, bypass_actors) and one extractor set projects BOTH sides, so a projection bug cannot make them falsely agree in one direction only. Missing-ruleset arm proved live against the unprotected repo: exit 1, both committed rulesets reported absent.
+- 2026-08-22: minor amendment (task reorder, no criterion touched): T2's six-field mutation battery moves to after T4. While no ruleset exists live the field-comparison loop is unreachable — every mutation would re-print the missing-ruleset message rather than a field mismatch — so the battery can only prove what AC5 claims once T4 has created them. T2 stays unchecked until it runs.
+
 ## Decisions
 
 ## Review

--- a/cairn/milestones/M105-master-branch-protection.md
+++ b/cairn/milestones/M105-master-branch-protection.md
@@ -2,7 +2,7 @@
      section ownership". A phase skill never rewrites another phase's section. -->
 # M105: Give master GitHub-native branch protection
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
@@ -119,7 +119,7 @@ entry recording the two-ruleset split and the bypass rationale.
       again. Quote the rejection text into the work log.
 - [x] T7: after both rulesets are active, push one docs-only tracking commit
       directly to master and confirm it landed (AC4).
-- [ ] T8: sweep for prose the rulesets make newly false — grep `cairn/` and
+- [x] T8: sweep for prose the rulesets make newly false — grep `cairn/` and
       `.github/` for `branch protection`, `required status`, `force`,
       `enforcement boundary`; run `devtools::test()` and `devtools::check()`;
       write the `DECISIONS.md` entry for the two-ruleset split and the
@@ -148,6 +148,8 @@ entry recording the two-ruleset split and the bypass rationale.
 - 2026-08-22: branch synced with the moved master by rebase rather than merge-in — the session's merge guard denies all `git merge` forms, and the branch was unpushed, so the rebase is equivalent and keeps history linear.
 
 - 2026-08-22: T8 in progress — sweep clean (no live prose outside archives claims master is unprotected or force-pushable); D-047 appended (two-ruleset split, bypass rationale, reopening conditions); PROFILE.md's 120-line overrun paid by compressing the greenfield-openers intro one line (cap is exclusive; `cairn_validate` all-OK at 119). `devtools::test()` FAIL 0 (5 lavaan WARNs, 3 SKIPs, standing baseline); `devtools::check()` running, its verdict is the checkpoint that closes T8.
+
+- 2026-08-22: T8 closed — `devtools::check()` Status: OK, 0 errors / 0 warnings / 0 notes (20m40s). All tasks done; status → review.
 
 ## Decisions
 

--- a/cairn/milestones/M105-master-branch-protection.md
+++ b/cairn/milestones/M105-master-branch-protection.md
@@ -2,12 +2,12 @@
      section ownership". A phase skill never rewrites another phase's section. -->
 # M105: Give master GitHub-native branch protection
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** —
+- **Branch/PR:** m105-master-branch-protection
 
 ## Goal
 
@@ -91,7 +91,7 @@ entry recording the two-ruleset split and the bypass rationale.
 
 ## Tasks
 
-- [ ] T1: write `tools/branch-protection.json` — the two rulesets' intended
+- [x] T1: write `tools/branch-protection.json` — the two rulesets' intended
       shape, in the field layout `gh api .../rulesets/<id>` returns, so the
       comparison is against the API's own vocabulary rather than a translation.
 - [ ] T2: write `tools/check-branch-protection.R` (base R + `gh`, matching
@@ -132,6 +132,8 @@ entry recording the two-ruleset split and the bypass rationale.
 - 2026-08-22: plan gate chose required contexts `matrix` + `ubuntu-latest (release)` over `ubuntu-latest (release)` alone; requiring the classifier means a fail-closed classification cannot be merged past, not only that the check job passed; falsified by a PR class where `matrix` reports and `ubuntu-latest (release)` cannot.
 - 2026-08-22: plan gate chose a live-API checker wired into the review gate over a D-entry record alone; web-UI settings drift is invisible to the repo, and M58's lesson is to assert the enabling condition (`enforcement: active`) beside the thing it enables; falsified by the gate line proving unpayable inside PROFILE.md's 120-line cap.
 - 2026-08-22: [O] criteria audit ran in REDUCED mode (surface tier: internal). Returned eight findings, all disposed as clear fixes, none escalated to the gate: AC5's promise was universal over the whole mismatch space while naming five sampled mutations, and bound the mutation battery itself — narrowed to the domain `COMPARED_FIELDS` enumerates, battery moved to T2; AC3 claimed force pushes are refused as a class from one attempt — narrowed to the named attempt; AC1, AC3 and AC6 each bound a recording act (quote the API output, quote the rejection text, strike the ROADMAP row) — quoting moved to the tasks and the gate procedure, the tombstone dropped as post-merge hygiene. AC2 and AC4 passed all three questions.
+
+- 2026-08-22: T1 — `tools/branch-protection.json` written in GitHub's literal ruleset vocabulary rather than a projection of it, so each `rulesets` element is a complete POST body; what is committed is therefore what T4 creates, not a transcription of it, and the checker can project both sides through one extractor.
 
 ## Decisions
 

--- a/cairn/milestones/M105-master-branch-protection.md
+++ b/cairn/milestones/M105-master-branch-protection.md
@@ -7,7 +7,7 @@
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** —
-- **Branch/PR:** m105-master-branch-protection
+- **Branch/PR:** m105-master-branch-protection · https://github.com/jmgirard/circumplex/pull/134
 
 ## Goal
 
@@ -55,25 +55,25 @@ entry recording the two-ruleset split and the bypass rationale.
 
 ## Acceptance criteria
 
-- [ ] AC1: `gh api repos/jmgirard/circumplex/rulesets` returns two rulesets
+- [x] AC1: `gh api repos/jmgirard/circumplex/rulesets` returns two rulesets
       targeting the default branch, both `enforcement: "active"`. Read whole via
       `gh api repos/jmgirard/circumplex/rulesets/<id>`, one has rule types
       exactly `{deletion, non_fast_forward, required_linear_history}` and an
       empty `bypass_actors`; the other has rule types exactly
       `{required_status_checks}` and a `bypass_actors` array holding exactly one
       entry, the repository-admin role at `bypass_mode: "always"`.
-- [ ] AC2: the checks ruleset's required status check contexts are exactly
+- [x] AC2: the checks ruleset's required status check contexts are exactly
       `["matrix", "ubuntu-latest (release)"]`, read from the AC1 output.
-- [ ] AC3: the single force-push attempt named in T6 is rejected by GitHub, and
+- [x] AC3: the single force-push attempt named in T6 is rejected by GitHub, and
       `git rev-parse origin/master` immediately afterwards equals the tip master
       held before the attempt.
-- [ ] AC4: at least one docs-only tracking commit is pushed directly to master
+- [x] AC4: at least one docs-only tracking commit is pushed directly to master
       after both rulesets are active, and `git log origin/master` shows it —
       i.e. the carve-out the bypass exists to preserve still works.
-- [ ] AC5: `tools/check-branch-protection.R` exits zero when the live rulesets
+- [x] AC5: `tools/check-branch-protection.R` exits zero when the live rulesets
       agree with committed `tools/branch-protection.json`, and non-zero on a
       difference in any field named by its own `COMPARED_FIELDS` constant.
-- [ ] AC6: `cairn/PROFILE.md`'s consistency-gate section names
+- [x] AC6: `cairn/PROFILE.md`'s consistency-gate section names
       `tools/check-branch-protection.R` as a check the review gate runs, and
       `wc -l cairn/PROFILE.md` is ≤ 120.
 - [ ] AC7: `Rscript -e 'devtools::test()'` clean and
@@ -154,3 +154,14 @@ entry recording the two-ruleset split and the bypass rationale.
 ## Decisions
 
 ## Review
+
+Review 2026-08-22 (PR #134). Evidence per criterion, fresh at review:
+
+- AC1: `gh api repos/jmgirard/circumplex/rulesets` → exactly two branch rulesets, both `enforcement: "active"`: 21216269 `master-destructive` (rules deletion + non_fast_forward + required_linear_history, `bypass_actors` []) and 21216270 `master-checks` (rules required_status_checks only, one bypass actor RepositoryRole/5/always). Verified.
+- AC2: 21216270's contexts read back as exactly `["matrix", "ubuntu-latest (release)"]`. Verified.
+- AC3: T6's attempt (`git push --force origin 0b1e1957:master`, run by Jeff) was refused — `remote: error: GH013: Repository rule violations found for refs/heads/master` — and `git rev-parse origin/master` at review still equals cd08db79, the pre-attempt tip. Verified.
+- AC4: docs-only commit cd08db79 pushed directly to master under both active rulesets is at `origin/master` tip at review; the remote's push reply showed the checks rule firing and the admin bypass carrying it. Verified.
+- AC5: pass arm exit 0 against the live pair; fail arm re-proved at review with a SECOND mutation battery using different forms than implement's (enforcement→disabled, target→tag, include→refs/heads/main, an ADDED rule type, an ADDED context, bypass_actors emptied) — all six exit 1, each naming exactly the mutated COMPARED_FIELDS field; clean pass after restore. Verified.
+- AC6: `cairn/PROFILE.md:49` names the checker in the consistency-gate; `wc -l` = 119 ≤ 120. Verified.
+
+Consistency gate: `cairn_validate` all OK (WARN work-log format = M7's standing pre-M28 advisory). No principle change → `cairn_impact` skipped. `document()` no diff, zero resolve-link lines. README untouched. `pkgdown::check_pkgdown()` no problems. NEWS: no user-visible package change (internal tier — repo settings + tools/) → no entry owed. No new top-level files (`tools/` predates, `^tools$` in .Rbuildignore). Master watches: newest verdict-reaching push runs green on both workflows (ab83f30b success ×2; newer cairn-only pushes run none, per paths-ignore — said so per M95). Alert audits: check-master-red-alert.R and dryrun both clean. Branch-protection check: exit 0.

--- a/tools/branch-protection.json
+++ b/tools/branch-protection.json
@@ -1,0 +1,74 @@
+{
+  "_readme": [
+    "Intended shape of this repository's two branch rulesets (cairn M105).",
+    "",
+    "Source of truth for tools/check-branch-protection.R, which reads the LIVE",
+    "rulesets via `gh api` and fails on any difference in the fields named by",
+    "that script's COMPARED_FIELDS constant.",
+    "",
+    "Two rulesets, not one, because a ruleset's bypass actor bypasses EVERY rule",
+    "in that ruleset. The destructive rules must bind the repository admin, and",
+    "the required-status-check rule must not: required status checks block direct",
+    "pushes as well as merges, and a `cairn/**`-only push runs no workflow at all,",
+    "so without the bypass the cairn docs-only direct-push carve-out deadlocks.",
+    "",
+    "Each element of `rulesets` below is a complete POST body for",
+    "`gh api --method POST repos/OWNER/REPO/rulesets`, so what is committed here",
+    "is what was created rather than a transcription of it. Server-assigned",
+    "fields (id, node_id, source, source_type, created_at, updated_at, _links)",
+    "are absent by design: they are not part of the intent.",
+    "",
+    "`~DEFAULT_BRANCH` rather than `refs/heads/master`: cairn never hardcodes the",
+    "default branch name, and this targeting follows a rename."
+  ],
+  "rulesets": [
+    {
+      "name": "master-destructive",
+      "target": "branch",
+      "enforcement": "active",
+      "conditions": {
+        "ref_name": {
+          "include": ["~DEFAULT_BRANCH"],
+          "exclude": []
+        }
+      },
+      "rules": [
+        { "type": "deletion" },
+        { "type": "non_fast_forward" },
+        { "type": "required_linear_history" }
+      ],
+      "bypass_actors": []
+    },
+    {
+      "name": "master-checks",
+      "target": "branch",
+      "enforcement": "active",
+      "conditions": {
+        "ref_name": {
+          "include": ["~DEFAULT_BRANCH"],
+          "exclude": []
+        }
+      },
+      "rules": [
+        {
+          "type": "required_status_checks",
+          "parameters": {
+            "strict_required_status_checks_policy": false,
+            "do_not_enforce_on_create": false,
+            "required_status_checks": [
+              { "context": "matrix" },
+              { "context": "ubuntu-latest (release)" }
+            ]
+          }
+        }
+      ],
+      "bypass_actors": [
+        {
+          "actor_type": "RepositoryRole",
+          "actor_id": 5,
+          "bypass_mode": "always"
+        }
+      ]
+    }
+  ]
+}

--- a/tools/check-branch-protection.R
+++ b/tools/check-branch-protection.R
@@ -1,0 +1,193 @@
+#!/usr/bin/env Rscript
+
+# Guard: this repository's LIVE branch rulesets must match the intent committed
+# in tools/branch-protection.json (cairn M105).
+#
+# Why this exists. Branch protection lives in GitHub's settings, not in the
+# tree, so it can be changed in the web UI — weakened, disabled, or deleted —
+# without leaving a trace any commit, review, or `R CMD check` would show. The
+# committed JSON is the intent; this script is the only thing that notices when
+# GitHub stops agreeing with it.
+#
+# It asserts `enforcement` as one of the compared fields deliberately. A ruleset
+# whose rules are all still correct but whose enforcement has been flipped to
+# "disabled" or "evaluate" is the failure mode that looks most like health: the
+# rules are right there in the UI, and they bind nothing. Validating the rules
+# without validating the switch that makes them authoritative leaves the hole
+# exactly where regression is likeliest (the lesson cairn M58 recorded).
+#
+# Scope: rulesets with `target: "branch"` whose source is this repository.
+# Tag and push rulesets, and any inherited from an owning organization, are
+# outside what the committed file describes and are not compared.
+#
+# Run by /milestone-review via cairn/PROFILE.md's consistency-gate. Needs `gh`
+# authenticated (the rulesets API is not public) and the `jsonlite` package;
+# it says so and fails rather than passing when either is missing. Not part of
+# the built package (`^tools$` is in .Rbuildignore).
+
+INTENT <- "tools/branch-protection.json"
+
+# ---- the compared domain --------------------------------------------------
+
+# The fields compared between the committed intent and the live API. The
+# comparison iterates this constant, so this vector — not any prose elsewhere —
+# is the domain over which "the live rulesets match the committed intent" is
+# claimed. Each name must have an extractor in EXTRACT below.
+COMPARED_FIELDS <- c(
+  "enforcement",
+  "target",
+  "ref_name_include",
+  "rule_types",
+  "required_status_check_contexts",
+  "bypass_actors"
+)
+
+# One extractor per compared field, applied to BOTH sides — a projection bug
+# therefore cannot make the two sides falsely agree in only one direction.
+# Each returns a character vector; order-insensitive fields are sorted so a
+# reordering in the API response is not reported as drift.
+EXTRACT <- list(
+  enforcement = function(r) as.character(r$enforcement %||% NA_character_),
+  target = function(r) as.character(r$target %||% NA_character_),
+  ref_name_include = function(r) {
+    sort(vapply(r$conditions$ref_name$include %||% list(), as.character, ""))
+  },
+  rule_types = function(r) {
+    sort(vapply(r$rules %||% list(), function(x) as.character(x$type), ""))
+  },
+  required_status_check_contexts = function(r) {
+    rules <- r$rules %||% list()
+    checks <- rules[vapply(rules, function(x) identical(x$type, "required_status_checks"), NA)]
+    sort(unlist(lapply(checks, function(x) {
+      vapply(x$parameters$required_status_checks %||% list(),
+             function(cc) as.character(cc$context), "")
+    }), use.names = FALSE))
+  },
+  bypass_actors = function(r) {
+    sort(vapply(r$bypass_actors %||% list(), function(a) {
+      sprintf("%s/%s/%s",
+              as.character(a$actor_type %||% NA_character_),
+              as.character(a$actor_id %||% NA_character_),
+              as.character(a$bypass_mode %||% NA_character_))
+    }, ""))
+  }
+)
+
+`%||%` <- function(x, y) if (is.null(x)) y else x
+
+stopifnot(setequal(COMPARED_FIELDS, names(EXTRACT)))
+
+# ---- fail-closed preconditions --------------------------------------------
+
+die <- function(...) stop(sprintf(...), call. = FALSE)
+
+if (!requireNamespace("jsonlite", quietly = TRUE)) {
+  die("this guard parses JSON and needs the `jsonlite` package installed.")
+}
+if (!nzchar(Sys.which("gh"))) {
+  die("this guard reads the live rulesets and needs the GitHub CLI (`gh`) on PATH.")
+}
+if (!file.exists(INTENT)) {
+  die("%s: file not found (run from the repository root).", INTENT)
+}
+
+# Every `gh` call is fail-closed: a non-zero exit, or output that is not the
+# JSON we expect, stops the script. There is no arm that treats an unanswered
+# question as agreement.
+gh <- function(...) {
+  args <- c(...)
+  out <- suppressWarnings(system2("gh", args, stdout = TRUE, stderr = TRUE))
+  status <- attr(out, "status") %||% 0L
+  if (!identical(as.integer(status), 0L)) {
+    die("`gh %s` failed (exit %s):\n%s",
+        paste(args, collapse = " "), status, paste(out, collapse = "\n"))
+  }
+  paste(out, collapse = "\n")
+}
+
+parse_json <- function(txt, what) {
+  parsed <- tryCatch(
+    jsonlite::fromJSON(txt, simplifyVector = FALSE),
+    error = function(e) die("%s: could not be parsed as JSON: %s", what, conditionMessage(e))
+  )
+  parsed
+}
+
+# ---- read both sides ------------------------------------------------------
+
+intent <- parse_json(paste(readLines(INTENT, warn = FALSE), collapse = "\n"), INTENT)
+committed <- intent$rulesets %||% list()
+if (!length(committed)) {
+  die("%s: no `rulesets` array, or it is empty — nothing to enforce.", INTENT)
+}
+
+# The slug comes from the checkout's own remote, so this guard is not pinned to
+# one repository name.
+slug <- trimws(gh("repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"))
+if (!grepl("^[^/]+/[^/]+$", slug)) {
+  die("could not derive OWNER/REPO from the checkout (got %s).", dQuote(slug))
+}
+
+summaries <- parse_json(gh("api", sprintf("repos/%s/rulesets", slug)),
+                        sprintf("the ruleset list for %s", slug))
+
+# Only this repository's own branch rulesets; see the scope note in the header.
+summaries <- Filter(function(s) {
+  identical(s$target, "branch") && identical(s$source_type %||% "Repository", "Repository")
+}, summaries)
+
+live <- lapply(summaries, function(s) {
+  parse_json(gh("api", sprintf("repos/%s/rulesets/%s", slug, s$id)),
+             sprintf("ruleset %s", s$id))
+})
+names(live) <- vapply(live, function(r) as.character(r$name), "")
+names(committed) <- vapply(committed, function(r) as.character(r$name), "")
+
+# ---- compare --------------------------------------------------------------
+
+problems <- character(0L)
+
+missing <- setdiff(names(committed), names(live))
+for (nm in missing) {
+  problems <- c(problems, sprintf(
+    "ruleset %s is committed in %s but does not exist on %s.", dQuote(nm), INTENT, slug))
+}
+unexpected <- setdiff(names(live), names(committed))
+for (nm in unexpected) {
+  problems <- c(problems, sprintf(
+    "branch ruleset %s exists on %s but is not committed in %s.", dQuote(nm), slug, INTENT))
+}
+
+show <- function(x) if (!length(x)) "<none>" else paste(x, collapse = ", ")
+
+for (nm in intersect(names(committed), names(live))) {
+  for (field in COMPARED_FIELDS) {
+    want <- EXTRACT[[field]](committed[[nm]])
+    got <- EXTRACT[[field]](live[[nm]])
+    if (!identical(want, got)) {
+      problems <- c(problems, sprintf(
+        "ruleset %s, field %s:\n    committed: %s\n    live:      %s",
+        dQuote(nm), field, show(want), show(got)))
+    }
+  }
+}
+
+# ---- report ---------------------------------------------------------------
+
+if (length(problems)) {
+  message(sprintf("Branch protection on %s does NOT match %s:\n", slug, INTENT))
+  for (p in problems) message("  - ", p)
+  message(sprintf(
+    "\nEither the settings drifted and should be restored, or the change was\nintended and %s should be updated to match in the same commit.",
+    INTENT))
+  quit(status = 1L)
+}
+
+message(sprintf("Branch protection on %s matches %s:", slug, INTENT))
+for (nm in names(committed)) {
+  message(sprintf("  - %s: %s (%s), bypass %s",
+                  nm,
+                  show(EXTRACT$rule_types(live[[nm]])),
+                  EXTRACT$enforcement(live[[nm]]),
+                  show(EXTRACT$bypass_actors(live[[nm]]))))
+}

--- a/tools/check-branch-protection.R
+++ b/tools/check-branch-protection.R
@@ -37,6 +37,7 @@ COMPARED_FIELDS <- c(
   "enforcement",
   "target",
   "ref_name_include",
+  "ref_name_exclude",
   "rule_types",
   "required_status_check_contexts",
   "bypass_actors"
@@ -50,18 +51,30 @@ EXTRACT <- list(
   enforcement = function(r) as.character(r$enforcement %||% NA_character_),
   target = function(r) as.character(r$target %||% NA_character_),
   ref_name_include = function(r) {
-    sort(vapply(r$conditions$ref_name$include %||% list(), as.character, ""))
+    sort(vapply(r$conditions$ref_name$include %||% list(), as.character, ""),
+         na.last = TRUE)
+  },
+  # The exclude list is a switch beside the rules it can disable: one pattern
+  # matching the default branch turns the ruleset off for it while enforcement
+  # stays "active" and include stays untouched (review finding, M105).
+  ref_name_exclude = function(r) {
+    sort(vapply(r$conditions$ref_name$exclude %||% list(), as.character, ""),
+         na.last = TRUE)
   },
   rule_types = function(r) {
-    sort(vapply(r$rules %||% list(), function(x) as.character(x$type), ""))
+    sort(vapply(r$rules %||% list(), function(x) as.character(x$type), ""),
+         na.last = TRUE)
   },
   required_status_check_contexts = function(r) {
     rules <- r$rules %||% list()
     checks <- rules[vapply(rules, function(x) identical(x$type, "required_status_checks"), NA)]
+    # na.last = TRUE throughout: sort()'s default na.last = NA silently DROPS
+    # an NA element, which would erase a malformed live entry instead of
+    # flagging it (the M98 lesson's shape).
     sort(unlist(lapply(checks, function(x) {
       vapply(x$parameters$required_status_checks %||% list(),
              function(cc) as.character(cc$context), "")
-    }), use.names = FALSE))
+    }), use.names = FALSE), na.last = TRUE)
   },
   bypass_actors = function(r) {
     sort(vapply(r$bypass_actors %||% list(), function(a) {
@@ -86,6 +99,10 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
 }
 if (!nzchar(Sys.which("gh"))) {
   die("this guard reads the live rulesets and needs the GitHub CLI (`gh`) on PATH.")
+}
+if (!identical(suppressWarnings(system2("gh", c("auth", "status"),
+                                        stdout = FALSE, stderr = FALSE)), 0L)) {
+  die("`gh` is not authenticated (`gh auth status` failed) — the rulesets API needs auth.")
 }
 if (!file.exists(INTENT)) {
   die("%s: file not found (run from the repository root).", INTENT)
@@ -128,12 +145,12 @@ if (!grepl("^[^/]+/[^/]+$", slug)) {
   die("could not derive OWNER/REPO from the checkout (got %s).", dQuote(slug))
 }
 
-summaries <- parse_json(gh("api", sprintf("repos/%s/rulesets", slug)),
+summaries <- parse_json(gh("api", "--paginate", sprintf("repos/%s/rulesets", slug)),
                         sprintf("the ruleset list for %s", slug))
 
 # Only this repository's own branch rulesets; see the scope note in the header.
 summaries <- Filter(function(s) {
-  identical(s$target, "branch") && identical(s$source_type %||% "Repository", "Repository")
+  identical(s$target, "branch") && identical(s$source_type %||% "", "Repository")
 }, summaries)
 
 live <- lapply(summaries, function(s) {
@@ -142,6 +159,13 @@ live <- lapply(summaries, function(s) {
 })
 names(live) <- vapply(live, function(r) as.character(r$name), "")
 names(committed) <- vapply(committed, function(r) as.character(r$name), "")
+
+# GitHub permits two rulesets with one name; a by-name lookup would compare
+# only the first and silently skip its twin. Refuse rather than guess.
+if (anyDuplicated(names(live))) {
+  die("two live branch rulesets share a name (%s) — refusing to compare by name.",
+      paste(unique(names(live)[duplicated(names(live))]), collapse = ", "))
+}
 
 # ---- compare --------------------------------------------------------------
 


### PR DESCRIPTION
Two rulesets on the default branch — `master-destructive` (deletion/non_fast_forward/required_linear_history, no bypass) and `master-checks` (required checks `matrix` + `ubuntu-latest (release)`, admin bypass) — plus committed intent (`tools/branch-protection.json`), a live-vs-committed checker (`tools/check-branch-protection.R`) wired into the consistency gate, and D-047. Cairn milestone M105.