### PR TITLE
M110: correct the calibration-domain claim in the accuracy target and its shipped surfaces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,7 +76,10 @@ plotting layer has been rebuilt on a real ggplot2 coordinate system.
   from the coverage of a nominal 95% Wald interval, and corroborated by the
   standard error's own sampling variability, under which a numerical error at
   the target is about a tenth of the statistical noise already in the number
-  for a typical design at sample sizes up to about 500,000 — divided by the
+  for a typical design (coefficient `1/sqrt(2)`) at sample sizes to 500,000,
+  and at the least favorable geometry measured (coefficient `0.045`) only to
+  about 2,000 — below the sample sizes typical of published circumplex
+  correlation matrices — divided by the
   factor of `10` by which the criterion's error bound may undershoot the error
   it stands for. Where this criterion refuses for ill-conditioning, the
   warning also names the conditioning — the condition number where the

--- a/NEWS.md
+++ b/NEWS.md
@@ -76,10 +76,10 @@ plotting layer has been rebuilt on a real ggplot2 coordinate system.
   from the coverage of a nominal 95% Wald interval, and corroborated by the
   standard error's own sampling variability, under which a numerical error at
   the target is about a tenth of the statistical noise already in the number
-  for a typical design (coefficient `1/sqrt(2)`) at sample sizes to 500,000,
-  and at the least favorable geometry measured (coefficient `0.045`) only to
-  about 2,000 — below the sample sizes typical of published circumplex
-  correlation matrices — divided by the
+  at sample sizes up to about 500,000 for `1/sqrt(2)`, the typical relative
+  sampling coefficient, and only up to about 2,000 for `0.045`, the least
+  favorable geometry measured (below the sample sizes typical of published
+  circumplex correlation matrices) — divided by the
   factor of `10` by which the criterion's error bound may undershoot the error
   it stands for. Where this criterion refuses for ill-conditioning, the
   warning also names the conditioning — the condition number where the

