### PR TITLE
Tolerate last-place noise between the two amplitude paths in the ssm_draws oracles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# circumplex (development version)
+
+## Minor improvements and fixes
+
+* The package's tests now pass on Linux arm64. Two checks of `ssm_draws()`
+  compared amplitudes computed by the package's C++ code against the same
+  amplitudes computed in R, and required the two to agree to the last bit.
+  They do on every other platform, but on that one they can differ by one
+  unit in the last place. The checks now require agreement to 12 significant
+  digits. No result reported by `ssm_draws()` has changed.
+
 # circumplex 2.0.1
 
 ## Minor improvements and fixes

--- a/tests/testthat/test-ssm_draws.R
+++ b/tests/testthat/test-ssm_draws.R
@@ -1,5 +1,24 @@
 # T3: ssm_draws() dispatch contract (spec sec. 5.1) ----------------------------
 
+# Amplitude is computed twice from the same (x, y): in C++ for profile draws
+# (`std::sqrt(std::pow(xval, 2) + std::pow(yval, 2))`, src/parameters.cpp) and
+# in R for parameter draws (`sqrt(x^2 + y^2)`, R/ssm_draws.R). The two agree
+# bit-for-bit on x86-64 and on macOS arm64, and land one unit in the last
+# place apart on Linux aarch64 -- CRAN's linux-arm64 additional check, where
+# 2.0.0 is an ERROR on exactly this comparison (2026-09-03). The shape
+# oracles below therefore ask for agreement to 12 significant digits, which
+# is the contract: last-place noise between the two implementations passes,
+# and every real change to either one still fails. The test immediately after
+# this block holds that line in both directions.
+expect_shape_equal <- function(actual, expected) {
+  expect_equal(actual, expected, tolerance = 1e-12)
+}
+
+# One unit in the last place, upward. Base R has no nextafter(); for the
+# amplitudes here (all in [0.25, 1)) adding eps * |x| moves one or two
+# representable steps, which is the perturbation being replayed.
+one_ulp_up <- function(x) x + abs(x) * .Machine$double.eps
+
 test_that("ssm_draws dispatches shape B when angles are supplied", {
   # Two profile draws over octants; each row goes through group_parameters()
   # exactly as a bootstrap replicate would. Row 1 is the pure first harmonic
@@ -291,39 +310,74 @@ test_that("feeding a run's bootstrap replicates reproduces its intervals exactly
     strata = bs_input$Group
   )
   # Replicate columns are (e, x, y, a, d, fit); the adapter recomputes a and
-  # d from (e, x, y) by the identical formulas, so the draws are bit-equal
-  # (compare in degrees -- both sides converted once by the same expression;
-  # a radian roundtrip would add a rounding step to only one side).
+  # d from (e, x, y) by the same formulas, so the draws agree to 12
+  # significant digits -- the same two amplitude implementations, and the
+  # same last-place caveat, as expect_shape_equal above (compare in degrees
+  # -- both sides converted once by the same expression; a radian roundtrip
+  # would add a rounding step to only one side).
   adapter <- ssm_draws(bs$t[, 1:3], type = "parameters")
-  expect_identical(as.numeric(adapter$draws[, "a"]), as.numeric(bs$t[, 4]))
-  expect_identical(as.numeric(adapter$draws[, "d"]),
-                   as.numeric(as_degree(as_radian(bs$t[, 5]))))
+  expect_shape_equal(as.numeric(adapter$draws[, "a"]), as.numeric(bs$t[, 4]))
+  expect_shape_equal(as.numeric(adapter$draws[, "d"]),
+                     as.numeric(as_degree(as_radian(bs$t[, 5]))))
   for (p in c("e", "x", "y", "a", "d")) {
-    expect_identical(
+    expect_shape_equal(
       as.numeric(adapter$results[[paste0(p, "_lci")]]),
       as.numeric(res$results[[paste0(p, "_lci")]])
     )
-    expect_identical(
+    expect_shape_equal(
       as.numeric(adapter$results[[paste0(p, "_uci")]]),
       as.numeric(res$results[[paste0(p, "_uci")]])
     )
   }
 })
 
+test_that("the shape oracles tolerate last-place noise and nothing else", {
+  # Replays what CRAN's linux-arm64 check hit: elements 34 and 35 of the
+  # matrix the next test compares are amplitudes, and there the C++ and R
+  # amplitude expressions disagreed in the last digit.
+  set.seed(7)
+  pdraws <- matrix(rnorm(10 * 8, mean = 1), ncol = 8)
+  cols <- c("e", "x", "y", "a", "d")
+  ref <- ssm_draws(pdraws, angles = octants())$draws[, cols]
+
+  nudged <- ref
+  nudged[c(34L, 35L)] <- one_ulp_up(nudged[c(34L, 35L)])
+  # The perturbation is real (so nothing below passes vacuously) and is
+  # last-place sized.
+  expect_false(identical(nudged, ref))
+  expect_lt(max(abs(nudged - ref) / abs(ref)), 1e-15)
+
+  # Byte-identity is what 2.0.0 asked for, and what that platform failed.
+  expect_failure(expect_identical(nudged, ref))
+  # Agreement to 12 significant digits is what the oracles ask for now.
+  expect_success(expect_shape_equal(nudged, ref))
+
+  # And nothing looser: a change far above last-place noise still fails, as
+  # does a wrong value in any other column.
+  wrong_a <- ref
+  wrong_a[34L] <- wrong_a[34L] * (1 + 1e-9)
+  expect_failure(expect_shape_equal(wrong_a, ref))
+
+  wrong_e <- ref
+  wrong_e[1L] <- wrong_e[1L] * (1 + 1e-9)
+  expect_failure(expect_shape_equal(wrong_e, ref))
+})
+
 test_that("shape B equals shape A applied to the per-row (e, x, y)", {
   # Oracle 3 (shape consistency): for any profile-draws matrix, shape B must
   # equal shape A applied to the per-row (e, x, y) computed from those
-  # profiles -- exact by construction, and the only oracle exercising the
-  # dispatch/column-mapping channels together.
+  # profiles -- exact but for last-place noise between the two amplitude
+  # implementations (see expect_shape_equal above), and the only oracle
+  # exercising the dispatch/column-mapping channels together.
   set.seed(7)
   pdraws <- matrix(rnorm(10 * 8, mean = 1), ncol = 8)
   resB <- ssm_draws(pdraws, angles = octants())
   resA <- ssm_draws(resB$draws[, c("e", "x", "y")], type = "parameters")
-  expect_identical(resA$draws[, c("e", "x", "y", "a", "d")],
-                   resB$draws[, c("e", "x", "y", "a", "d")])
+  expect_shape_equal(resA$draws[, c("e", "x", "y", "a", "d")],
+                     resB$draws[, c("e", "x", "y", "a", "d")])
   for (p in c("e", "x", "y", "a", "d")) {
     for (s in c("est", "lci", "uci")) {
-      expect_identical(
+      expect_shape_equal(
         as.numeric(resA$results[[paste0(p, "_", s)]]),
         as.numeric(resB$results[[paste0(p, "_", s)]])
       )


### PR DESCRIPTION
CRAN's `linux-arm64` additional check reports 1 ERROR against 2.0.0. The two
failures are in `test-ssm_draws.R`'s shape-consistency oracle, at elements 34
and 35 of the compared matrix — the amplitude column.

Amplitude is computed twice from the same `(x, y)`:

* profile draws → `src/parameters.cpp:34`, `std::sqrt(std::pow(xval, 2) + std::pow(yval, 2))`
* parameter draws → `R/ssm_draws.R:178`, `sqrt(x^2 + y^2)`

Those are bit-identical on x86-64 and on macOS arm64, so the oracle's
"exact by construction" claim held on every platform it had been run on. On
Linux aarch64 they land one unit in the last place apart, and the oracle
asserts `expect_identical()`.

## What changed

Both oracles making the byte-identity claim now ask for agreement to 12
significant digits, via a shared `expect_shape_equal()`:

* the shape A/B consistency test (runs on CRAN — this is the one that errors)
* the adapter test that compares the same two amplitude implementations
  (carries `skip_on_cran()`, so it cannot error on CRAN, but makes the same
  false claim and would fail for anyone running the suite on Linux arm64)

A new test replays the platform perturbation and holds the line both ways:
one ulp on elements 34 and 35 passes the new comparison and is shown to fail
byte-identity, while a 1e-9 relative change — in the amplitude column or in
the elevation column — still fails. It also asserts the perturbation is real
and last-place sized, so nothing passes vacuously.

No exported behavior changes; `ssm_draws()` output is untouched.

## Verification

* `devtools::test()`: 0 failures, 9255 passing (9249 before; +6 from the new test)
* `test-ssm_draws.R` green with `NOT_CRAN=false` (111 passing, 2 skipped) and
  with the CRAN-skipped blocks enabled (127 passing, 0 skipped)

## Note on release state

2.0.1 is submitted to CRAN and does not contain this fix — 2.0.1 addresses the
macOS x86_64 syntax-fixture failure, which is a different test. Whether this
ships as a corrected 2.0.1 or as a later version is still open.