### PR TITLE
M114: pin the shared refusal predicate, and assert the dead literal rather than dropping it

### DIFF
--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | — (all deps done) | high | milestones/M7-v2-release-prep.md |
-| M114 | Pin the shared refusal predicate, and assert the dead literal rather than dropping it | in-progress | M113 | normal | milestones/M114-refusal-predicate-fences.md |
+| M114 | Pin the shared refusal predicate, and assert the dead literal rather than dropping it | review | M113 | normal | milestones/M114-refusal-predicate-fences.md |
 | M115 | Make the packaged accuracy bracket assert where the shipped pricing differs | planned | M113 | normal | milestones/M115-certificate-bracket-reach.md |
 | M109 | Repair the test guards that skip on the surface that ships | done | — | normal | milestones/archive/M109-source-tree-test-reads.md |
 | M110 | Correct the calibration-domain claim in the accuracy target and its shipped surfaces | done | — | high | milestones/archive/M110-calibration-domain-claim.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -10,7 +10,7 @@ Pre-migration history: see `cairn/legacy/` and git log.
 | ID | Title | Status | Depends on | Priority | File/Archive |
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | — (all deps done) | high | milestones/M7-v2-release-prep.md |
-| M114 | Pin the shared refusal predicate, and assert the dead literal rather than dropping it | planned | M113 | normal | milestones/M114-refusal-predicate-fences.md |
+| M114 | Pin the shared refusal predicate, and assert the dead literal rather than dropping it | in-progress | M113 | normal | milestones/M114-refusal-predicate-fences.md |
 | M115 | Make the packaged accuracy bracket assert where the shipped pricing differs | planned | M113 | normal | milestones/M115-certificate-bracket-reach.md |
 | M109 | Repair the test guards that skip on the surface that ships | done | — | normal | milestones/archive/M109-source-tree-test-reads.md |
 | M110 | Correct the calibration-domain claim in the accuracy target and its shipped surfaces | done | — | high | milestones/archive/M110-calibration-domain-claim.md |

--- a/cairn/milestones/M114-refusal-predicate-fences.md
+++ b/cairn/milestones/M114-refusal-predicate-fences.md
@@ -33,19 +33,19 @@ performance residue → the ROADMAP degeneracy candidate row.
 
 ## Acceptance criteria
 
-- [ ] AC1 A committed input on which the certificate's fields straddle
+- [x] AC1 A committed input on which the certificate's fields straddle
       `axes_degeneracy_delta_star` — at least one at or below it, at least one
       above — is asserted to refuse `"uncertified"` at both surfaces; with the
       shared max replaced by each surface reading only its own field, that
       assertion reddens at one surface. Where no matrix producing a straddling
       set is found, the same assertion is driven by a stubbed
       `axes_accuracy_certificate()` return instead.
-- [ ] AC2 `check_nested()`'s literal set in
+- [x] AC2 `check_nested()`'s literal set in
       `tests/testthat/test-axes-scaled-fit.R:1409` still contains
       `"ill_conditioned"`, and the AC8 test additionally asserts that on every
       matrix its own grid drives, neither surface's `reason` field returns that
       literal.
-- [ ] AC3 `devtools::test()` clean; `devtools::document()` no diff and no
+- [x] AC3 `devtools::test()` clean; `devtools::document()` no diff and no
       unresolved-link warning at pinned `cli.width`;
       `devtools::check(args = "--no-manual")` 0 errors / 0 warnings / 0 notes.
 
@@ -85,3 +85,117 @@ performance residue → the ROADMAP degeneracy candidate row.
 ## Decisions
 
 ## Review