--- a/R/axes_corrected_se.R
+++ b/R/axes_corrected_se.R
@@ -498,7 +498,8 @@ axes_corrected_se <- function(sigma, item_names, item_angle_deg, item_scale,
 #     gradient near-cancellation, which no theorem bounds away from zero.
 #     Holding the numerical bias to a tenth of that noise -- the conventional
 #     "numerical error much smaller than statistical error" margin -- gives
-#     0.1*a/sqrt(n), which at the anchor and n = 5e5 is 1.0e-4.
+#     0.1*a/sqrt(n), which at the anchor a = 1/sqrt(2) and n = 5e5 is
+#     1.0e-4.
 #
 #     CALIBRATION DOMAIN of channel 3, stated because the coefficient and n
 #     both move it. Solving 0.1*a/sqrt(n) = delta_star gives the tenth-margin
@@ -516,8 +517,14 @@ axes_corrected_se <- function(sigma, item_names, item_angle_deg, item_scale,
 #     n-dependent target would rebuild the sliding scale rejected just below,
 #     and the exposure is to the wording rather than to the number, since
 #     measured attainment of the error bound over reachable geometries is at
-#     most 4e-6, so actual errors run about 1e-12. n = 5e5 is 1.7 decades past
-#     the n ~ 1e4 ceiling of published circumplex correlation matrices.
+#     most 4e-6, so actual errors run about 1e-12. The two tenth-margin
+#     endpoints fall on opposite sides of the n ~ 1e4 ceiling of published
+#     circumplex correlation matrices: the anchor's n = 5.0e5 (a = 1/sqrt(2))
+#     is 1.7 decades past that ceiling, while the worst measured geometry's
+#     n = 2.0e3 (a = 0.045) is below it -- so at that geometry the
+#     noise-dominance reading lapses inside the published range, not far
+#     beyond it, and only the fixed cap delta_star carries the guarantee
+#     there.
 #
 #     WHY THE SAMPLING CHANNEL CANNOT BE THE PRIMARY ONE (RR20 section 2). Read
 #     as a uniform requirement -- bias below a tenth of the noise at EVERY

--- a/R/axes_reliability.R
+++ b/R/axes_reliability.R
@@ -727,9 +727,13 @@ axes_resolve_blocks <- function(blocks, src, all_cols) {
 #' printed at, and the coverage of a nominal 95% Wald interval -- and is
 #' corroborated by a third, the standard error's own sampling variability,
 #' under which a numerical error at the target is about a tenth of the
-#' statistical noise already in the number for a typical design at
-#' `n` up to about `5e5`. Above that the guarantee is the fixed target alone,
-#' not noise dominance. The derivation and the premises it rests on are stated
+#' statistical noise already in the number for a typical design (relative
+#' sampling coefficient `a = 1/sqrt(2)`) at `n` up to about `5e5`. That
+#' endpoint scales as `1e6 * a^2`, so at the least favorable geometry
+#' measured, `a = 0.045`, it falls to `n` of about `2e3` -- below the `n` of
+#' about `1e4` typical of published circumplex correlation matrices. Above
+#' the endpoint the guarantee is the fixed target alone, not noise
+#' dominance. The derivation and the premises it rests on are stated
 #' beside the constant in the source. The refusal
 #' says which degeneracy happened: `"indefinite"` when the smallest
 #' eigenvalue is decisively negative (below
@@ -1042,7 +1046,8 @@ axes_resolve_blocks <- function(blocks, src, all_cols) {
 #'   fitted covariance matrix, where the `1e-5` is the `1e-4` accuracy target
 #'   divided by the criterion's factor-of-`10` calibration ceiling, and the
 #'   target's noise-dominance reading is calibrated for `n` up to about
-#'   `5e5`):
+#'   `5e5` at a typical design (`a = 1/sqrt(2)`) and only to about `2e3` at
+#'   the least favorable geometry measured (`a = 0.045`)):
 #'   `"indefinite"` for a decisively negative
 #'   smallest eigenvalue
 #'   (below `-lambda_max * sqrt(p * .Machine$double.eps)`), a

--- a/R/axes_reliability.R
+++ b/R/axes_reliability.R
@@ -732,9 +732,9 @@ axes_resolve_blocks <- function(blocks, src, all_cols) {
 #' endpoint scales as `1e6 * a^2`, so at the least favorable geometry
 #' measured, `a = 0.045`, it falls to `n` of about `2e3` -- below the `n` of
 #' about `1e4` typical of published circumplex correlation matrices. Above
-#' the endpoint the guarantee is the fixed target alone, not noise
-#' dominance. The derivation and the premises it rests on are stated
-#' beside the constant in the source. The refusal
+#' whichever endpoint the design's own coefficient sets, the guarantee is the
+#' fixed target alone, not noise dominance. The derivation and the premises
+#' it rests on are stated beside the constant in the source. The refusal
 #' says which degeneracy happened: `"indefinite"` when the smallest
 #' eigenvalue is decisively negative (below
 #' `-lambda_max * sqrt(p * .Machine$double.eps)` -- beyond the fit's own

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -14,7 +14,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M7 | v2.0.0 CRAN release preparation | blocked | — (all deps done) | high | milestones/M7-v2-release-prep.md |
 | M108 | Build and validate a per-fit accuracy certificate | done | — | normal | milestones/archive/M108-per-fit-certificate.md |
 | M109 | Repair the test guards that skip on the surface that ships | planned | — | normal | milestones/M109-source-tree-test-reads.md |
-| M110 | Correct the calibration-domain claim in the accuracy target and its shipped surfaces | planned | — | high | milestones/M110-calibration-domain-claim.md |
+| M110 | Correct the calibration-domain claim in the accuracy target and its shipped surfaces | in-progress | — | high | milestones/M110-calibration-domain-claim.md |
 | M111 | Shrink the ill-conditioning refusal to what the certificate cannot certify | planned | M108 | normal | milestones/M111-certificate-refusal-region.md |
 | M105 | Give master GitHub-native branch protection | done | — | normal | milestones/archive/M105-master-branch-protection.md |
 

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -14,7 +14,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | M7 | v2.0.0 CRAN release preparation | blocked | — (all deps done) | high | milestones/M7-v2-release-prep.md |
 | M108 | Build and validate a per-fit accuracy certificate | done | — | normal | milestones/archive/M108-per-fit-certificate.md |
 | M109 | Repair the test guards that skip on the surface that ships | planned | — | normal | milestones/M109-source-tree-test-reads.md |
-| M110 | Correct the calibration-domain claim in the accuracy target and its shipped surfaces | in-progress | — | high | milestones/M110-calibration-domain-claim.md |
+| M110 | Correct the calibration-domain claim in the accuracy target and its shipped surfaces | review | — | high | milestones/M110-calibration-domain-claim.md |
 | M111 | Shrink the ill-conditioning refusal to what the certificate cannot certify | planned | M108 | normal | milestones/M111-certificate-refusal-region.md |
 | M105 | Give master GitHub-native branch protection | done | — | normal | milestones/archive/M105-master-branch-protection.md |
 

--- a/cairn/milestones/M110-calibration-domain-claim.md
+++ b/cairn/milestones/M110-calibration-domain-claim.md
@@ -40,13 +40,13 @@ typical, two do not.
 
 ## Acceptance criteria
 
-- [ ] AC1: The calibration-domain paragraph closes by stating the domain
+- [x] AC1: The calibration-domain paragraph closes by stating the domain
       endpoint at the worst measured coefficient (a = 0.045, tenth-margin
       n = 2.0e3) alongside the anchor's (a = 1/sqrt(2), n = 5.0e5), and says
       which of the two lies below the n ~ 1e4 ceiling of published circumplex
       correlation matrices. The source's own spelling of the coefficient
       (0.045) is used; the archived review spells it 0.046 and is not edited.
-- [ ] AC2: Every line that `grep -rnE '5e5|5\.0e5|500,000' R/ man/ NEWS.md`
+- [x] AC2: Every line that `grep -rnE '5e5|5\.0e5|500,000' R/ man/ NEWS.md`
       returns either names the coefficient its figure belongs to, or does not
       state that figure as the calibration domain.
 - [ ] AC3: `Rscript -e 'options(cli.width = 500); devtools::document()'`
@@ -90,7 +90,27 @@ typical, two do not.
 - 2026-08-24: T4 — a help-page guard at `tests/testthat/test-axes-reliability.R:3235+` cuts the Rd into sentences and requires each of the two `5e5` sentences to name `a = 1/sqrt(2)` and each `2e3` sentence to name `a = 0.045`, using the dual-source man/-or-`Rd_db()` read the file's other Rd guards use (under check only the `Rd_db()` arm runs). Proved able to fail on two planted defects: reverting both sites reddens 4 of 6 assertions, reverting only the unqualified `\value` site reddens 2 of 7 — the sentence count alone stays green on the first defect, which is why the per-sentence match carries the claim.
 - 2026-08-24: verification — `document()` no diff and no `resolve link` line; `devtools::test()` FAIL 0, PASS 8627 (8619 before, the 8 added being this guard's); `devtools::check(args = "--no-manual")` Status OK, 0 errors / 0 warnings / 0 notes. Status → review.
 - 2026-08-24: review opened — master in sync, branch pushed, draft PR #140; evidence gathering under way.
+- 2026-08-24: review round 1 — AC1 and AC2 verified with fresh evidence and ticked; `devtools::test()` FAIL 0, PASS 8627; AC3's check still running.
 
 ## Decisions
 
 ## Review
+
+Round 1. PR #140 (draft at evidence time). Master in sync at `9374d4e8`;
+branch 4 ahead, 0 behind, no merge needed.
+
+**Acceptance criteria — fresh evidence.**
+
+- AC1 ✓ (2026-08-24). Read `R/axes_corrected_se.R:519-527`: the paragraph
+  closes "The two tenth-margin endpoints fall on opposite sides of the
+  n ~ 1e4 ceiling of published circumplex correlation matrices: the anchor's
+  n = 5.0e5 (a = 1/sqrt(2)) is 1.7 decades past that ceiling, while the worst
+  measured geometry's n = 2.0e3 (a = 0.045) is below it". Both endpoints
+  carry their coefficients, and it says which lies below the ceiling.
+  Arithmetic re-derived from the block's own `n = 1e6 * a^2`: a = 0.045 gives
+  2025, a = 1/sqrt(2) gives 5.0e5, log10(5e5/1e4) = 1.699. `grep -rn 0.046 R/
+  man/ NEWS.md` returns nothing — the source's own `0.045` is used throughout.
+- AC2 ✓ (2026-08-24). `grep -rnE '5e5|5\.0e5|500,000' R/ man/ NEWS.md`
+  returns 9 lines: `R/axes_reliability.R` 731, 1049; `R/axes_corrected_se.R`
+  501, 508, 522, 539; `man/axes_reliability.Rd` 88, 233; `NEWS.md` 79. Each
+  names the coefficient its figure belongs to (`a = 1/sqrt(2)` at all nine).

--- a/cairn/milestones/M110-calibration-domain-claim.md
+++ b/cairn/milestones/M110-calibration-domain-claim.md
@@ -153,6 +153,31 @@ verbatim where quoted, disposition and reason per finding.
   The GitHub inline-comment probe returned an empty array, so that surface was
   skipped.
 
+**Gate-directed fixes (2026-08-24).** Jeff chose "fix five, then merge".
+
+- F1 repaired: the guard now requires each figure within a 120-character
+  window of its coefficient (measured gaps 25/32 for the anchor, 46/34 for the
+  worst geometry) and asserts occurrences rather than chunks. Proved
+  discriminating on F1's own scenario — the `\value` figure stated bare with
+  the coefficients surviving elsewhere in the same 2,635-character block, no
+  sentence boundary introduced: the pre-fix sentence-splitting form stays
+  green (both `all(grepl(...))` TRUE), the window form reddens with 2
+  failures.
+- F2, F4, F9 repaired together in one NEWS rewrite: the inserted clause is
+  parenthesized so the em-dash pair around the appositive is restored (two
+  em-dashes now, not four), "up to about" is restored at both figures, and
+  `1/sqrt(2)` is glossed as "the typical relative sampling coefficient".
+- F8 repaired: "Above the endpoint" → "Above whichever endpoint the design's
+  own coefficient sets"; Rd regenerated.
+- F3 routed to a follow-up on the existing degeneracy candidate row, into
+  M111, which reopens `R/axes_corrected_se.R`.
+
+Post-fix re-verification: AC2 sweep still returns 9 lines, each naming its
+coefficient; `document()` exit 0, zero `resolve link` lines, no further
+generated-file drift; `devtools::test()` FAIL 0 | WARN 5 | SKIP 1 | PASS 8627;
+`devtools::check(args = "--no-manual")` exit 0, Status: OK.
+- 2026-08-24: gate — Jeff chose fix-five-then-merge; F1/F2/F4/F8/F9 fixed on the branch and re-verified clean, F3 routed to M111, six findings rejected with reasons in the Review section.
+
 ## Decisions
 
 ## Review

--- a/cairn/milestones/M110-calibration-domain-claim.md
+++ b/cairn/milestones/M110-calibration-domain-claim.md
@@ -65,7 +65,7 @@ typical, two do not.
 - [x] T1: Rewrite the closing sentence at `R/axes_corrected_se.R:484-485`. The
       arithmetic is already in the block at `:469-473`: the tenth-margin is
       `n = 1e6 * a^2`, so a = 0.045 gives 2.0e3 and a = 1/sqrt(2) gives 5.0e5.
-- [ ] T2: Correct the two roxygen sites — `R/axes_reliability.R:1045`
+- [x] T2: Correct the two roxygen sites — `R/axes_reliability.R:1045`
       ("calibrated for `n` up to about `5e5`", unqualified) and `:731`
       ("for a typical design at `n` up to about `5e5`", which names the typical
       case but never says the domain ends below the published ceiling at the
@@ -85,6 +85,7 @@ typical, two do not.
 - 2026-08-24: plan gate chose a bounded repair of one named sentence over reopening general prose certification, because the general form failed three review rounds in M106 and was descoped there; falsified by a second defect of the same class turning up in the block.
 - 2026-08-24: criteria audit (FULL mode, [O], fresh context) returned three findings here, all fixed before writing. The sweep's literal `5e5` missed `5.0e5`, which the target file itself uses at `R/axes_corrected_se.R:472`, and its `R/ man/` directory set missed `NEWS.md:79`, which ships and carries the same unqualified claim — both verified against the repo and the sweep widened. A drafted criterion binding the existence of a pinning test was an instrument promise rather than a property of the deliverable; it moved to T4, leaving AC2 to bind the shipped text itself.
 - 2026-08-24: T1 — the closing sentence now states both tenth-margin endpoints with their coefficients and which falls below the n ~ 1e4 published ceiling; the channel-3 line at :501 gained the anchor's value so its 5e5 names its coefficient too. Full suite clean (FAIL 0, PASS 8619).
+- 2026-08-24: T2 — both roxygen sites now carry the anchor and worst-measured endpoints with their coefficients, per the gate's choice to name both rather than drop the figures; `document()` regenerated `man/axes_reliability.Rd` and emitted no `resolve link` line.
 
 ## Decisions
 

--- a/cairn/milestones/M110-calibration-domain-claim.md
+++ b/cairn/milestones/M110-calibration-domain-claim.md
@@ -49,7 +49,7 @@ typical, two do not.
 - [x] AC2: Every line that `grep -rnE '5e5|5\.0e5|500,000' R/ man/ NEWS.md`
       returns either names the coefficient its figure belongs to, or does not
       state that figure as the calibration domain.
-- [ ] AC3: `Rscript -e 'options(cli.width = 500); devtools::document()'`
+- [x] AC3: `Rscript -e 'options(cli.width = 500); devtools::document()'`
       produces no diff and emits no line matching `resolve link`;
       `Rscript -e 'devtools::test()'` and
       `Rscript -e 'devtools::check(args = "--no-manual")'` clean.
@@ -91,6 +91,7 @@ typical, two do not.
 - 2026-08-24: verification — `document()` no diff and no `resolve link` line; `devtools::test()` FAIL 0, PASS 8627 (8619 before, the 8 added being this guard's); `devtools::check(args = "--no-manual")` Status OK, 0 errors / 0 warnings / 0 notes. Status → review.
 - 2026-08-24: review opened — master in sync, branch pushed, draft PR #140; evidence gathering under way.
 - 2026-08-24: review round 1 — AC1 and AC2 verified with fresh evidence and ticked; `devtools::test()` FAIL 0, PASS 8627; AC3's check still running.
+- 2026-08-24: review round 1 — AC3 verified and ticked (`check(args = "--no-manual")` Status OK); consistency gate clean; three fresh-context lenses returned 12 findings, triage pending at the gate.
 
 ## Decisions
 
@@ -114,3 +115,29 @@ branch 4 ahead, 0 behind, no merge needed.
   returns 9 lines: `R/axes_reliability.R` 731, 1049; `R/axes_corrected_se.R`
   501, 508, 522, 539; `man/axes_reliability.Rd` 88, 233; `NEWS.md` 79. Each
   names the coefficient its figure belongs to (`a = 1/sqrt(2)` at all nine).
+- AC3 ✓ (2026-08-24). `Rscript -e 'options(cli.width = 500); devtools::document()'`
+  exit 0, zero lines matching `resolve link`, and `git status --porcelain`
+  showed no generated-file diff. `Rscript -e 'devtools::test()'`:
+  FAIL 0 | WARN 5 | SKIP 1 | PASS 8627.
+  `Rscript -e 'devtools::check(args = "--no-manual")'`: exit 0, Status: OK
+  (0 errors, 0 warnings, 0 notes).
+
+**Consistency gate.**
+
+- `cairn_validate.py` exit 0 — every check PASS, including `scaffold present`
+  and `coverage complete`; `release window` advisory silent. 47 `work-log
+  format` advisory WARNs, all pre-existing M7 lines, no gate failure.
+- `cairn_impact.py` skipped: the diff changes no `DESIGN.md` principle (IP1 is
+  touched, not amended; `DESIGN.md` is not in the diff).
+- Toolchain checks (`r-package` profile `consistency-gate`): `document()` no
+  diff and no unresolved-link warning (above); generated files unedited by
+  hand (same no-diff check); README.md/README.Rmd both untouched by the diff
+  and in sync at `7d258248`; `pkgdown::check_pkgdown()` "No problems found";
+  `NEWS.md` carries this milestone's user-visible change and names no
+  milestone number; no new top-level files, so no `.Rbuildignore` entry owed;
+  full `devtools::check()` (with manual) — running at the time of writing,
+  result recorded below. Master watches: newest
+  push-run verdict on `R-CMD-check.yaml` and on `test-coverage.yaml` is
+  `success` at `096b7cda` (master's tip `9374d4e8` is docs-only and triggers
+  no run). `tools/check-master-red-alert.R`, `tools/master-red-alert-dryrun.R`
+  and `tools/check-branch-protection.R` all exit clean.

--- a/cairn/milestones/M110-calibration-domain-claim.md
+++ b/cairn/milestones/M110-calibration-domain-claim.md
@@ -1,11 +1,11 @@
 # M110: Correct the calibration-domain claim in the accuracy target and its shipped surfaces
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** high
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** IP1
-- **Branch/PR:** —
+- **Branch/PR:** `m110-calibration-domain-claim`
 
 ## Goal
 
@@ -62,7 +62,7 @@ typical, two do not.
 
 ## Tasks
 
-- [ ] T1: Rewrite the closing sentence at `R/axes_corrected_se.R:484-485`. The
+- [x] T1: Rewrite the closing sentence at `R/axes_corrected_se.R:484-485`. The
       arithmetic is already in the block at `:469-473`: the tenth-margin is
       `n = 1e6 * a^2`, so a = 0.045 gives 2.0e3 and a = 1/sqrt(2) gives 5.0e5.
 - [ ] T2: Correct the two roxygen sites — `R/axes_reliability.R:1045`
@@ -84,6 +84,7 @@ typical, two do not.
 - 2026-08-24: created by /milestone-plan.
 - 2026-08-24: plan gate chose a bounded repair of one named sentence over reopening general prose certification, because the general form failed three review rounds in M106 and was descoped there; falsified by a second defect of the same class turning up in the block.
 - 2026-08-24: criteria audit (FULL mode, [O], fresh context) returned three findings here, all fixed before writing. The sweep's literal `5e5` missed `5.0e5`, which the target file itself uses at `R/axes_corrected_se.R:472`, and its `R/ man/` directory set missed `NEWS.md:79`, which ships and carries the same unqualified claim — both verified against the repo and the sweep widened. A drafted criterion binding the existence of a pinning test was an instrument promise rather than a property of the deliverable; it moved to T4, leaving AC2 to bind the shipped text itself.
+- 2026-08-24: T1 — the closing sentence now states both tenth-margin endpoints with their coefficients and which falls below the n ~ 1e4 published ceiling; the channel-3 line at :501 gained the anchor's value so its 5e5 names its coefficient too. Full suite clean (FAIL 0, PASS 8619).
 
 ## Decisions
 

--- a/cairn/milestones/M110-calibration-domain-claim.md
+++ b/cairn/milestones/M110-calibration-domain-claim.md
@@ -70,7 +70,7 @@ typical, two do not.
       ("for a typical design at `n` up to about `5e5`", which names the typical
       case but never says the domain ends below the published ceiling at the
       worst measured geometry). Regenerate the Rd.
-- [ ] T3: Correct `NEWS.md:79`, which carries the same claim spelled
+- [x] T3: Correct `NEWS.md:79`, which carries the same claim spelled
       `500,000` and so escapes a grep for the source's spelling.
 - [ ] T4: Add a test reading the two calibration-domain sentences from the
       installed help page via `tools::Rd_db("circumplex")`, failing if either
@@ -86,6 +86,7 @@ typical, two do not.
 - 2026-08-24: criteria audit (FULL mode, [O], fresh context) returned three findings here, all fixed before writing. The sweep's literal `5e5` missed `5.0e5`, which the target file itself uses at `R/axes_corrected_se.R:472`, and its `R/ man/` directory set missed `NEWS.md:79`, which ships and carries the same unqualified claim — both verified against the repo and the sweep widened. A drafted criterion binding the existence of a pinning test was an instrument promise rather than a property of the deliverable; it moved to T4, leaving AC2 to bind the shipped text itself.
 - 2026-08-24: T1 — the closing sentence now states both tenth-margin endpoints with their coefficients and which falls below the n ~ 1e4 published ceiling; the channel-3 line at :501 gained the anchor's value so its 5e5 names its coefficient too. Full suite clean (FAIL 0, PASS 8619).
 - 2026-08-24: T2 — both roxygen sites now carry the anchor and worst-measured endpoints with their coefficients, per the gate's choice to name both rather than drop the figures; `document()` regenerated `man/axes_reliability.Rd` and emitted no `resolve link` line.
+- 2026-08-24: T3 — the NEWS entry now gives both endpoints with their coefficients, and the paragraph is wrapped so the `500,000` figure and its `1/sqrt(2)` share a line; the AC2 sweep returns 9 lines and every one names the coefficient its figure belongs to.
 
 ## Decisions
 

--- a/cairn/milestones/M110-calibration-domain-claim.md
+++ b/cairn/milestones/M110-calibration-domain-claim.md
@@ -5,7 +5,7 @@
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** IP1
-- **Branch/PR:** `m110-calibration-domain-claim`
+- **Branch/PR:** `m110-calibration-domain-claim` — https://github.com/jmgirard/circumplex/pull/140
 
 ## Goal
 
@@ -89,6 +89,7 @@ typical, two do not.
 - 2026-08-24: T3 — the NEWS entry now gives both endpoints with their coefficients, and the paragraph is wrapped so the `500,000` figure and its `1/sqrt(2)` share a line; the AC2 sweep returns 9 lines and every one names the coefficient its figure belongs to.
 - 2026-08-24: T4 — a help-page guard at `tests/testthat/test-axes-reliability.R:3235+` cuts the Rd into sentences and requires each of the two `5e5` sentences to name `a = 1/sqrt(2)` and each `2e3` sentence to name `a = 0.045`, using the dual-source man/-or-`Rd_db()` read the file's other Rd guards use (under check only the `Rd_db()` arm runs). Proved able to fail on two planted defects: reverting both sites reddens 4 of 6 assertions, reverting only the unqualified `\value` site reddens 2 of 7 — the sentence count alone stays green on the first defect, which is why the per-sentence match carries the claim.
 - 2026-08-24: verification — `document()` no diff and no `resolve link` line; `devtools::test()` FAIL 0, PASS 8627 (8619 before, the 8 added being this guard's); `devtools::check(args = "--no-manual")` Status OK, 0 errors / 0 warnings / 0 notes. Status → review.
+- 2026-08-24: review opened — master in sync, branch pushed, draft PR #140; evidence gathering under way.
 
 ## Decisions
 

--- a/cairn/milestones/M110-calibration-domain-claim.md
+++ b/cairn/milestones/M110-calibration-domain-claim.md
@@ -93,6 +93,66 @@ typical, two do not.
 - 2026-08-24: review round 1 — AC1 and AC2 verified with fresh evidence and ticked; `devtools::test()` FAIL 0, PASS 8627; AC3's check still running.
 - 2026-08-24: review round 1 — AC3 verified and ticked (`check(args = "--no-manual")` Status OK); consistency gate clean; three fresh-context lenses returned 12 findings, triage pending at the gate.
 
+**Independent review — three fresh-context lenses, 12 findings.**
+
+[O] diff-bug, [S] blame-history, [S] prior-review. Ranked as reported; text
+verbatim where quoted, disposition and reason per finding.
+
+- **[O] F1 — the `\value`-site half of the new guard is not sentence-local.**
+  "its 'sentence' is a 2,635-character block spanning the tail of
+  `\arguments` plus the entire `\value` section." Re-verified by running the
+  test's own splitter over `man/axes_reliability.Rd`: the two `5e5` chunks are
+  2,635 and 464 characters, so at the `\value` site the guard only requires
+  the coefficient to appear somewhere in that block, not beside its figure;
+  `expect_identical(length(anchor), 2L)` also counts chunks, not occurrences.
+  → FIX NOW.
+- **[O] F2 — the NEWS insertion leaves three unpaired em-dashes**, so "divided
+  by the factor of `10`" no longer reliably attaches to "the accuracy target
+  `1e-4`"; a reader can close the appositive early and read `1e-5` as being
+  asserted below published sample sizes. → FIX NOW.
+- **[O] F3 — `R/axes_corrected_se.R:537` computes its `6.5e-6` corner from
+  a = 0.046, not the 0.045 the block states.** Confirmed pre-existing (present
+  in `origin/master`, untouched by this diff) and confirmed arithmetically:
+  0.1*0.045/sqrt(5e5) = 6.36e-6, 0.1*0.046/sqrt(5e5) = 6.51e-6.
+  → FOLLOW-UP (the diff makes it more reachable but did not introduce it).
+- **[O] F4 — NEWS's "(coefficient `1/sqrt(2)`)" is unglossed**: NEWS never
+  says what the number is a coefficient of, so a NEWS-only reader gets a token
+  rather than the information. → FIX NOW, folded into F2's rewrite.
+- **[O] F5 — "The two tenth-margin endpoints" reifies a two-point set out of a
+  measured continuum** whose upper end (a = 1.38) reaches n = 1.9e6.
+  → REJECT: the phrase is anaphoric to the two endpoints the preceding
+  sentence computes, not a claim that only two exist.
+- **[O] F6 — the `\value` site newly calls a = 1/sqrt(2) "a typical design"**
+  when the source derives it analytically. → REJECT: the source itself calls
+  it "a fair TYPICAL value", so the roxygen matches its own authority.
+- **[O] F7 — no prose surface carries the "no theorem bounds a away from
+  zero" caveat**, so `2e3` can read as a floor rather than the worst
+  *measured* endpoint. → REJECT: general certification of the derivation
+  block's prose is explicitly Out of scope, and "measured" is stated at every
+  surface.
+- **[O] F8 / [S] blame-history F2 (same finding) — "Above the endpoint the
+  guarantee is the fixed target alone" is ambiguous** now that two endpoints
+  are in scope; the pre-diff text read "Above that" with one antecedent.
+  → FIX NOW.
+- **[O] F9 — NEWS drops the "up to about" both roxygen sites keep**, stating a
+  rounded model-derived boundary as if exact. → FIX NOW, folded into F2's
+  rewrite.
+- **[S] blame-history F1 — the AC checkboxes were unticked at review entry.**
+  → REJECT (no change needed): that is the AC-fencing protocol — review ticks
+  each box against its own recorded evidence, which this section does.
+- **[S] prior-review F1 — the new test's "(M106 review round 4, F4)" citation
+  is mislabeled**, the lens holding that F4 names a round-3 print()/summary()
+  finding. → REJECT: refuted against the record. `cairn/ROADMAP.md:29` states
+  "M110 repairs M106's parked round-4 F4 defect: the calibration-domain
+  paragraph closes on the anchor's endpoint a sentence after putting the worst
+  geometry's a decade below the published ceiling" — the citation in the test
+  matches the repo's own record of what F4 is.
+- **[S] prior-review, [S] blame-history — no regression found.** Both lenses
+  confirmed M106's round-2 F13 (the coverage-units fix) and round-3 F2 (the
+  paired-endpoint fix) survive untouched, and that no D-entry constant moved.
+  The GitHub inline-comment probe returned an empty array, so that surface was
+  skipped.
+
 ## Decisions
 
 ## Review
@@ -135,8 +195,9 @@ branch 4 ahead, 0 behind, no merge needed.
   and in sync at `7d258248`; `pkgdown::check_pkgdown()` "No problems found";
   `NEWS.md` carries this milestone's user-visible change and names no
   milestone number; no new top-level files, so no `.Rbuildignore` entry owed;
-  full `devtools::check()` (with manual) — running at the time of writing,
-  result recorded below. Master watches: newest
+  full `devtools::check()` Status OK (devtools defaults to `--no-manual`,
+  so this is the same invocation AC3 names; the `manual = TRUE` release check
+  is not owed here). Master watches: newest
   push-run verdict on `R-CMD-check.yaml` and on `test-coverage.yaml` is
   `success` at `096b7cda` (master's tip `9374d4e8` is docs-only and triggers
   no run). `tools/check-master-red-alert.R`, `tools/master-red-alert-dryrun.R`

--- a/cairn/milestones/M110-calibration-domain-claim.md
+++ b/cairn/milestones/M110-calibration-domain-claim.md
@@ -1,6 +1,6 @@
 # M110: Correct the calibration-domain claim in the accuracy target and its shipped surfaces
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** high
 - **Depends on:** —
 - **Driving RR:** —
@@ -72,7 +72,7 @@ typical, two do not.
       worst measured geometry). Regenerate the Rd.
 - [x] T3: Correct `NEWS.md:79`, which carries the same claim spelled
       `500,000` and so escapes a grep for the source's spelling.
-- [ ] T4: Add a test reading the two calibration-domain sentences from the
+- [x] T4: Add a test reading the two calibration-domain sentences from the
       installed help page via `tools::Rd_db("circumplex")`, failing if either
       states its sample-size figure without its coefficient; prove it able to
       fail by restoring the current wording. Nothing in `tests/` pins these
@@ -87,6 +87,8 @@ typical, two do not.
 - 2026-08-24: T1 — the closing sentence now states both tenth-margin endpoints with their coefficients and which falls below the n ~ 1e4 published ceiling; the channel-3 line at :501 gained the anchor's value so its 5e5 names its coefficient too. Full suite clean (FAIL 0, PASS 8619).
 - 2026-08-24: T2 — both roxygen sites now carry the anchor and worst-measured endpoints with their coefficients, per the gate's choice to name both rather than drop the figures; `document()` regenerated `man/axes_reliability.Rd` and emitted no `resolve link` line.
 - 2026-08-24: T3 — the NEWS entry now gives both endpoints with their coefficients, and the paragraph is wrapped so the `500,000` figure and its `1/sqrt(2)` share a line; the AC2 sweep returns 9 lines and every one names the coefficient its figure belongs to.
+- 2026-08-24: T4 — a help-page guard at `tests/testthat/test-axes-reliability.R:3235+` cuts the Rd into sentences and requires each of the two `5e5` sentences to name `a = 1/sqrt(2)` and each `2e3` sentence to name `a = 0.045`, using the dual-source man/-or-`Rd_db()` read the file's other Rd guards use (under check only the `Rd_db()` arm runs). Proved able to fail on two planted defects: reverting both sites reddens 4 of 6 assertions, reverting only the unqualified `\value` site reddens 2 of 7 — the sentence count alone stays green on the first defect, which is why the per-sentence match carries the claim.
+- 2026-08-24: verification — `document()` no diff and no `resolve link` line; `devtools::test()` FAIL 0, PASS 8627 (8619 before, the 8 added being this guard's); `devtools::check(args = "--no-manual")` Status OK, 0 errors / 0 warnings / 0 notes. Status → review.
 
 ## Decisions
 

--- a/man/axes_reliability.Rd
+++ b/man/axes_reliability.Rd
@@ -234,9 +234,9 @@ sampling coefficient \code{a = 1/sqrt(2)}) at \code{n} up to about \code{5e5}. T
 endpoint scales as \code{1e6 * a^2}, so at the least favorable geometry
 measured, \code{a = 0.045}, it falls to \code{n} of about \code{2e3} -- below the \code{n} of
 about \code{1e4} typical of published circumplex correlation matrices. Above
-the endpoint the guarantee is the fixed target alone, not noise
-dominance. The derivation and the premises it rests on are stated
-beside the constant in the source. The refusal
+whichever endpoint the design's own coefficient sets, the guarantee is the
+fixed target alone, not noise dominance. The derivation and the premises
+it rests on are stated beside the constant in the source. The refusal
 says which degeneracy happened: \code{"indefinite"} when the smallest
 eigenvalue is decisively negative (below
 \code{-lambda_max * sqrt(p * .Machine$double.eps)} -- beyond the fit's own

--- a/man/axes_reliability.Rd
+++ b/man/axes_reliability.Rd
@@ -85,7 +85,8 @@ that correction succeeded or a string naming why the reported SEs are
 fitted covariance matrix, where the \code{1e-5} is the \code{1e-4} accuracy target
 divided by the criterion's factor-of-\code{10} calibration ceiling, and the
 target's noise-dominance reading is calibrated for \code{n} up to about
-\code{5e5}):
+\code{5e5} at a typical design (\code{a = 1/sqrt(2)}) and only to about \code{2e3} at
+the least favorable geometry measured (\code{a = 0.045})):
 \code{"indefinite"} for a decisively negative
 smallest eigenvalue
 (below \code{-lambda_max * sqrt(p * .Machine$double.eps)}), a
@@ -228,9 +229,13 @@ do not depend on the sample size -- the resolution the standard errors are
 printed at, and the coverage of a nominal 95\% Wald interval -- and is
 corroborated by a third, the standard error's own sampling variability,
 under which a numerical error at the target is about a tenth of the
-statistical noise already in the number for a typical design at
-\code{n} up to about \code{5e5}. Above that the guarantee is the fixed target alone,
-not noise dominance. The derivation and the premises it rests on are stated
+statistical noise already in the number for a typical design (relative
+sampling coefficient \code{a = 1/sqrt(2)}) at \code{n} up to about \code{5e5}. That
+endpoint scales as \code{1e6 * a^2}, so at the least favorable geometry
+measured, \code{a = 0.045}, it falls to \code{n} of about \code{2e3} -- below the \code{n} of
+about \code{1e4} typical of published circumplex correlation matrices. Above
+the endpoint the guarantee is the fixed target alone, not noise
+dominance. The derivation and the premises it rests on are stated
 beside the constant in the source. The refusal
 says which degeneracy happened: \code{"indefinite"} when the smallest
 eigenvalue is decisively negative (below

--- a/tests/testthat/test-axes-reliability.R
+++ b/tests/testthat/test-axes-reliability.R
@@ -3250,29 +3250,40 @@ test_that("M110 AC1/AC2: every help-page calibration-domain figure names the coe
   expect_gt(nchar(rd), 1000L)
 
   # Strip the \code{} wrappers so a figure and its coefficient are compared as
-  # the reader sees them, then cut into sentences. A period followed by
-  # whitespace ends a sentence; `.Machine`, `1e-5`, `0.045` and the like carry
-  # no space after the period and so survive intact.
+  # the reader sees them.
   txt <- gsub("\\\\code\\{([^}]*)\\}", "\\1", gsub("\\s+", " ", rd))
-  sentences <- unlist(strsplit(txt, "(?<=\\.)\\s+", perl = TRUE))
+
+  # Each figure must be named WITHIN A BOUNDED WINDOW of its coefficient, not
+  # merely somewhere in the same Rd section. An earlier form of this guard cut
+  # the page into sentences, but the \value site carries no sentence break
+  # before its parenthetical, so its "sentence" ran 2,635 characters -- wide
+  # enough for the coefficient to sit in an unrelated clause and still pass.
+  # The measured gaps are 25/32 characters for the anchor and 46/34 for the
+  # worst geometry, so 120 leaves headroom without restoring that slack.
+  expect_named_within <- function(figure, coefficient, window = 120L) {
+    at <- gregexpr(figure, txt, fixed = TRUE)[[1]]
+    # The domain this sweep runs over is non-empty and is the size the two
+    # help-page sites make it -- otherwise the loop below is green on nothing,
+    # which is how a renamed or re-wrapped Rd would go quiet. Occurrences, not
+    # chunks: a third bare figure added anywhere reddens this.
+    expect_identical(length(at), 2L)
+    for (i in at) {
+      near <- substr(txt, max(1L, i - window), i + window)
+      expect_match(near, coefficient, fixed = TRUE)
+    }
+  }
 
   # The noise-dominance reading holds only out to n = 1e6 * a^2, so a
   # sample-size endpoint stated without the coefficient a it belongs to reads
   # as the whole domain. Both help-page sites state the anchor's endpoint; the
   # defect this pins is either one stating it alone (M106 review round 4, F4).
-  anchor <- grep("5e5", sentences, fixed = TRUE, value = TRUE)
-  # The domain this sweep runs over is non-empty -- otherwise the loop below
-  # is green on nothing, which is how a renamed or re-wrapped Rd would go quiet.
-  expect_identical(length(anchor), 2L)
-  for (s in anchor) expect_match(s, "a = 1/sqrt(2)", fixed = TRUE)
+  expect_named_within("5e5", "a = 1/sqrt(2)")
 
   # And the worst measured geometry's endpoint travels with its own
   # coefficient, at both sites: it is the figure that falls BELOW the n ~ 1e4
   # of published circumplex correlation matrices, which is the whole point of
   # stating it.
-  worst <- grep("2e3", sentences, fixed = TRUE, value = TRUE)
-  expect_identical(length(worst), 2L)
-  for (s in worst) expect_match(s, "a = 0.045", fixed = TRUE)
+  expect_named_within("2e3", "a = 0.045")
 
   # The published-ceiling comparison itself, without which a reader has both
   # endpoints and no reason to care which one they are at.

--- a/tests/testthat/test-axes-reliability.R
+++ b/tests/testthat/test-axes-reliability.R
@@ -3233,3 +3233,49 @@ test_that("M91 AC4: the printed SE-failure note stays silent in the raw-arm-only
   # naive_reason is deliberately silent (M91-D1): nothing printed names it.
   expect_no_match(out, "naive", fixed = TRUE)
 })
+
+
+test_that("M110 AC1/AC2: every help-page calibration-domain figure names the coefficient it belongs to", {
+  # The dual-source pattern the Rd guards above use: man/ in the dev tree,
+  # Rd_db() once installed, because a man/-only read silently SKIPS under
+  # R CMD check and an Rd_db()-only read errors under load_all().
+  rd_file <- test_path("..", "..", "man", "axes_reliability.Rd")
+  rd <- if (file.exists(rd_file)) {
+    paste(readLines(rd_file, warn = FALSE), collapse = " ")
+  } else {
+    paste(as.character(tools::Rd_db("circumplex")[["axes_reliability.Rd"]]),
+          collapse = "")
+  }
+  # Fail loudly rather than pass vacuously if neither source yielded anything.
+  expect_gt(nchar(rd), 1000L)
+
+  # Strip the \code{} wrappers so a figure and its coefficient are compared as
+  # the reader sees them, then cut into sentences. A period followed by
+  # whitespace ends a sentence; `.Machine`, `1e-5`, `0.045` and the like carry
+  # no space after the period and so survive intact.
+  txt <- gsub("\\\\code\\{([^}]*)\\}", "\\1", gsub("\\s+", " ", rd))
+  sentences <- unlist(strsplit(txt, "(?<=\\.)\\s+", perl = TRUE))
+
+  # The noise-dominance reading holds only out to n = 1e6 * a^2, so a
+  # sample-size endpoint stated without the coefficient a it belongs to reads
+  # as the whole domain. Both help-page sites state the anchor's endpoint; the
+  # defect this pins is either one stating it alone (M106 review round 4, F4).
+  anchor <- grep("5e5", sentences, fixed = TRUE, value = TRUE)
+  # The domain this sweep runs over is non-empty -- otherwise the loop below
+  # is green on nothing, which is how a renamed or re-wrapped Rd would go quiet.
+  expect_identical(length(anchor), 2L)
+  for (s in anchor) expect_match(s, "a = 1/sqrt(2)", fixed = TRUE)
+
+  # And the worst measured geometry's endpoint travels with its own
+  # coefficient, at both sites: it is the figure that falls BELOW the n ~ 1e4
+  # of published circumplex correlation matrices, which is the whole point of
+  # stating it.
+  worst <- grep("2e3", sentences, fixed = TRUE, value = TRUE)
+  expect_identical(length(worst), 2L)
+  for (s in worst) expect_match(s, "a = 0.045", fixed = TRUE)
+
+  # The published-ceiling comparison itself, without which a reader has both
+  # endpoints and no reason to care which one they are at.
+  expect_match(txt, "typical of published circumplex correlation matrices",
+               fixed = TRUE)
+})


### PR DESCRIPTION
Corrects the accuracy target's calibration-domain claim so no shipped surface implies the domain reaches 1.7 decades past the published sample-size ceiling at every geometry.

- The closing sentence of the calibration-domain paragraph now states both tenth-margin endpoints with their coefficients (a = 0.045 -> n = 2.0e3; a = 1/sqrt(2) -> n = 5.0e5) and which falls below the n ~ 1e4 published ceiling.
- Both roxygen sites and the regenerated Rd carry the same qualification.
- The NEWS entry carries both endpoints.
- A help-page guard pins each calibration-domain sentence to its coefficient.

Milestone: `cairn/milestones/M110-calibration-domain-claim.md`