### PR TITLE
M117: Price the accuracy certificate once per checked fit

### DIFF
--- a/R/axes_corrected_se.R
+++ b/R/axes_corrected_se.R
@@ -352,6 +352,7 @@ axes_corrected_se <- function(sigma, item_names, item_angle_deg, item_scale,
   degenerate <- if (is.null(refusal)) {
     axes_degeneracy_refusal(cor_sigma, d)
   } else {
+    axes_check_shared_refusal(refusal, cor_sigma)
     refusal
   }
   if (!is.null(degenerate$reason)) {
@@ -815,23 +816,57 @@ axes_degeneracy_refusal <- function(sigma, d) {
 # (M117 plan gate).
 #
 # Returns NULL -- "nothing precomputed; decide at your own doors", the
-# `refusal` argument's default -- whenever the matrix would be refused by
-# either surface's door guards BEFORE the degeneracy seam (missing dimnames,
-# a nonpositive or infinite diagonal, non-finite entries): those doors keep
-# their own precedence and literals, they cost nothing, and cov2cor() must
-# not run on such a matrix here for exactly the reasons documented at the
-# guards themselves (NaN laundering, double warnings). The guard expressions
-# mirror the callees' own doors verbatim; the callees remain authoritative.
+# `refusal` argument's default -- whenever the matrix would be refused by the
+# MATRIX door guards the two surfaces share BEFORE the degeneracy seam
+# (missing dimnames, a nonpositive or infinite diagonal, non-finite entries):
+# those doors keep their own precedence and literals, they cost nothing, and
+# cov2cor() must not run on such a matrix here for exactly the reasons
+# documented at the guards themselves (NaN laundering, double warnings). Those
+# expressions, and the order they run in against the derivative build, mirror
+# axes_corrected_se()'s own doors; the callees remain authoritative.
+#
+# NOT mirrored, deliberately: axes_scaling_factor()'s `df_mismatch`,
+# `baseline_df_mismatch` and `saturated` doors, which read arguments this
+# helper is not given. A non-NULL return therefore does NOT promise that
+# surface reaches the seam -- those three doors stay ahead of it and discard
+# the precomputed decision unread, exactly as they discarded the surface's own
+# before M117. (M117 review F2.)
+#
+# The realigned cov2cor matrix the decision was priced FOR travels with it in
+# `$priced`, and each surface checks it against the matrix in hand before
+# consuming the decision: nothing else ties the argument to the matrix, and a
+# mismatched pair would otherwise report numbers for a matrix the criterion
+# refuses, silently and with no warning (M117 review F1). `axes_reliability()`
+# passes a matched pair, so the check is an internal invariant, not a
+# user-reachable condition.
 axes_shared_refusal <- function(sigma, item_names, item_angle_deg, item_scale,
-                                item_block, fit_zeta1, fit_zeta2) {
+                                item_block = NULL, fit_zeta1, fit_zeta2) {
   if (is.null(rownames(sigma)) || is.null(colnames(sigma))) return(NULL)
   sigma <- sigma[item_names, item_names, drop = FALSE]
+  d <- axes_se_derivs(item_angle_deg, item_scale, item_block,
+                      fit_zeta1, fit_zeta2)
   if (any(diag(sigma) <= 0, na.rm = TRUE)) return(NULL)
   if (any(is.infinite(diag(sigma)))) return(NULL)
   if (!all(is.finite(sigma))) return(NULL)
-  d <- axes_se_derivs(item_angle_deg, item_scale, item_block,
-                      fit_zeta1, fit_zeta2)
-  axes_degeneracy_refusal(stats::cov2cor(sigma), d)
+  cor_sigma <- stats::cov2cor(sigma)
+  out <- axes_degeneracy_refusal(cor_sigma, d)
+  out$priced <- cor_sigma
+  out
+}
+
+# The `refusal` argument's consumption guard, one definition for both surfaces
+# (M117 review F1). A precomputed decision is consumed only when it was priced
+# for exactly this matrix; anything else is a caller pairing two matrices, and
+# aborting is the only honest answer, since the alternative is a reported
+# number for a matrix the criterion refuses.
+axes_check_shared_refusal <- function(refusal, cor_sigma) {
+  if (!identical(refusal$priced, cor_sigma)) {
+    stop(
+      "`refusal` was priced for a different matrix than the one in hand.",
+      call. = FALSE
+    )
+  }
+  invisible(TRUE)
 }
 
 # The one definition of "the certificate's estimate for this fit", read by the

--- a/R/axes_corrected_se.R
+++ b/R/axes_corrected_se.R
@@ -247,7 +247,8 @@ axes_se_pricing <- function(sigma, d, n) {
 
 
 axes_corrected_se <- function(sigma, item_names, item_angle_deg, item_scale,
-                              item_block = NULL, n, fit_zeta1, fit_zeta2) {
+                              item_block = NULL, n, fit_zeta1, fit_zeta2,
+                              refusal = NULL) {
   if (is.null(rownames(sigma)) || is.null(colnames(sigma))) {
     stop(
       "`sigma` must carry dimnames so it can be realigned to the item map.",
@@ -342,7 +343,17 @@ axes_corrected_se <- function(sigma, item_names, item_angle_deg, item_scale,
   # refusal across the arms' boundary).
   if (!all(is.finite(sigma))) return(na_out("singular"))
   cor_sigma <- stats::cov2cor(sigma)
-  degenerate <- axes_degeneracy_refusal(cor_sigma, d)
+  # `refusal`, when supplied, is axes_shared_refusal()'s answer for THIS
+  # matrix and derivative set, computed once by axes_reliability() so the
+  # certificate is not priced a second time by the sibling surface (M117).
+  # Every guard above stays ahead of this seam: a matrix those doors refuse
+  # never consults the argument, so the finiteness / "singular" /
+  # "infinite_diagonal" precedence is unchanged whether or not it is passed.
+  degenerate <- if (is.null(refusal)) {
+    axes_degeneracy_refusal(cor_sigma, d)
+  } else {
+    refusal
+  }
   if (!is.null(degenerate$reason)) {
     # Only the "uncertified" literal gets the diagnostic -- see the scope note
     # at axes_degeneracy_hint(). The sibling surface calls the SAME decision
@@ -734,10 +745,10 @@ axes_sigma_degenerate <- function(sigma) {
 #                     literal, "uncertified".
 #   NULL              computes, and pays nothing: the certificate runs only on
 #                     the floor's own side, so an ordinary fit never buys the
-#                     16-108x replay (M108). A fit that IS checked buys it
-#                     twice, once per surface: both call this helper on the
-#                     same matrix with the same derivative set, and nothing
-#                     memoizes between them (M111 review F14).
+#                     16-108x replay (M108). Until M117 a fit that WAS checked
+#                     bought it twice, once per surface (M111 review F14);
+#                     axes_reliability() now makes this decision once via
+#                     axes_shared_refusal() below and hands it to both.
 #
 # ONE PREDICATE, BOTH SURFACES (M111 gate). The certificate reports three
 # estimates -- the corrected component SEs' (worst component), the scaling
@@ -790,6 +801,37 @@ axes_degeneracy_refusal <- function(sigma, d) {
     return(list(reason = NULL, cert = cert))
   }
   list(reason = "uncertified", cert = cert)
+}
+
+# The refusal decision computed ONCE per checked fit (M117), for
+# axes_reliability() to hand to both surfaces through their `refusal`
+# argument. Both call axes_degeneracy_refusal() on the same matrix (the
+# realigned cov2cor(Sigma-hat)) with the same derivative set, so until M117 a
+# fit the floor sent to the certificate paid for the double-double replay
+# twice, once per surface, with nothing memoizing between them (M111 review
+# F14). This helper is deliberately NOT a cache: a per-call argument threads
+# the decision through one call's own dataflow, where a cache would have to
+# invent key identity for a floating-point matrix and would outlive the call
+# (M117 plan gate).
+#
+# Returns NULL -- "nothing precomputed; decide at your own doors", the
+# `refusal` argument's default -- whenever the matrix would be refused by
+# either surface's door guards BEFORE the degeneracy seam (missing dimnames,
+# a nonpositive or infinite diagonal, non-finite entries): those doors keep
+# their own precedence and literals, they cost nothing, and cov2cor() must
+# not run on such a matrix here for exactly the reasons documented at the
+# guards themselves (NaN laundering, double warnings). The guard expressions
+# mirror the callees' own doors verbatim; the callees remain authoritative.
+axes_shared_refusal <- function(sigma, item_names, item_angle_deg, item_scale,
+                                item_block, fit_zeta1, fit_zeta2) {
+  if (is.null(rownames(sigma)) || is.null(colnames(sigma))) return(NULL)
+  sigma <- sigma[item_names, item_names, drop = FALSE]
+  if (any(diag(sigma) <= 0, na.rm = TRUE)) return(NULL)
+  if (any(is.infinite(diag(sigma)))) return(NULL)
+  if (!all(is.finite(sigma))) return(NULL)
+  d <- axes_se_derivs(item_angle_deg, item_scale, item_block,
+                      fit_zeta1, fit_zeta2)
+  axes_degeneracy_refusal(stats::cov2cor(sigma), d)
 }
 
 # The one definition of "the certificate's estimate for this fit", read by the

--- a/R/axes_reliability.R
+++ b/R/axes_reliability.R
@@ -1810,9 +1810,20 @@ axes_reliability <- function(data = NULL, items, angles = NULL,
   #
   # `n` is the sample size the SEs are priced at on each path: complete cases
   # for listwise, the supplied `n` for cormat.
+  # The degeneracy/certificate decision is made ONCE here (M117) and handed to
+  # both consumers below: they price the same realigned cov2cor matrix with
+  # the same derivative set, so before this seam a fit the floor sent to the
+  # certificate paid for the double-double replay twice, once per surface.
+  # NULL when the matrix would be refused at a door guard ahead of the seam --
+  # each consumer then decides at its own doors, unchanged and cheap.
+  fitted_sigma <- axes_fitted_cov(fit)
+  refusal <- axes_shared_refusal(
+    fitted_sigma, all_cols, item_angle, item_scale, item_block,
+    fit_zeta1 = fit_zeta1, fit_zeta2 = fit_zeta2
+  )
   corrected <- axes_corrected_se(
-    axes_fitted_cov(fit), all_cols, item_angle, item_scale, item_block,
-    n = n, fit_zeta1 = fit_zeta1, fit_zeta2 = fit_zeta2
+    fitted_sigma, all_cols, item_angle, item_scale, item_block,
+    n = n, fit_zeta1 = fit_zeta1, fit_zeta2 = fit_zeta2, refusal = refusal
   )
   se_reported <- if (missing == "fiml") {
     # The FIML path composes MULTIPLICATIVELY rather than by replacement
@@ -1920,9 +1931,9 @@ axes_reliability <- function(data = NULL, items, angles = NULL,
   # this point, so no scaled statistic is ever computed against a saturated
   # model that was never reached.
   scaling <- axes_scaling_factor(
-    axes_fitted_cov(fit), all_cols, item_angle, item_scale, item_block,
+    fitted_sigma, all_cols, item_angle, item_scale, item_block,
     fit_zeta1 = fit_zeta1, fit_zeta2 = fit_zeta2,
-    df = fm[["df"]], baseline_df = fm[["baseline.df"]]
+    df = fm[["df"]], baseline_df = fm[["baseline.df"]], refusal = refusal
   )
   scaled <- axes_scale_fit_measures(fm, scaling)
 

--- a/R/axes_scaled_fit.R
+++ b/R/axes_scaled_fit.R
@@ -148,7 +148,7 @@ axes_u_pricing <- function(sigma, d) {
 # is the single failure a user could not detect (the M66 contract).
 axes_scaling_factor <- function(sigma, item_names, item_angle_deg, item_scale,
                                 item_block = NULL, fit_zeta1, fit_zeta2,
-                                df, baseline_df) {
+                                df, baseline_df, refusal = NULL) {
   if (is.null(rownames(sigma)) || is.null(colnames(sigma))) {
     stop(
       "`sigma` must carry dimnames so it can be realigned to the item map.",
@@ -238,7 +238,17 @@ axes_scaling_factor <- function(sigma, item_names, item_angle_deg, item_scale,
   # so hoisting it moves no refusal across the two arms' boundary.
   if (!all(is.finite(sigma))) return(na_out("singular"))
   sigma <- stats::cov2cor(sigma)
-  degenerate <- axes_degeneracy_refusal(sigma, d)
+  # `refusal`, when supplied, is axes_shared_refusal()'s answer for this
+  # matrix and derivative set, computed once by axes_reliability() so the
+  # certificate is not priced again here after the sibling surface (M117).
+  # Every guard above -- the df pair, saturation, the diagonal doors and
+  # finiteness -- stays ahead of this seam, so the refusal precedence is
+  # unchanged whether or not the argument is passed.
+  degenerate <- if (is.null(refusal)) {
+    axes_degeneracy_refusal(sigma, d)
+  } else {
+    refusal
+  }
   if (!is.null(degenerate$reason)) {
     # Only the "uncertified" literal gets the diagnostic -- see the scope note
     # at axes_degeneracy_hint() in R/axes_corrected_se.R. The sibling surface

--- a/R/axes_scaled_fit.R
+++ b/R/axes_scaled_fit.R
@@ -243,10 +243,14 @@ axes_scaling_factor <- function(sigma, item_names, item_angle_deg, item_scale,
   # certificate is not priced again here after the sibling surface (M117).
   # Every guard above -- the df pair, saturation, the diagonal doors and
   # finiteness -- stays ahead of this seam, so the refusal precedence is
-  # unchanged whether or not the argument is passed.
+  # unchanged whether or not the argument is passed; the first three of those
+  # the helper does not mirror at all, and discard the precomputed decision
+  # unread. The consumption guard pins the decision to THIS matrix: see
+  # axes_check_shared_refusal() in R/axes_corrected_se.R.
   degenerate <- if (is.null(refusal)) {
     axes_degeneracy_refusal(sigma, d)
   } else {
+    axes_check_shared_refusal(refusal, sigma)
     refusal
   }
   if (!is.null(degenerate$reason)) {

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -11,7 +11,7 @@ Pre-migration history: `cairn/legacy/` and git log.
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | — (all deps done) | high | milestones/M7-v2-release-prep.md |
 | M116 | Make three passing-without-checking assertions in the certificate suite redden | done | — | normal | milestones/archive/M116-certificate-suite-vacuities.md |
-| M117 | Price the accuracy certificate once per checked fit | in-progress | — | normal | milestones/M117-certificate-once-per-fit.md |
+| M117 | Price the accuracy certificate once per checked fit | review | — | normal | milestones/M117-certificate-once-per-fit.md |
 | M114 | Pin the shared refusal predicate, and assert the dead literal rather than dropping it | done | M113 | normal | milestones/archive/M114-refusal-predicate-fences.md |
 | M115 | Make the packaged accuracy bracket assert where the shipped pricing differs | done | M113 | normal | milestones/archive/M115-certificate-bracket-reach.md |
 | M112 | Withdraw the CAIS adult normative sample | done | — | normal | milestones/archive/M112-cais-adult-sample-withdrawal.md |

--- a/cairn/ROADMAP.md
+++ b/cairn/ROADMAP.md
@@ -11,7 +11,7 @@ Pre-migration history: `cairn/legacy/` and git log.
 |---|---|---|---|---|---|
 | M7 | v2.0.0 CRAN release preparation | blocked | — (all deps done) | high | milestones/M7-v2-release-prep.md |
 | M116 | Make three passing-without-checking assertions in the certificate suite redden | done | — | normal | milestones/archive/M116-certificate-suite-vacuities.md |
-| M117 | Price the accuracy certificate once per checked fit | planned | — | normal | milestones/M117-certificate-once-per-fit.md |
+| M117 | Price the accuracy certificate once per checked fit | in-progress | — | normal | milestones/M117-certificate-once-per-fit.md |
 | M114 | Pin the shared refusal predicate, and assert the dead literal rather than dropping it | done | M113 | normal | milestones/archive/M114-refusal-predicate-fences.md |
 | M115 | Make the packaged accuracy bracket assert where the shipped pricing differs | done | M113 | normal | milestones/archive/M115-certificate-bracket-reach.md |
 | M112 | Withdraw the CAIS adult normative sample | done | — | normal | milestones/archive/M112-cais-adult-sample-withdrawal.md |

--- a/cairn/milestones/M117-certificate-once-per-fit.md
+++ b/cairn/milestones/M117-certificate-once-per-fit.md
@@ -78,7 +78,7 @@ seam.
       it; `axes_reliability()` computes it once and passes it to both. The
       finiteness / `"singular"` / `"infinite_diagonal"` precedence and the
       `naive_reason` decoupling stay ahead of the seam.
-- [ ] T3: Write the trace test (AC1, both `missing` paths), the two standalone
+- [x] T3: Write the trace test (AC1, both `missing` paths), the two standalone
       tests (AC2), and the agreement test on both sides of the seam (AC3).
 - [ ] T4: Re-measure T1's fit after the change; record beside T1's figure.
 - [ ] T5: `devtools::test()` clean with no snapshot diff;
@@ -93,6 +93,7 @@ seam.
 - 2026-08-31: implement started; branch m117-certificate-once-per-fit. Question gate skipped — both seam surfaces are internal (`NAMESPACE` exports only `axes_reliability`), the plan gate settled the design, no tripwire tags; the two minor choices made here: the argument is named `refusal` (the `axes_degeneracy_refusal()` return, default `NULL` = compute it), and `axes_reliability()` builds it once inline at the seam.
 - 2026-08-31: T1 done — scratchpad script (M89 AC6 injection shape: p = 24 octant matrix, item 2 duplicated + 1e-9 ridge, mocked at `axes_fitted_cov`), 5 timed reps after warm-up via `system.time`, Apple M5 Pro / R 4.6.1, 2026-08-31: median 0.033 s per `axes_reliability()` call; one `axes_accuracy_certificate()` evaluation on that matrix: median 0.002 s.
 - 2026-08-31: T2 done — `refusal = NULL` argument on both surfaces, consulted only at the `axes_degeneracy_refusal()` seam (every door guard stays ahead); new `axes_shared_refusal()` beside the refusal helper mirrors the door guards and returns NULL when a door would refuse; `axes_reliability()` computes `axes_fitted_cov(fit)` and the refusal once and passes both to the two call sites. test-axes-corrected-se.R, test-axes-scaled-fit.R and test-axes-certificate-refusal.R pass under load_all.
+- 2026-08-31: T3 done — two tests appended to test-axes-certificate-refusal.R: an AC1 trace (counting wrapper around `axes_accuracy_certificate`, M89 AC6-style injection at `axes_fitted_cov`, exactly 1 evaluation per call on listwise and fiml, both surfaces still warning "uncertified") and a combined AC2+AC3 test on the committed p = 3 counterexample (each standalone surface moves the trace by one and warns the estimate re-derived independently from the certificate; with the shared refusal passed the trace does not move; one extracted estimate across all four warnings). Discrimination proven: planting the old double evaluation reddened AC1 on both paths (count 2), and a callee ignoring `refusal` reddened the seam-side count (4 vs 3); both plants reverted.
 
 ## Decisions
 

--- a/cairn/milestones/M117-certificate-once-per-fit.md
+++ b/cairn/milestones/M117-certificate-once-per-fit.md
@@ -174,34 +174,59 @@ Findings, ranked as reported, with disposition:
   estimate from one matrix beside a condition number from the other, because
   `axes_degeneracy_note()` mixes the passed refusal with the local matrix.
   Unreachable through the exported API today — `axes_reliability()` is the only
-  caller and passes a matched pair. Disposition: TBD at gate.
+  caller and passes a matched pair. Disposition: FIXED at the gate. The
+  decision now carries the realigned cov2cor matrix it was priced for in
+  `$priced`, and one shared `axes_check_shared_refusal()` aborts at both
+  consumption sites when it does not `identical()` the matrix in hand.
+  Discrimination proven: deleting both guard calls reddens the new test's two
+  `expect_error()` assertions; the plant was reverted.
 - F2 [O], echoed by [S] blame: `axes_shared_refusal()`'s header claims it
   returns NULL whenever *either* surface's pre-seam doors would refuse and that
   the guards mirror the callees "verbatim", but `axes_scaling_factor()`'s
   `df_mismatch`, `baseline_df_mismatch` and `saturated` doors are not mirrored
   (`R/axes_corrected_se.R:817-824` vs `R/axes_scaled_fit.R:174-185`). No
   behavior consequence — those doors stay ahead of the seam — but the stated
-  contract is false as written. Disposition: TBD at gate.
+  contract is false as written. Disposition: FIXED at the gate. The header now
+  scopes its NULL promise to the matrix doors the two surfaces share, names the
+  three scaling-only doors it does not mirror, and says a non-NULL return does
+  not promise that surface reaches the seam.
 - F3 [O] the derivative set is built after the matrix guards in the helper and
   before them in both callees, so a malformed derivative spec now aborts from
   `axes_shared_refusal()` rather than from the callee: same condition,
   different call context, and a second way the "verbatim mirror" claim fails.
-  Disposition: TBD at gate.
+  Disposition: FIXED at the gate by reordering rather than by documenting — the
+  helper now builds the derivative set immediately after realignment, where
+  both callees build theirs, so the abort surfaces from the same position.
 - F4 [O] a third `axes_se_derivs()` build is constructed and discarded on every
   call, including the common non-degenerate one. Measured at review on the
   clean p = 24 fit (same machine and date as T1/T4): branch 0.042 s and 0.049 s
   across two runs of 7 reps, master's code in the same tree 0.046 s — the
   branch-vs-master gap sits inside this measurement's own run-to-run spread, so
-  no clean-fit regression is demonstrated. Disposition: TBD at gate.
+  no clean-fit regression is demonstrated. Disposition: REJECTED at the gate on
+  that measurement — the cost is real but below what this fit can resolve, and
+  threading the derivative set through both surfaces would widen the seam the
+  milestone deliberately kept to one argument.
 - F5 [O] `item_block` carries no `= NULL` default in the helper, unlike both
   functions it mirrors, so the natural named-argument spelling errors and the
   new test has to pass NULL positionally (`R/axes_corrected_se.R:826`).
-  Disposition: TBD at gate.
+  Disposition: FIXED at the gate — `item_block = NULL`, asserted by the new
+  test calling the helper with the named-argument spelling.
 - F6 [S] prior-review, surfaced as low-confidence: `axes_shared_refusal()` is a
   third hand-copied instance of the door-guard sequence already duplicated
   between the two surfaces, the divergence class M69 A1 and M71 F1 both hit.
   The lens judged it an acknowledged tradeoff, not a reintroduced defect.
-  Disposition: TBD at gate.
+  Disposition: REJECTED at the gate — the duplication is what keeps each
+  surface's doors authoritative over its own refusal literals, which is the
+  property M69 and M71 were about; the header now says so.
+
+### Re-verification after the gate fixes
+
+`Rscript -e 'devtools::test()'`: 0 failed / 9192 passed (was 9185 before the
+fixes; the seven are the new F1 guard test), 5 warnings / 1 skip, all
+pre-existing; `git status --short tests/testthat/_snaps/` printed nothing.
+`Rscript -e 'devtools::check(args = "--no-manual")'`: Status OK, 0 errors /
+0 warnings / 0 notes, 8m 22s. AC1-AC5 therefore stand on the merged tree, not
+only on the pre-fix one.
 
 Return floor: no finding demonstrates an acceptance criterion failing, and F1
 — the only one with a wrong-number scenario — is unreachable through the

--- a/cairn/milestones/M117-certificate-once-per-fit.md
+++ b/cairn/milestones/M117-certificate-once-per-fit.md
@@ -73,7 +73,7 @@ seam.
 - [x] T1: Measure the wall-clock cost of one `axes_reliability()` call on an
       ill-conditioned p = 24 fit before the change. Record the command, date,
       machine and figure in the work log.
-- [ ] T2: Add the optional pre-computed-refusal argument to
+- [x] T2: Add the optional pre-computed-refusal argument to
       `axes_corrected_se()` and `axes_scaling_factor()`, defaulting to computing
       it; `axes_reliability()` computes it once and passes it to both. The
       finiteness / `"singular"` / `"infinite_diagonal"` precedence and the
@@ -92,6 +92,7 @@ seam.
 
 - 2026-08-31: implement started; branch m117-certificate-once-per-fit. Question gate skipped — both seam surfaces are internal (`NAMESPACE` exports only `axes_reliability`), the plan gate settled the design, no tripwire tags; the two minor choices made here: the argument is named `refusal` (the `axes_degeneracy_refusal()` return, default `NULL` = compute it), and `axes_reliability()` builds it once inline at the seam.
 - 2026-08-31: T1 done — scratchpad script (M89 AC6 injection shape: p = 24 octant matrix, item 2 duplicated + 1e-9 ridge, mocked at `axes_fitted_cov`), 5 timed reps after warm-up via `system.time`, Apple M5 Pro / R 4.6.1, 2026-08-31: median 0.033 s per `axes_reliability()` call; one `axes_accuracy_certificate()` evaluation on that matrix: median 0.002 s.
+- 2026-08-31: T2 done — `refusal = NULL` argument on both surfaces, consulted only at the `axes_degeneracy_refusal()` seam (every door guard stays ahead); new `axes_shared_refusal()` beside the refusal helper mirrors the door guards and returns NULL when a door would refuse; `axes_reliability()` computes `axes_fitted_cov(fit)` and the refusal once and passes both to the two call sites. test-axes-corrected-se.R, test-axes-scaled-fit.R and test-axes-certificate-refusal.R pass under load_all.
 
 ## Decisions
 

--- a/cairn/milestones/M117-certificate-once-per-fit.md
+++ b/cairn/milestones/M117-certificate-once-per-fit.md
@@ -2,7 +2,7 @@
      section ownership". A phase skill never rewrites another phase's section. -->
 # M117: Price the accuracy certificate once per checked fit
 
-- **Status:** in-progress
+- **Status:** review
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
@@ -81,7 +81,7 @@ seam.
 - [x] T3: Write the trace test (AC1, both `missing` paths), the two standalone
       tests (AC2), and the agreement test on both sides of the seam (AC3).
 - [x] T4: Re-measure T1's fit after the change; record beside T1's figure.
-- [ ] T5: `devtools::test()` clean with no snapshot diff;
+- [x] T5: `devtools::test()` clean with no snapshot diff;
       `devtools::check(args = "--no-manual")` clean.
 
 ## Work log
@@ -95,6 +95,7 @@ seam.
 - 2026-08-31: T2 done — `refusal = NULL` argument on both surfaces, consulted only at the `axes_degeneracy_refusal()` seam (every door guard stays ahead); new `axes_shared_refusal()` beside the refusal helper mirrors the door guards and returns NULL when a door would refuse; `axes_reliability()` computes `axes_fitted_cov(fit)` and the refusal once and passes both to the two call sites. test-axes-corrected-se.R, test-axes-scaled-fit.R and test-axes-certificate-refusal.R pass under load_all.
 - 2026-08-31: T3 done — two tests appended to test-axes-certificate-refusal.R: an AC1 trace (counting wrapper around `axes_accuracy_certificate`, M89 AC6-style injection at `axes_fitted_cov`, exactly 1 evaluation per call on listwise and fiml, both surfaces still warning "uncertified") and a combined AC2+AC3 test on the committed p = 3 counterexample (each standalone surface moves the trace by one and warns the estimate re-derived independently from the certificate; with the shared refusal passed the trace does not move; one extracted estimate across all four warnings). Discrimination proven: planting the old double evaluation reddened AC1 on both paths (count 2), and a callee ignoring `refusal` reddened the seam-side count (4 vs 3); both plants reverted.
 - 2026-08-31: T4 done — same script, machine and date as T1: median 0.029 s per call after the change (was 0.033 s; the saved evaluation is the certificate's own ~0.002 s plus its setup on this p = 24 fit). Both "uncertified" warnings still emitted.
+- 2026-08-31: T5 done — `devtools::test()` 0 failed / 9185 passed, `git status --short tests/testthat/_snaps/` empty; `devtools::check(args = "--no-manual")` 0 errors / 0 warnings / 0 notes. Status → review.
 
 ## Decisions
 

--- a/cairn/milestones/M117-certificate-once-per-fit.md
+++ b/cairn/milestones/M117-certificate-once-per-fit.md
@@ -2,12 +2,12 @@
      section ownership". A phase skill never rewrites another phase's section. -->
 # M117: Price the accuracy certificate once per checked fit
 
-- **Status:** planned
+- **Status:** in-progress
 - **Priority:** normal
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** IP1, GP2
-- **Branch/PR:** —
+- **Branch/PR:** m117-certificate-once-per-fit
 
 ## Goal
 

--- a/cairn/milestones/M117-certificate-once-per-fit.md
+++ b/cairn/milestones/M117-certificate-once-per-fit.md
@@ -70,7 +70,7 @@ seam.
 
 ## Tasks
 
-- [ ] T1: Measure the wall-clock cost of one `axes_reliability()` call on an
+- [x] T1: Measure the wall-clock cost of one `axes_reliability()` call on an
       ill-conditioned p = 24 fit before the change. Record the command, date,
       machine and figure in the work log.
 - [ ] T2: Add the optional pre-computed-refusal argument to
@@ -89,6 +89,9 @@ seam.
 - 2026-08-30: created by /milestone-plan.
 - 2026-08-30: plan gate chose an optional per-call pre-computed-refusal argument over memoizing inside `axes_degeneracy_refusal()` on a cache keyed by the matrix, because a cache would have to decide key identity for a floating-point matrix and would outlive the call; falsified by a second duplication appearing on a path that cannot thread an argument through.
 - 2026-08-30: criteria audit ran in **full** mode (user-facing tier), fresh-context [O] reader, two passes. First pass returned three findings — a goal sentence claiming the duplication departs from D-051's decision text when D-051 states a cost model rather than a call-count contract, a criterion binding a before-measurement that cannot be reproduced from the merged tree, and a criterion already green on the pre-change tree. Second pass over the post-gate wording returned three more — a wrong injection-site line reference, one probe standing for a family free in the `missing` path, and an unbounded promise over a warning text whose estimate is machine-dependent by design. All disposed before this file was written.
+
+- 2026-08-31: implement started; branch m117-certificate-once-per-fit. Question gate skipped — both seam surfaces are internal (`NAMESPACE` exports only `axes_reliability`), the plan gate settled the design, no tripwire tags; the two minor choices made here: the argument is named `refusal` (the `axes_degeneracy_refusal()` return, default `NULL` = compute it), and `axes_reliability()` builds it once inline at the seam.
+- 2026-08-31: T1 done — scratchpad script (M89 AC6 injection shape: p = 24 octant matrix, item 2 duplicated + 1e-9 ridge, mocked at `axes_fitted_cov`), 5 timed reps after warm-up via `system.time`, Apple M5 Pro / R 4.6.1, 2026-08-31: median 0.033 s per `axes_reliability()` call; one `axes_accuracy_certificate()` evaluation on that matrix: median 0.002 s.
 
 ## Decisions
 

--- a/cairn/milestones/M117-certificate-once-per-fit.md
+++ b/cairn/milestones/M117-certificate-once-per-fit.md
@@ -7,7 +7,7 @@
 - **Depends on:** —
 - **Driving RR:** —
 - **Principles touched:** IP1, GP2
-- **Branch/PR:** m117-certificate-once-per-fit
+- **Branch/PR:** m117-certificate-once-per-fit / PR #148
 
 ## Goal
 
@@ -38,26 +38,26 @@ seam.
 
 ## Acceptance criteria
 
-- [ ] AC1: For `axes_reliability()` calls whose realigned `cov2cor` matrix
+- [x] AC1: For `axes_reliability()` calls whose realigned `cov2cor` matrix
       `axes_sigma_degenerate()` answers `"ill_conditioned"` for — injected at
       the `axes_fitted_cov` binding the way
       `tests/testthat/test-axes-reliability.R:3105` already does —
       `axes_accuracy_certificate()` is entered exactly once per call, counted by
       a trace, on both a listwise-default call and a `missing = "fiml"` call.
-- [ ] AC2: `axes_corrected_se()` and `axes_scaling_factor()` called WITHOUT the
+- [x] AC2: `axes_corrected_se()` and `axes_scaling_factor()` called WITHOUT the
       new pre-computed-refusal argument each compute the certificate themselves
       and return the `"uncertified"` literal with a warning matching
       `"estimated relative error "` whose estimate is derived from that
       certificate, asserted by a test firing each surface standalone on an
       uncertifiable matrix.
-- [ ] AC3: On one matrix refused as `"uncertified"`, the warning
+- [x] AC3: On one matrix refused as `"uncertified"`, the warning
       `axes_corrected_se()` emits and the warning `axes_scaling_factor()` emits
       report the same estimated relative error — asserted both where each
       surface computes its own certificate and where both receive the
       pre-computed refusal.
-- [ ] AC4: `Rscript -e 'devtools::test()'` is clean and
+- [x] AC4: `Rscript -e 'devtools::test()'` is clean and
       `git status --short tests/testthat/_snaps/` reports nothing.
-- [ ] AC5: `Rscript -e 'devtools::check(args = "--no-manual")'` reports 0 errors
+- [x] AC5: `Rscript -e 'devtools::check(args = "--no-manual")'` reports 0 errors
       and 0 warnings.
 
 ## Coverage
@@ -97,6 +97,112 @@ seam.
 - 2026-08-31: T4 done — same script, machine and date as T1: median 0.029 s per call after the change (was 0.033 s; the saved evaluation is the certificate's own ~0.002 s plus its setup on this p = 24 fit). Both "uncertified" warnings still emitted.
 - 2026-08-31: T5 done — `devtools::test()` 0 failed / 9185 passed, `git status --short tests/testthat/_snaps/` empty; `devtools::check(args = "--no-manual")` 0 errors / 0 warnings / 0 notes. Status → review.
 
+- 2026-08-31: review — all five criteria verified with fresh evidence; consistency gate clean; three-lens fan-out returned six findings, none demonstrating a criterion failing, so no floor return.
+
 ## Decisions
 
 ## Review
+
+### Acceptance-criterion evidence (2026-08-31, branch m117-certificate-once-per-fit @ eb5ea92b, PR #148)
+
+- AC1 — `Rscript -e 'devtools::test()'` and a targeted `test_file()` run of
+  `tests/testthat/test-axes-certificate-refusal.R`: the M117 AC1 test passes on
+  both the listwise-default and the `missing = "fiml"` call, asserting the
+  traced `axes_accuracy_certificate` count is exactly 1 per call while both
+  surfaces still warn `"uncertified"`. Discrimination re-proven at review, not
+  taken from the work log: with `refusal = NULL` planted at both
+  `axes_reliability()` call sites the same test reddens twice (one failure per
+  `missing` path) at `test-axes-certificate-refusal.R:647`; the plant was
+  reverted and `git status R/` is clean.
+- AC2 — same targeted run: the M117 AC2+AC3 test fires `axes_corrected_se()`
+  and `axes_scaling_factor()` standalone on the committed p = 3
+  `rb18-counterexample-b` matrix without the new argument. Each moves the
+  certificate trace by exactly one, returns `reason == "uncertified"`, and
+  warns an estimate matched against `axes_certificate_worst()` recomputed
+  independently from `axes_accuracy_certificate(cov2cor(S), d)` in the test.
+- AC3 — same test: the estimate substring is extracted from all four warnings
+  (each surface with its own certificate, each surface given the shared
+  refusal) and `unique()` over the four is length one.
+- AC4 — `Rscript -e 'devtools::test()'`: 0 failed / 9185 passed / 5 warnings /
+  1 skip (the pre-existing lavaan-version fixture skip and the pre-existing
+  CPM/lavaan warnings, all on master too). `git status --short
+  tests/testthat/_snaps/` printed nothing.
+- AC5 — `Rscript -e 'devtools::check(args = "--no-manual")'`: Status OK,
+  0 errors / 0 warnings / 0 notes, 8m 14s.
+
+### Consistency gate
+
+- `cairn_validate.py` exit 0, all checks pass; 47 advisory work-log-format
+  warnings, all on M7, all pre-existing. `release window` did not fire.
+- No `DESIGN.md` principle changed, so `cairn_impact.py` was skipped.
+- Toolchain slot (`r-package`): `document()` produced no diff and zero
+  `resolve link` lines at `cli.width = 500`; `NAMESPACE`, `man/` and the
+  RcppExports pair unchanged. `pkgdown::check_pkgdown()` — no problems.
+  README.md is newer than README.Rmd and neither is touched. No NEWS entry is
+  owed: the change is behavior-preserving and both seam surfaces are internal
+  (`NAMESPACE` exports only `axes_reliability`). No new top-level files.
+  Master watches: newest push run reaching a verdict is `success` on both
+  `R-CMD-check.yaml` and `test-coverage.yaml` (head `bb0be478`).
+  `tools/check-master-red-alert.R`, `tools/master-red-alert-dryrun.R` (5/5
+  synthetic payloads ok) and `tools/check-branch-protection.R` all exit clean.
+
+### Independent review (three fresh-context lenses, user-facing tier)
+
+[O] diff-bug, [S] blame-history, [S] prior-review, none having seen the
+implementation. The [O] lens verified behavior-preservation by execution, not
+by reading: a 13-matrix battery (clean, rescaled, ill-conditioned, negative /
+zero / infinite / NA / NaN diagonal, NA and Inf off-diagonal, exactly singular,
+indefinite) fired each surface with `refusal = NULL` and with the shared
+refusal, and return value and warning vector were `identical()` across all 26
+comparisons; end-to-end `axes_reliability()` on a clean p = 24 fit and on the
+M89-style injection was `identical()` with the seam live and with
+`axes_shared_refusal` mocked to NULL. The [S] blame lens cleared the M66 / M89
+/ M108 / M111 / M113 / M114 intent behind every touched line and the
+D-044 / D-048 / D-049 / D-051 / D-053 / D-054 family, and confirmed the raw
+arm's `naive_reason` decoupling and the guard-order precedence are untouched.
+The [S] prior-review lens found the diff implements M111 review finding F14
+rather than regressing anything; `gh api .../pulls/comments` returned `[]`, so
+no PR-thread surface was walked.
+
+Findings, ranked as reported, with disposition:
+
+- F1 [O] `refusal` is consumed with no check that it belongs to this matrix,
+  and the failure is silent and fail-open (`R/axes_corrected_se.R:352-356`,
+  `R/axes_scaled_fit.R:247-251`). Demonstrated: handing a clean matrix's
+  refusal to the degenerate `rb18-counterexample-b` matrix returns populated
+  corrected SEs and emits no warning at all; the reverse direction warns an
+  estimate from one matrix beside a condition number from the other, because
+  `axes_degeneracy_note()` mixes the passed refusal with the local matrix.
+  Unreachable through the exported API today — `axes_reliability()` is the only
+  caller and passes a matched pair. Disposition: TBD at gate.
+- F2 [O], echoed by [S] blame: `axes_shared_refusal()`'s header claims it
+  returns NULL whenever *either* surface's pre-seam doors would refuse and that
+  the guards mirror the callees "verbatim", but `axes_scaling_factor()`'s
+  `df_mismatch`, `baseline_df_mismatch` and `saturated` doors are not mirrored
+  (`R/axes_corrected_se.R:817-824` vs `R/axes_scaled_fit.R:174-185`). No
+  behavior consequence — those doors stay ahead of the seam — but the stated
+  contract is false as written. Disposition: TBD at gate.
+- F3 [O] the derivative set is built after the matrix guards in the helper and
+  before them in both callees, so a malformed derivative spec now aborts from
+  `axes_shared_refusal()` rather than from the callee: same condition,
+  different call context, and a second way the "verbatim mirror" claim fails.
+  Disposition: TBD at gate.
+- F4 [O] a third `axes_se_derivs()` build is constructed and discarded on every
+  call, including the common non-degenerate one. Measured at review on the
+  clean p = 24 fit (same machine and date as T1/T4): branch 0.042 s and 0.049 s
+  across two runs of 7 reps, master's code in the same tree 0.046 s — the
+  branch-vs-master gap sits inside this measurement's own run-to-run spread, so
+  no clean-fit regression is demonstrated. Disposition: TBD at gate.
+- F5 [O] `item_block` carries no `= NULL` default in the helper, unlike both
+  functions it mirrors, so the natural named-argument spelling errors and the
+  new test has to pass NULL positionally (`R/axes_corrected_se.R:826`).
+  Disposition: TBD at gate.
+- F6 [S] prior-review, surfaced as low-confidence: `axes_shared_refusal()` is a
+  third hand-copied instance of the door-guard sequence already duplicated
+  between the two surfaces, the divergence class M69 A1 and M71 F1 both hit.
+  The lens judged it an acknowledged tradeoff, not a reintroduced defect.
+  Disposition: TBD at gate.
+
+Return floor: no finding demonstrates an acceptance criterion failing, and F1
+— the only one with a wrong-number scenario — is unreachable through the
+exported API, so none returns the milestone to `in-progress`.

--- a/cairn/milestones/M117-certificate-once-per-fit.md
+++ b/cairn/milestones/M117-certificate-once-per-fit.md
@@ -80,7 +80,7 @@ seam.
       `naive_reason` decoupling stay ahead of the seam.
 - [x] T3: Write the trace test (AC1, both `missing` paths), the two standalone
       tests (AC2), and the agreement test on both sides of the seam (AC3).
-- [ ] T4: Re-measure T1's fit after the change; record beside T1's figure.
+- [x] T4: Re-measure T1's fit after the change; record beside T1's figure.
 - [ ] T5: `devtools::test()` clean with no snapshot diff;
       `devtools::check(args = "--no-manual")` clean.
 
@@ -94,6 +94,7 @@ seam.
 - 2026-08-31: T1 done — scratchpad script (M89 AC6 injection shape: p = 24 octant matrix, item 2 duplicated + 1e-9 ridge, mocked at `axes_fitted_cov`), 5 timed reps after warm-up via `system.time`, Apple M5 Pro / R 4.6.1, 2026-08-31: median 0.033 s per `axes_reliability()` call; one `axes_accuracy_certificate()` evaluation on that matrix: median 0.002 s.
 - 2026-08-31: T2 done — `refusal = NULL` argument on both surfaces, consulted only at the `axes_degeneracy_refusal()` seam (every door guard stays ahead); new `axes_shared_refusal()` beside the refusal helper mirrors the door guards and returns NULL when a door would refuse; `axes_reliability()` computes `axes_fitted_cov(fit)` and the refusal once and passes both to the two call sites. test-axes-corrected-se.R, test-axes-scaled-fit.R and test-axes-certificate-refusal.R pass under load_all.
 - 2026-08-31: T3 done — two tests appended to test-axes-certificate-refusal.R: an AC1 trace (counting wrapper around `axes_accuracy_certificate`, M89 AC6-style injection at `axes_fitted_cov`, exactly 1 evaluation per call on listwise and fiml, both surfaces still warning "uncertified") and a combined AC2+AC3 test on the committed p = 3 counterexample (each standalone surface moves the trace by one and warns the estimate re-derived independently from the certificate; with the shared refusal passed the trace does not move; one extracted estimate across all four warnings). Discrimination proven: planting the old double evaluation reddened AC1 on both paths (count 2), and a callee ignoring `refusal` reddened the seam-side count (4 vs 3); both plants reverted.
+- 2026-08-31: T4 done — same script, machine and date as T1: median 0.029 s per call after the change (was 0.033 s; the saved evaluation is the certificate's own ~0.002 s plus its setup on this p = 24 fit). Both "uncertified" warnings still emitted.
 
 ## Decisions
 

--- a/tests/testthat/test-axes-certificate-refusal.R
+++ b/tests/testthat/test-axes-certificate-refusal.R
@@ -718,3 +718,60 @@ test_that("M117 AC2 + AC3 (both sides of the seam): standalone surfaces price th
             m117_estimate(wse2), m117_estimate(wsf2))
   expect_identical(unique(ests), ests[[1L]])
 })
+
+
+test_that("M117 review F1: a refusal priced for a different matrix is refused, not consumed", {
+  # Without the consumption guard this pairing is silent and fail-open: the
+  # degenerate matrix's own criterion refuses it "uncertified", but a clean
+  # matrix's precomputed decision carries reason = NULL, so both surfaces
+  # would report populated numbers with no warning at all.
+  fx <- readRDS(test_path("fixtures", "rb18-counterexample-b.rds"))
+  S <- fx$S
+  ang <- as.numeric(fx$ia)
+  scl <- c("A", "B", "C")
+  clean <- diag(3)
+  clean[1, 2] <- clean[2, 1] <- 0.3
+  clean[1, 3] <- clean[3, 1] <- 0.2
+  clean[2, 3] <- clean[3, 2] <- 0.25
+  dimnames(clean) <- dimnames(S)
+
+  bad_ref <- axes_shared_refusal(clean, rownames(S), ang, scl,
+                                 fit_zeta1 = FALSE, fit_zeta2 = FALSE)
+  # The pairing is only dangerous because the two decisions DISAGREE: pin that
+  # the borrowed decision is the permissive one, so the guard is what stands
+  # between the caller and a reported number.
+  expect_null(bad_ref$reason)
+  own_ref <- axes_shared_refusal(S, rownames(S), ang, scl,
+                                 fit_zeta1 = FALSE, fit_zeta2 = FALSE)
+  expect_identical(own_ref$reason, "uncertified")
+
+  expect_error(
+    axes_corrected_se(S, rownames(S), ang, scl, n = 600,
+                      fit_zeta1 = FALSE, fit_zeta2 = FALSE, refusal = bad_ref),
+    "priced for a different matrix"
+  )
+  expect_error(
+    axes_scaling_factor(S, rownames(S), ang, scl,
+                        fit_zeta1 = FALSE, fit_zeta2 = FALSE,
+                        df = 1, baseline_df = 3, refusal = bad_ref),
+    "priced for a different matrix"
+  )
+
+  # The passing control: the MATCHED decision passes the guard and still
+  # refuses "uncertified" -- the guard rejects mispairing, not the seam.
+  expect_warning(
+    se <- axes_corrected_se(S, rownames(S), ang, scl, n = 600,
+                            fit_zeta1 = FALSE, fit_zeta2 = FALSE,
+                            refusal = own_ref),
+    "uncertified"
+  )
+  expect_identical(se$reason, "uncertified")
+
+  # F5: `item_block` takes a default, so the named-argument spelling both
+  # callees accept works here too.
+  expect_identical(
+    axes_shared_refusal(S, rownames(S), ang, scl,
+                        fit_zeta1 = FALSE, fit_zeta2 = FALSE),
+    own_ref
+  )
+})

--- a/tests/testthat/test-axes-certificate-refusal.R
+++ b/tests/testthat/test-axes-certificate-refusal.R
@@ -569,3 +569,152 @@ test_that("M114 AC1: a straddling certificate refuses at BOTH surfaces, whicheve
                      label = sprintf("%s: scaling note", lab))
   }
 })
+
+
+# ---- M117: the refusal decision is priced once per checked fit ---------------
+#
+# Both surfaces call axes_degeneracy_refusal() on the same realigned cov2cor
+# matrix with the same derivative set, so until M117 a fit the floor sent to
+# the certificate paid for the double-double replay twice, once per surface.
+# axes_reliability() now makes the decision once (axes_shared_refusal) and
+# hands it to both through their `refusal` argument. What is pinned here:
+# exactly ONE certificate evaluation per exported call (AC1), each surface
+# still pricing its own certificate when called standalone with the argument
+# absent (AC2), and one estimate in every warning on both sides of the seam
+# (AC3).
+
+# The estimate substring a refusal warning carries, extracted so two warnings
+# can be compared as numbers-as-printed rather than by whole-message identity.
+m117_estimate <- function(w) {
+  m <- regmatches(w, regexpr("estimated relative error [0-9.e+-]+", w))
+  expect_length(m, 1L)
+  m
+}
+
+test_that("M117 AC1: the certificate is evaluated exactly once per checked axes_reliability() call, on both missing paths", {
+  skip_if_not_installed("lavaan")
+  # The M89 AC6 injection idiom: the fit runs on clean data and the
+  # ill-conditioned matrix is injected at axes_fitted_cov(), the one seam both
+  # consumers read. The matrix is this file's own sentinel-route case, renamed
+  # to the fixture's item names so realignment lands.
+  oct <- octants()
+  set.seed(70)
+  dat <- axes_simulate(600L, oct, 3L, xi1 = .20, xi2 = .05, zeta1 = .08)
+  inames <- sprintf("i%02d", seq_len(ncol(dat)))
+  colnames(dat) <- inames
+  items <- split(inames, rep(seq_along(oct), each = 3L))
+  expect_length(inames, 24L)
+  bad <- m106_family_a(1.5e-9, 3L)
+  dimnames(bad) <- list(inames, inames)
+  # The precondition that routes this matrix to the certificate at all: the
+  # criterion answers "ill_conditioned" for it, the one arm M111 handed over.
+  expect_identical(axes_sigma_degenerate(bad), "ill_conditioned")
+
+  # Item-level holes so the fiml path exercises its own estimation route
+  # rather than degenerating to the listwise one.
+  holed <- dat
+  for (j in 1:6) holed[sample(seq_len(nrow(holed)), 40L), j] <- NA_real_
+
+  count <- 0L
+  real_cert <- axes_accuracy_certificate
+  local_mocked_bindings(
+    axes_fitted_cov = function(fit) bad,
+    axes_accuracy_certificate = function(sigma, d) {
+      count <<- count + 1L
+      real_cert(sigma, d)
+    }
+  )
+
+  for (path in c("listwise", "fiml")) {
+    count <- 0L
+    w <- testthat::capture_warnings(
+      suppressMessages(
+        if (path == "fiml") {
+          axes_reliability(holed, items = items, angles = oct,
+                           missing = "fiml")
+        } else {
+          axes_reliability(dat, items = items, angles = oct)
+        }
+      )
+    )
+    # BOTH surfaces still refuse -- proof the one evaluation fed two
+    # consumers, not that one consumer stopped consulting the certificate.
+    expect_length(grep("uncertified", w, fixed = TRUE), 2L)
+    expect_true(any(grepl("standard errors could not be computed", w)),
+                label = path)
+    expect_true(any(grepl("scaled fit statistics could not be computed", w)),
+                label = path)
+    expect_identical(count, 1L, label = path)
+  }
+})
+
+test_that("M117 AC2 + AC3 (both sides of the seam): standalone surfaces price their own certificate; every warning carries one estimate", {
+  # The committed graded-route matrix: p = 3, unreachable through the exported
+  # path, so the two surfaces are fired DIRECTLY -- which is exactly the
+  # standalone shape AC2 binds. Provenance documented at its other readers.
+  fx <- readRDS(test_path("fixtures", "rb18-counterexample-b.rds"))
+  S <- fx$S
+  ang <- as.numeric(fx$ia)
+  scl <- c("A", "B", "C")
+  expect_identical(axes_sigma_degenerate(S), "ill_conditioned")
+
+  count <- 0L
+  real_cert <- axes_accuracy_certificate
+  local_mocked_bindings(
+    axes_accuracy_certificate = function(sigma, d) {
+      count <<- count + 1L
+      real_cert(sigma, d)
+    }
+  )
+
+  # AC2: each surface, called WITHOUT the argument, evaluates the certificate
+  # itself (the trace moves by one per call) and refuses "uncertified".
+  wse <- testthat::capture_warnings(
+    se <- axes_corrected_se(S, rownames(S), ang, scl, n = 600,
+                            fit_zeta1 = FALSE, fit_zeta2 = FALSE)
+  )
+  expect_identical(count, 1L)
+  wsf <- testthat::capture_warnings(
+    sf <- axes_scaling_factor(S, rownames(S), ang, scl,
+                              fit_zeta1 = FALSE, fit_zeta2 = FALSE,
+                              df = 1, baseline_df = 3)
+  )
+  expect_identical(count, 2L)
+  expect_identical(se$reason, "uncertified")
+  expect_identical(sf$reason, "uncertified")
+
+  # The warned estimate is derived from THE certificate for this matrix and
+  # derivative set -- recomputed here independently of either surface -- not
+  # merely some number in the right format.
+  d <- axes_se_derivs(ang, scl, NULL, FALSE, FALSE)
+  want <- sprintf("estimated relative error %.2g",
+                  axes_certificate_worst(real_cert(stats::cov2cor(S), d)))
+  expect_match(wse, want, fixed = TRUE)
+  expect_match(wsf, want, fixed = TRUE)
+
+  # The seam side: axes_shared_refusal() decides once, both surfaces receive
+  # the decision, and the trace does not move -- neither reprices.
+  ref <- axes_shared_refusal(S, rownames(S), ang, scl, NULL,
+                             fit_zeta1 = FALSE, fit_zeta2 = FALSE)
+  expect_identical(count, 3L)  # the shared decision itself priced it once
+  expect_identical(ref$reason, "uncertified")
+  wse2 <- testthat::capture_warnings(
+    se2 <- axes_corrected_se(S, rownames(S), ang, scl, n = 600,
+                             fit_zeta1 = FALSE, fit_zeta2 = FALSE,
+                             refusal = ref)
+  )
+  wsf2 <- testthat::capture_warnings(
+    sf2 <- axes_scaling_factor(S, rownames(S), ang, scl,
+                               fit_zeta1 = FALSE, fit_zeta2 = FALSE,
+                               df = 1, baseline_df = 3, refusal = ref)
+  )
+  expect_identical(count, 3L)
+  expect_identical(se2$reason, "uncertified")
+  expect_identical(sf2$reason, "uncertified")
+
+  # AC3: one estimate, all four warnings -- across the two surfaces AND
+  # across the two sides of the seam.
+  ests <- c(m117_estimate(wse), m117_estimate(wsf),
+            m117_estimate(wse2), m117_estimate(wsf2))
+  expect_identical(unique(ests), ests[[1L]])
+})


### PR DESCRIPTION
`axes_reliability()` now prices the per-fit accuracy certificate once per checked fit instead of twice.

Both `axes_corrected_se()` and `axes_scaling_factor()` gain an optional pre-computed-refusal argument (`refusal`, default `NULL` = compute it); `axes_reliability()` computes the shared refusal once and passes it to both. Both surfaces stay standalone-callable with the argument absent, and the two agree on the reported estimated relative error on both sides of the seam.

No change to any refusal, warning, or reported number.

Milestone: `cairn/milestones/M117-certificate-once-per-fit.md`