+
+PR: https://github.com/jmgirard/circumplex/pull/145. Master had not moved since
+the branch was cut (`origin/master..HEAD` two commits, `HEAD..origin/master`
+empty), so no merge was needed before gathering evidence.
+
+### Acceptance-criterion evidence (fresh, this session)
+
+- **AC1 — met.** The committed straddle is `m106_family_c(eps, xi1 = 0.1,
+  xi2 = 0.3)` at eps 3e-9 / 5e-9 / 8e-9, p = 4. On this machine all three
+  members straddle: `cval` 0.35 / 0.50 / 0.040 against a target of 1e-4, with
+  `se` and `fiml_ratio` at 3.5e-8 to 1.2e-7 — three to four decades inside it.
+  Both surfaces refuse `"uncertified"` on each, and the test asserts the
+  straddle facts before the refusals and refuses to pass on an empty band.
+  Mutation, run fresh here: `axes_degeneracy_refusal()` rewritten to read
+  `max(se, fiml_ratio)` under the SE helper and `cval` under the scaling
+  surface reddened the SE helper at every band member — `reason` NULL rather
+  than `"uncertified"`, `corrected` finite, no warning emitted (failures at
+  `test-axes-certificate-refusal.R:415/417/420/427/429`, hitting testthat's
+  failure cap). Reverted; `git status` clean, and the two touched files back to
+  0 failures / 2,279 passing. The second AC1 test drives the other two fields
+  from a stubbed certificate, with a both-directions liveness check on the stub.
+- **AC2 — met.** `check_nested()`'s guard set at
+  `test-axes-scaled-fit.R:1425-1426` still lists `"ill_conditioned"`, unchanged.
+  The two added `expect_false()` assertions sit unconditionally in
+  `check_nested()`, which the AC8 grid calls on all 34 inflation matrices per
+  map plus the indefinite and near-singular cases, across three maps — no
+  branch skips them and no loop is empty. Non-vacuity proved fresh here by
+  planting `reason = "ill_conditioned"` on the certificate branch of
+  `axes_degeneracy_refusal()`: five of the new assertions reddened at both
+  surfaces before the failure cap. Reverted; tree clean.
+- **AC3 — met.** `devtools::test()` 0 failures / 9,100 passing (5 warnings and
+  1 skip, all in files this branch does not touch);
+  `Rscript -e 'options(cli.width = 500); devtools::document()'` exit 0, zero
+  lines matching `resolve link`, and `git status` empty afterwards;
+  `devtools::check(args = "--no-manual")` Status OK — 0 errors, 0 warnings,
+  0 notes, 8m 7.6s.
+
+### Consistency gate
+
+`cairn_validate.py` exit 0, all checks pass (47 advisory work-log-format warnings,
+all pre-existing in M7). No `DESIGN.md` principle changed, so `cairn_impact.py`
+does not apply. Toolchain slot: `document()` no diff and no unresolved-link
+warning (above); no generated file hand-edited; README.md in sync;
+`pkgdown::check_pkgdown()` "No problems found"; no NEWS entry owed (tests and
+tracking only, no user-visible behaviour moved); no new top-level files;
+`devtools::check()` clean (above). Master watches: newest push run on master
+reaching a verdict is `success` for both `R-CMD-check.yaml` and
+`test-coverage.yaml` (2026-08-30T20:11:30Z). `tools/check-master-red-alert.R`,
+`tools/master-red-alert-dryrun.R` (5/5 synthetic payloads ok) and
+`tools/check-branch-protection.R` all exit clean.
+
+### Independent review — three lenses, fresh context
+
+Declared tier is user-facing, so the full fan-out ran.
+
+**[S] blame-history — no findings.** The pre-existing pointwise nestedness
+assertion is untouched (same guard set, same `expect_identical`); the two new
+`expect_false()` calls are strictly additive and strictly stronger. The literal
+retention matches M111 F12's recorded disposition; F4 and M113's F3 are named as
+deferred rather than silently dropped. No `R/` or `src/` change anywhere in the
+diff.
+
+**[S] prior-PR-comments — no findings.** The `gh api .../pulls/comments` probe
+returned `[]` (no inline review comments at all), so the PR-thread walk was
+skipped. On the archived `## Review` record the diff complies rather than
+regresses: it is the fix M111 F4 asked for, it follows the M108-era lesson to
+fence a refusal warning's *route* and not its digits, and it carries the
+non-empty-domain guard that lesson requires.
+
+**[O] diff-bug — ten findings, ranked.** Verdict: both criteria met in
+substance, tests mutation-sensitive, every load-bearing factual claim in the new
+comments verified true except as noted. Findings and dispositions:
+
+1. `test-axes-certificate-refusal.R:378,387` — `straddling` is built with
+   `format(eps)` on scalars but filtered with `format(m114_straddle_eps)` on the
+   vector, and `format()` pads a numeric *vector* to a common mantissa width.
+   Confirmed here: `format(c(1e-9, 1.25e-9, 3e-9))` gives `"1.00e-09"` where
+   `format(1e-9)` gives `"1e-09"`. Harmless on today's band, but widen it and
+   the non-vacuity guard can pass while the assertion loop runs zero times.
+   **Fix now.**
+2. `:481-511` — the stubbed certificates are hand-written three-field lists, so
+   a fourth certificate field (as M113 added `fiml_ratio`) would be pinned by
+   nothing while all six straddle assertions stayed green. This is the field-set
+   drift `axes_certificate_sentinel()` exists to prevent, reintroduced test-side.
+   **Fix now.**
+3. `:354,504` — neither committed domain asserts its own length, against this
+   file's own convention at `:51`. A dropped case would lose coverage silently.
+   **Fix now.**
+4. `:384` — `straddling` is checked non-empty but never against an expected set,
+   so a partial band collapse is invisible. **Reject:** the tolerance is
+   deliberate, and bounding it re-imports the M113 windows problem in weaker form.
+5. `:526-527` — the literal `"0.01"` in the warning grep is derived from
+   `axes_degeneracy_delta_star` but hard-coded, so a change to that constant
+   fails these greps for an unrelated reason. **Fix now.**
+6. Milestone file `:31` cites `R/axes_corrected_se.R:765` for the shared `max()`,
+   which is at `:789` (comparison) and `:800` (definition); AC2's own
+   `test-axes-scaled-fit.R:1409` citation is now self-stale at `:1425`.
+   **Reject:** pre-existing on master, and both live in plan-owned text review
+   must not edit.
+7. `:447-450` — "AC2 above" inside a block headed "M114 AC1" means *M111* AC2,
+   and that test can `skip_if_not_installed("lavaan")`. The liveness argument
+   does not depend on it, so this is comment precision. **Fix now.**
+8. `:407-408` — df hard-coded where `m111_dfs()` exists twenty lines up for
+   exactly this reason. Correct today and a mismatch would redden rather than
+   pass. **Fix now.**
+9. `:460-473` — the stub test does not assert one warning per refusal, unlike its
+   sibling at `:427-428`. **Fix now.**
+10. Observation, not a defect: the straddle rests on the three fields disagreeing
+    by six decades on one matrix, so a later correction to the `cval` estimate
+    may collapse it — loudly, thanks to the `:384` guard. **No action.**
+
+Return floor: none of the ten demonstrates an acceptance criterion failing, and
+the diff changes no shipped behaviour, so none is a load-bearing defect in what
+the package does for users. No status return.

--- a/cairn/milestones/M114-refusal-predicate-fences.md
+++ b/cairn/milestones/M114-refusal-predicate-fences.md
@@ -1,6 +1,6 @@
 # M114: Pin the shared refusal predicate, and assert the dead literal rather than dropping it
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** M113
 - **Driving RR:** —
@@ -57,15 +57,15 @@ performance residue → the ROADMAP degeneracy candidate row.
 
 ## Tasks
 
-- [ ] T1 Search the anchor families and the committed counterexample for an
+- [x] T1 Search the anchor families and the committed counterexample for an
       input whose certificate fields straddle `axes_degeneracy_delta_star`;
       record the search and its outcome either way.
-- [ ] T2 Commit the straddling input (or the stub), assert `"uncertified"` at
+- [x] T2 Commit the straddling input (or the stub), assert `"uncertified"` at
       both surfaces, mutate the predicate to per-surface fields, record the
       redden, revert and verify the tree clean.
 - [x] T3 Add the AC8 grid assertion, keeping `"ill_conditioned"` in the guard
       set; prove it able to fail by planting that return.
-- [ ] T4 NEWS entry if any user-visible behaviour moved; profile verify and
+- [x] T4 NEWS entry if any user-visible behaviour moved; profile verify and
       consistency-gate slot.
 
 ## Work log
@@ -77,6 +77,10 @@ performance residue → the ROADMAP degeneracy candidate row.
 - 2026-08-30: pre-implementation gate: the per-surface alternative AC1 must redden against is `max(se, fiml_ratio)` at the SE helper and `cval` at the scaling surface — the partition each function's own return defines; the M113 review's F3 fail-open on a short certificate was declined for this milestone and stays on the ROADMAP degeneracy row.
 - 2026-08-30: T3 run ahead of T1/T2 (minor reorder — the AC2 assertion is independent of AC1's input search, which runs long).
 - 2026-08-30: T3 done. `check_nested()` now asserts `reason` is not `"ill_conditioned"` at both surfaces on every matrix the AC8 grid drives, with the literal kept in the guard set; planting `list(reason = "ill_conditioned", ...)` in `axes_degeneracy_refusal()` reddened both new assertions (`actual TRUE` at the near-singular matrix, all three p), reverted and green at 348 passing.
+- 2026-08-30: T1 done. Searched the three anchor families' stated parameter space and a neighbourhood of the committed counterexample for a straddling certificate: 9,588 candidates, 6,666 of which reached the certificate, 388 straddling. Families A and B produce none at any parameter tried -- their three fields climb together to ~1e-7 and then both pricing routes fail at once, so all three become the sentinel with nothing between; the committed counterexample does not straddle either (se 3.4e-2, cval 4.9, fiml_ratio 8.7e-4, all above the target). Family C does, at p = 4: across item-error variances 2.5e-9 to 8e-9 with xi1 = 0.1, xi2 = 0.3 the cval estimate runs 400-5000x the target while the SE vector's and the quotient's sit about 1000x below it. Search scripts in the session scratchpad, not committed.
+- 2026-08-30: T2 done. The straddle is committed as a closed-form call on the existing `m106_family_c()` builder at three band members (3e-9, 5e-9, 8e-9) -- deterministic, no fixture, no seed -- and both surfaces are asserted to refuse `"uncertified"` on each, the SE helper being the one whose own two fields are inside the target. Mutating `axes_degeneracy_refusal()` to read `max(se, fiml_ratio)` at the SE helper and `cval` at the scaling surface reddened the SE helper at all three members (`reason` NULL rather than `"uncertified"`, with the raw arm's `"ill_conditioned"` surfacing in `naive_reason`); reverted, `git status` clean under R/. A second stubbed-certificate test covers the other two fields, which the search found on the far side only in company.
+
+- 2026-08-30: T4 done. No NEWS entry: the branch changes tests and tracking only, and no user-visible behaviour moved. `devtools::test()` 0 failures / 9,100 passing, with the suite's 5 warnings and 1 skip all in files this branch does not touch (`test-ci_accuracy.R`, `test-ssm_sem.R`, and the pre-existing fixture-version skip at `test-axes-scaled-fit.R:921`); `devtools::document()` no diff and no unresolved-link warning at pinned `cli.width`; `devtools::check(args = "--no-manual")` Status OK, 0 errors / 0 warnings / 0 notes in 8m 48.5s; `cairn_validate` all checks pass.
 
 ## Decisions
 

--- a/cairn/milestones/M114-refusal-predicate-fences.md
+++ b/cairn/milestones/M114-refusal-predicate-fences.md
@@ -1,11 +1,11 @@
 # M114: Pin the shared refusal predicate, and assert the dead literal rather than dropping it
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** M113
 - **Driving RR:** —
 - **Principles touched:** GP2
-- **Branch/PR:** —
+- **Branch/PR:** `m114-refusal-predicate-fences`
 
 ## Goal
 
@@ -63,7 +63,7 @@ performance residue → the ROADMAP degeneracy candidate row.
 - [ ] T2 Commit the straddling input (or the stub), assert `"uncertified"` at
       both surfaces, mutate the predicate to per-surface fields, record the
       redden, revert and verify the tree clean.
-- [ ] T3 Add the AC8 grid assertion, keeping `"ill_conditioned"` in the guard
+- [x] T3 Add the AC8 grid assertion, keeping `"ill_conditioned"` in the guard
       set; prove it able to fail by planting that return.
 - [ ] T4 NEWS entry if any user-visible behaviour moved; profile verify and
       consistency-gate slot.
@@ -74,6 +74,9 @@ performance residue → the ROADMAP degeneracy candidate row.
 - 2026-08-30: criteria audit ran in FULL mode (declared user-facing tier) as part of the joint M113/M114/M115 run; its finding on AC2 is disposed in the gate line below, and its instrument-property finding on AC1's "the search that failed is recorded" clause was fixed by moving that clause to T1.
 - 2026-08-30: plan gate chose keeping `"ill_conditioned"` in `check_nested()`'s set and asserting its deadness on the AC8 grid over dropping it as M111 review F12 proposed, because `axes_scaling_factor()`'s `cval <= 0` backstop still emits that literal (`R/axes_scaled_fit.R:302`, asserted at `test-axes-scaled-fit.R:1764`), so dropping it would silently retire nestedness coverage there; falsified by that backstop being removed or proved unreachable.
 - 2026-08-30: `Depends on: M113` because M113 adds a third certificate field, which changes what a straddling set means for AC1.
+- 2026-08-30: pre-implementation gate: the per-surface alternative AC1 must redden against is `max(se, fiml_ratio)` at the SE helper and `cval` at the scaling surface — the partition each function's own return defines; the M113 review's F3 fail-open on a short certificate was declined for this milestone and stays on the ROADMAP degeneracy row.
+- 2026-08-30: T3 run ahead of T1/T2 (minor reorder — the AC2 assertion is independent of AC1's input search, which runs long).
+- 2026-08-30: T3 done. `check_nested()` now asserts `reason` is not `"ill_conditioned"` at both surfaces on every matrix the AC8 grid drives, with the literal kept in the guard set; planting `list(reason = "ill_conditioned", ...)` in `axes_degeneracy_refusal()` reddened both new assertions (`actual TRUE` at the near-singular matrix, all three p), reverted and green at 348 passing.
 
 ## Decisions
 

--- a/cairn/milestones/M114-refusal-predicate-fences.md
+++ b/cairn/milestones/M114-refusal-predicate-fences.md
@@ -5,7 +5,7 @@
 - **Depends on:** M113
 - **Driving RR:** —
 - **Principles touched:** GP2
-- **Branch/PR:** `m114-refusal-predicate-fences`
+- **Branch/PR:** `m114-refusal-predicate-fences` / https://github.com/jmgirard/circumplex/pull/145
 
 ## Goal
 

--- a/cairn/milestones/M114-refusal-predicate-fences.md
+++ b/cairn/milestones/M114-refusal-predicate-fences.md
@@ -199,3 +199,34 @@ comments verified true except as noted. Findings and dispositions:
 Return floor: none of the ten demonstrates an acceptance criterion failing, and
 the diff changes no shipped behaviour, so none is a load-bearing defect in what
 the package does for users. No status return.
+
+### Fix-now work at the gate
+
+The maintainer chose "fix six, then merge" at the approval chip, so findings 1,
+2, 3, 5, 7, 8 and 9 were repaired on the branch (seven changes; 3 and 9 are one
+sitting each at two sites). Findings 4, 6 and 10 stand rejected as recorded
+above. Changes, all in `tests/testthat/test-axes-certificate-refusal.R`:
+
+- F1: the band-membership set is now a logical mask indexed positionally, so no
+  `format()` round-trip stands between the straddle test and the loop it feeds;
+  the non-emptiness guard is `expect_true(any(straddling))`.
+- F2: `expect_named(axes_certificate_sentinel(), c("se", "cval", "fiml_ratio"))`
+  now precedes the stubs, so adding a fourth certificate field reddens here
+  rather than leaving the hand-written stubs silently short.
+- F3: `expect_length(m114_straddle_eps, 3L)` and `expect_length(straddles, 3L)`.
+- F5: the expected note text is built with `sprintf("estimated relative error
+  %.2g", hi)` rather than the literal `"0.01"`.
+- F7: the comment now names the M111 AC2 test and says outright that the
+  liveness argument rests on the all-fields-inside baseline run in this test,
+  not on a case that can skip without lavaan.
+- F8: the AC1 df pair comes from `m111_dfs(4L, ang, scl)`.
+- F9: one warning per refusal asserted at both surfaces in the stub test.
+
+`expect_length()` takes no `label`, so the two count assertions are
+`expect_identical(length(...), 1L, label = ...)`.
+
+Re-verified after the fixes: the two touched files 0 failures / 2,288 passing
+(up 9 from the pre-fix 2,279); the AC1 per-surface mutation still reddens, at
+`test-axes-certificate-refusal.R:428/430/433/440/442` across the band, reverted
+with `R/` clean; `devtools::check(args = "--no-manual")` Status OK — 0 errors,
+0 warnings, 0 notes, 7m 44.2s.

--- a/tests/testthat/test-axes-certificate-refusal.R
+++ b/tests/testthat/test-axes-certificate-refusal.R
@@ -324,3 +324,206 @@ test_that("M111 AC4: 'indefinite' and 'singular' still refuse at both surfaces, 
     expect_identical(r$sf, "singular", label = sprintf("p %d, non-finite", p))
   }
 })
+
+
+# ---- M114 AC1: the shared predicate, fenced against the per-surface split ----
+#
+# WHAT IS UNDER TEST. axes_degeneracy_refusal() reads ONE number for both
+# surfaces -- axes_certificate_worst(), the max over the certificate's three
+# fields -- rather than letting each surface read the field it produces. That
+# was the M111 gate's choice over the per-surface alternative, on the grounds
+# that gating each surface on its own field would let one surface compute while
+# the other refuses the same matrix, which is the split M89's nestedness
+# contract exists to prevent. Nothing failed if the max were replaced by that
+# alternative (M111 review F4): every case committed before this milestone has
+# all three fields on one side of the target, so both readings agree on all of
+# them.
+#
+# WHERE THE STRADDLE COMES FROM. T1 searched the three anchor families' stated
+# parameter space and a neighbourhood of the committed counterexample for an
+# input whose fields land on opposite sides of the target. Families A and B do
+# not produce one at any parameter tried: their fields climb together to ~1e-7
+# and then both pricing routes fail at once, so all three become the sentinel 1
+# with nothing in between. Family C does, and not marginally. At p = 4 -- the
+# minimum design the exported API accepts -- the cval sum cancels decades
+# earlier than the SE quadratic forms do, so across a band of item-error
+# variances the scaling factor's estimate is past the target while the SE
+# vector's and the quotient's are three decades inside it. The margins are what
+# make this worth committing rather than stubbing: a platform whose arithmetic
+# differs would have to move a field by three decades to unmake the straddle.
+m114_straddle_eps <- c(3e-9, 5e-9, 8e-9)
+m114_straddle_sigma <- function(eps) m106_family_c(eps, xi1 = 0.1, xi2 = 0.3)
+
+test_that("M114 AC1: an input whose fields straddle the target refuses at BOTH surfaces", {
+  ang <- c(90, 180, 270, 360)
+  scl <- as.character(1:4)
+  d <- axes_se_derivs(ang, scl, NULL, FALSE, FALSE)
+  ds <- axes_degeneracy_delta_star
+
+  # WHICH members of the band straddle HERE, named rather than counted. The
+  # certificate's fields are this machine's own arithmetic, and a platform that
+  # prices these matrices differently could push a member onto the sentinel
+  # route, where all three fields become 1 and the straddle is gone (the M113
+  # windows-latest lesson, reached at a third surface). So the band is measured
+  # first and the assertions below run over what it actually yields.
+  straddling <- character()
+  for (eps in m114_straddle_eps) {
+    sigma <- m114_straddle_sigma(eps)
+    # The precondition: the criterion routes this matrix to the certificate,
+    # rather than to one of the two literals that refuse without consulting it.
+    expect_identical(axes_sigma_degenerate(sigma), "ill_conditioned",
+                     label = sprintf("eps %g: criterion verdict", eps))
+    cert <- axes_accuracy_certificate(sigma, d)
+    if (cert$cval > ds && cert$se <= ds && cert$fiml_ratio <= ds) {
+      straddling <- c(straddling, format(eps))
+    }
+  }
+  # The domain is not allowed to empty silently. If every member degenerated,
+  # this criterion has nothing to assert on this machine and must say so rather
+  # than pass vacuously.
+  expect_false(identical(straddling, character()),
+               label = "band members straddling the target, as a set")
+
+  for (eps in m114_straddle_eps[format(m114_straddle_eps) %in% straddling]) {
+    lab <- sprintf("family C p = 4, eps %g", eps)
+    sigma <- m114_straddle_sigma(eps)
+    cert <- axes_accuracy_certificate(sigma, d)
+
+    # The straddle itself, stated as the two facts that make it one: the
+    # scaling surface's own field is past the target, and BOTH of the SE
+    # helper's own fields are inside it. This is the configuration on which the
+    # shared max and the per-surface reading disagree.
+    expect_gt(cert$cval, ds)
+    expect_lte(cert$se, ds)
+    expect_lte(cert$fiml_ratio, ds)
+
+    wse <- testthat::capture_warnings(
+      se <- axes_corrected_se(sigma, rownames(sigma), ang, scl, NULL, n = 600,
+                              fit_zeta1 = FALSE, fit_zeta2 = FALSE)
+    )
+    wsf <- testthat::capture_warnings(
+      sf <- axes_scaling_factor(sigma, rownames(sigma), ang, scl, NULL,
+                                fit_zeta1 = FALSE, fit_zeta2 = FALSE,
+                                df = 4L * 5L / 2L - length(d$mats),
+                                baseline_df = 4L * 3L / 2L)
+    )
+
+    # BOTH surfaces refuse, under one literal. The SE helper is the one the
+    # per-surface reading would let compute: neither of the fields it produces
+    # is past the target, and it refuses anyway because the decision is not
+    # its own field's to make.
+    expect_identical(se$reason, "uncertified", label = sprintf("%s: SE helper", lab))
+    expect_identical(sf$reason, "uncertified", label = sprintf("%s: scaling", lab))
+    expect_true(all(is.na(se$corrected)), label = lab)
+    expect_identical(sf$scale, NA_real_, label = lab)
+    # A unit refusal: the one reason speaks for all three SE vectors (M91).
+    expect_null(se$naive_reason, label = lab)
+
+    # One warning each, and the estimate each carries is the field the refusal
+    # was actually made on -- the note reads axes_certificate_worst() too, so a
+    # surface cannot be refused on one number and shown another. Asserted as
+    # the route rather than the digits, which are this machine's arithmetic:
+    # the note is present and it is NOT the sentinel's 1.
+    expect_length(wse, 1L)
+    expect_length(wsf, 1L)
+    expect_length(grep("estimated relative error ", wse, fixed = TRUE), 1L)
+    expect_length(grep("estimated relative error ", wsf, fixed = TRUE), 1L)
+    expect_length(grep("estimated relative error 1;", wse, fixed = TRUE), 0L)
+    expect_length(grep("estimated relative error 1;", wsf, fixed = TRUE), 0L)
+  }
+})
+
+
+# The same fence, per field, on a stubbed certificate. The case above is the
+# real input AC1 asks for and it exercises exactly one of the three fields --
+# `cval`, the only one the search found on the far side alone. This one covers
+# the other two, and covers all three with fields that are exact rather than
+# measured, so what it pins is the PREDICATE's arithmetic and not some
+# machine's rounding near a threshold.
+test_that("M114 AC1: a straddling certificate refuses at BOTH surfaces, whichever field is the bad one", {
+  # The matrix only has to reach the certificate branch and be one BOTH
+  # surfaces can otherwise price; the stub supplies the numbers. That rules out
+  # the committed counterexample, whose scaling surface trips the `cval <= 0`
+  # backstop whatever the certificate says. Reachable geometry a5 -- family A
+  # at p = 8, kappa 1e5 -- is below the criterion's floor and computes at both
+  # surfaces, which is what AC2 above asserts of it end-to-end.
+  sigma <- m106_family_a(2.4e-5, 1L)
+  ang <- as.numeric(octants())
+  scl <- as.character(1:8)
+  di <- m111_dfs(nrow(sigma), ang, scl)
+  expect_identical(axes_sigma_degenerate(sigma), "ill_conditioned")
+
+  ds <- axes_degeneracy_delta_star
+  lo <- ds / 1e4                       # four decades inside the target
+  hi <- ds * 1e2                       # two decades past it
+
+  both <- function(cert) {
+    local_mocked_bindings(axes_accuracy_certificate = function(sigma, d) cert)
+    wse <- testthat::capture_warnings(
+      se <- axes_corrected_se(sigma, rownames(sigma), ang, scl, NULL,
+                              n = 600, fit_zeta1 = FALSE, fit_zeta2 = FALSE)
+    )
+    wsf <- testthat::capture_warnings(
+      sf <- axes_scaling_factor(sigma, rownames(sigma), ang, scl, NULL,
+                                fit_zeta1 = FALSE, fit_zeta2 = FALSE,
+                                df = di$df, baseline_df = di$baseline_df)
+    )
+    list(se = se$reason, sf = sf$reason, wse = wse, wsf = wsf)
+  }
+
+  # THE STUB IS LIVE, and shown to be by the direction that cannot be the
+  # matrix's own doing: this geometry COMPUTES at both surfaces unstubbed (AC2
+  # above), and with every field stubbed past the target it refuses at both.
+  # Without this the cases below could be reading the matrix rather than the
+  # certificate and stay green under any predicate at all.
+  r <- both(list(se = hi, cval = hi, fiml_ratio = hi))
+  expect_identical(r$se, "uncertified", label = "all three past: SE helper")
+  expect_identical(r$sf, "uncertified", label = "all three past: scaling")
+
+  # The baseline in the other direction: every field inside the target and
+  # both surfaces compute, so a refusal below is a refusal the stub caused.
+  r <- both(list(se = lo, cval = lo, fiml_ratio = lo))
+  expect_null(r$se, label = "all three inside: SE helper")
+  expect_null(r$sf, label = "all three inside: scaling surface")
+
+  # THE STRADDLES, one per field. In each, exactly one field is past the target
+  # and the other two are four decades inside it, so the shared max refuses and
+  # a per-surface reading would not. The FIELDS ARE NAMED, not counted: which
+  # field is bad is the whole content of the case, because each one belongs to
+  # a different surface under the alternative this fences.
+  #
+  #   `cval`        the scaling surface's own field. Under the alternative the
+  #                 SE helper reads max(se, fiml_ratio) and COMPUTES -- so this
+  #                 case is what reddens at the SE helper.
+  #   `se`          the SE helper's own. The scaling surface reads cval alone
+  #                 and computes -- this case reddens at the scaling surface.
+  #   `fiml_ratio`  also the SE helper's (axes_corrected_se() returns the
+  #                 quotient). Same redden as `se`, at the scaling surface, and
+  #                 it is asserted separately because a mutation could easily
+  #                 carry `se` and drop the quotient.
+  straddles <- list(
+    list(field = "cval",
+         cert = list(se = lo, cval = hi, fiml_ratio = lo)),
+    list(field = "se",
+         cert = list(se = hi, cval = lo, fiml_ratio = lo)),
+    list(field = "fiml_ratio",
+         cert = list(se = lo, cval = lo, fiml_ratio = hi))
+  )
+  for (case in straddles) {
+    lab <- sprintf("only `%s` past the target", case$field)
+    r <- both(case$cert)
+
+    # One shared literal, both surfaces -- M89's nestedness contract, which is
+    # what the shared max buys.
+    expect_identical(r$se, "uncertified", label = sprintf("%s: SE helper", lab))
+    expect_identical(r$sf, "uncertified",
+                     label = sprintf("%s: scaling surface", lab))
+
+    # And the number the user is shown is the same one the refusal was made
+    # against -- the note reads axes_certificate_worst() too, so a field the
+    # predicate refused on cannot be a field the note declines to print. `hi`
+    # is 0.01, which is what "%.2g" makes of it.
+    expect_length(grep("estimated relative error 0.01", r$wse, fixed = TRUE), 1L)
+    expect_length(grep("estimated relative error 0.01", r$wsf, fixed = TRUE), 1L)
+  }
+})

--- a/tests/testthat/test-axes-certificate-refusal.R
+++ b/tests/testthat/test-axes-certificate-refusal.R
@@ -358,6 +358,10 @@ test_that("M114 AC1: an input whose fields straddle the target refuses at BOTH s
   ang <- c(90, 180, 270, 360)
   scl <- as.character(1:4)
   d <- axes_se_derivs(ang, scl, NULL, FALSE, FALSE)
+  # Computed by the same helper the M111 cases use, not hard-coded: a p change
+  # must not silently turn a refusal into the scaling surface's df_mismatch
+  # door and pass for the wrong reason (M114 review [O] F8).
+  di <- m111_dfs(4L, ang, scl)
   ds <- axes_degeneracy_delta_star
 
   # WHICH members of the band straddle HERE, named rather than counted. The
@@ -366,25 +370,35 @@ test_that("M114 AC1: an input whose fields straddle the target refuses at BOTH s
   # route, where all three fields become 1 and the straddle is gone (the M113
   # windows-latest lesson, reached at a third surface). So the band is measured
   # first and the assertions below run over what it actually yields.
-  straddling <- character()
-  for (eps in m114_straddle_eps) {
+  # The band this test runs over, asserted rather than assumed, per this file's
+  # convention at "M111 AC2" above: a shortened band would quietly reduce what
+  # the loop below covers.
+  expect_length(m114_straddle_eps, 3L)
+
+  # A LOGICAL MASK, not a set of formatted numbers (M114 review [O] F1). Round-
+  # tripping eps through format() would compare a scalar's rendering with a
+  # vector's, and format() pads a numeric VECTOR to a common mantissa width --
+  # so on a widened band the membership test could match nothing while the
+  # non-emptiness guard below still passed, emptying the assertion loop
+  # silently. Indexing by mask cannot drift that way.
+  straddling <- logical(length(m114_straddle_eps))
+  for (i in seq_along(m114_straddle_eps)) {
+    eps <- m114_straddle_eps[[i]]
     sigma <- m114_straddle_sigma(eps)
     # The precondition: the criterion routes this matrix to the certificate,
     # rather than to one of the two literals that refuse without consulting it.
     expect_identical(axes_sigma_degenerate(sigma), "ill_conditioned",
                      label = sprintf("eps %g: criterion verdict", eps))
     cert <- axes_accuracy_certificate(sigma, d)
-    if (cert$cval > ds && cert$se <= ds && cert$fiml_ratio <= ds) {
-      straddling <- c(straddling, format(eps))
-    }
+    straddling[[i]] <- cert$cval > ds && cert$se <= ds && cert$fiml_ratio <= ds
   }
   # The domain is not allowed to empty silently. If every member degenerated,
   # this criterion has nothing to assert on this machine and must say so rather
   # than pass vacuously.
-  expect_false(identical(straddling, character()),
-               label = "band members straddling the target, as a set")
+  expect_true(any(straddling),
+              label = "at least one band member straddles the target")
 
-  for (eps in m114_straddle_eps[format(m114_straddle_eps) %in% straddling]) {
+  for (eps in m114_straddle_eps[straddling]) {
     lab <- sprintf("family C p = 4, eps %g", eps)
     sigma <- m114_straddle_sigma(eps)
     cert <- axes_accuracy_certificate(sigma, d)
@@ -404,8 +418,7 @@ test_that("M114 AC1: an input whose fields straddle the target refuses at BOTH s
     wsf <- testthat::capture_warnings(
       sf <- axes_scaling_factor(sigma, rownames(sigma), ang, scl, NULL,
                                 fit_zeta1 = FALSE, fit_zeta2 = FALSE,
-                                df = 4L * 5L / 2L - length(d$mats),
-                                baseline_df = 4L * 3L / 2L)
+                                df = di$df, baseline_df = di$baseline_df)
     )
 
     # BOTH surfaces refuse, under one literal. The SE helper is the one the
@@ -446,12 +459,25 @@ test_that("M114 AC1: a straddling certificate refuses at BOTH surfaces, whicheve
   # the committed counterexample, whose scaling surface trips the `cval <= 0`
   # backstop whatever the certificate says. Reachable geometry a5 -- family A
   # at p = 8, kappa 1e5 -- is below the criterion's floor and computes at both
-  # surfaces, which is what AC2 above asserts of it end-to-end.
+  # surfaces, which is what the M111 AC2 test above asserts of it end-to-end.
+  # That test is not what makes this one honest, though: it can skip when
+  # lavaan is absent, so the liveness argument rests on the all-fields-inside
+  # baseline below, which is run here (M114 review [O] F7).
   sigma <- m106_family_a(2.4e-5, 1L)
   ang <- as.numeric(octants())
   scl <- as.character(1:8)
   di <- m111_dfs(nrow(sigma), ang, scl)
   expect_identical(axes_sigma_degenerate(sigma), "ill_conditioned")
+
+  # THE FIELD SET THE STUBS BELOW MUST COVER, pinned to the certificate's own
+  # sentinel rather than to this file's memory of it (M114 review [O] F2).
+  # axes_certificate_worst() is a max over the fields it is handed, and
+  # `max(1, 2, NULL)` is 2 -- so a fourth field added the way M113 added
+  # `fiml_ratio` would leave every hand-written stub here silently short, the
+  # new field pinned by nothing while all six straddle assertions stayed green.
+  # This is the same drift axes_certificate_sentinel() exists to prevent at the
+  # call site; asserting against it makes a field addition redden HERE.
+  expect_named(axes_certificate_sentinel(), c("se", "cval", "fiml_ratio"))
 
   ds <- axes_degeneracy_delta_star
   lo <- ds / 1e4                       # four decades inside the target
@@ -509,6 +535,9 @@ test_that("M114 AC1: a straddling certificate refuses at BOTH surfaces, whicheve
     list(field = "fiml_ratio",
          cert = list(se = lo, cval = lo, fiml_ratio = hi))
   )
+  # One case per field, asserted rather than assumed: a dropped entry would
+  # retire a field's coverage with nothing to show for it.
+  expect_length(straddles, 3L)
   for (case in straddles) {
     lab <- sprintf("only `%s` past the target", case$field)
     r <- both(case$cert)
@@ -519,11 +548,24 @@ test_that("M114 AC1: a straddling certificate refuses at BOTH surfaces, whicheve
     expect_identical(r$sf, "uncertified",
                      label = sprintf("%s: scaling surface", lab))
 
+    # One warning per refusal, at each surface -- the contract M90 AC7 states,
+    # asserted here too so a second warning carrying the note could not pass
+    # for the one (M114 review [O] F9).
+    expect_identical(length(r$wse), 1L,
+                     label = sprintf("%s: SE helper warning count", lab))
+    expect_identical(length(r$wsf), 1L,
+                     label = sprintf("%s: scaling warning count", lab))
+
     # And the number the user is shown is the same one the refusal was made
     # against -- the note reads axes_certificate_worst() too, so a field the
-    # predicate refused on cannot be a field the note declines to print. `hi`
-    # is 0.01, which is what "%.2g" makes of it.
-    expect_length(grep("estimated relative error 0.01", r$wse, fixed = TRUE), 1L)
-    expect_length(grep("estimated relative error 0.01", r$wsf, fixed = TRUE), 1L)
+    # predicate refused on cannot be a field the note declines to print. The
+    # expected text is DERIVED from `hi` rather than spelled "0.01", so a
+    # change to axes_degeneracy_delta_star cannot fail these greps for a reason
+    # that has nothing to do with what they test (M114 review [O] F5).
+    note <- sprintf("estimated relative error %.2g", hi)
+    expect_identical(length(grep(note, r$wse, fixed = TRUE)), 1L,
+                     label = sprintf("%s: SE helper note", lab))
+    expect_identical(length(grep(note, r$wsf, fixed = TRUE)), 1L,
+                     label = sprintf("%s: scaling note", lab))
   }
 })

--- a/tests/testthat/test-axes-scaled-fit.R
+++ b/tests/testthat/test-axes-scaled-fit.R
@@ -1403,6 +1403,23 @@ test_that("AC8: scaling-surface degeneracy refusals nest inside the SE helper's,
 
     # The nested contract, pointwise: wherever the scaling surface refuses for
     # degeneracy, the SE helper refuses with the same literal.
+    #
+    # WHY "ill_conditioned" IS STILL IN THE GUARD SET, AND WHY THE ASSERTION
+    # BELOW SAYS IT IS DEAD HERE (M114; M111 review F12). Since M111 that
+    # literal reaches no `reason` field on this grid: axes_degeneracy_refusal()
+    # hands every "ill_conditioned" verdict to the certificate, which either
+    # certifies the fit (reason NULL) or refuses it under "uncertified". F12
+    # proposed dropping the literal from the set on that ground. It stays,
+    # because axes_scaling_factor()'s `cval <= 0` backstop still emits it
+    # (`return(na_out("ill_conditioned"))` in R/axes_scaled_fit.R, asserted by
+    # "M90 AC5: the backstop's own literal ..." below), so dropping it
+    # would retire this guard's coverage of that route without saying so. The
+    # deadness F12 observed is instead ASSERTED, on every matrix this grid
+    # drives -- which is what makes the retained set-member honest rather than
+    # merely unfalsified. The two fields are separate claims: the RAW arm's
+    # `naive_reason` still carries "ill_conditioned" at high inflation (the
+    # k = 16 case below asserts exactly that), so only `reason` is asserted
+    # dead here.
     check_nested <- function(sig, what) {
       r <- m89_reasons(sig, pp, df, bdf, m$zeta1)
       if (!is.null(r$sf) &&
@@ -1414,6 +1431,14 @@ test_that("AC8: scaling-surface degeneracy refusals nest inside the SE helper's,
           expected.label = "the scaling surface's literal"
         )
       }
+      expect_false(
+        identical(r$sf, "ill_conditioned"),
+        label = sprintf("%s: scaling surface reason is \"ill_conditioned\"", what)
+      )
+      expect_false(
+        identical(r$se, "ill_conditioned"),
+        label = sprintf("%s: SE helper reason is \"ill_conditioned\"", what)
+      )
       r
     }
 


### PR DESCRIPTION
Fences the one-predicate-both-surfaces refusal design against the per-surface alternative it was chosen over, and asserts the deadness claim that motivated dropping `"ill_conditioned"` from the nestedness set without paying the backstop coverage that drop would cost.

- A committed straddling input (Family C at p = 4, three band members) is asserted to refuse `"uncertified"` at both surfaces; mutating the shared `max()` to per-surface fields reddens the SE helper.
- The AC8 grid additionally asserts neither surface's `reason` returns `"ill_conditioned"`, with the literal kept in `check_nested()`'s guard set.

Tests and tracking only; no user-visible behaviour moved.

Milestone: `cairn/milestones/M114-refusal-predicate-fences.md`